### PR TITLE
Fix French teletext subtitles

### DIFF
--- a/lib/dvb/teletext.cpp
+++ b/lib/dvb/teletext.cpp
@@ -66,7 +66,7 @@ const char * const eDVBTeletextParser::my_country_codes[] =
 
 unsigned char country_lookup[] =
 {
-	255, 1, 4, 11, 11, 11, 5, 4,
+	255, 1, 4, 11, 11, 11, 5, 3,
 	8, 8, 0, 0, 7, 12, 10, 10,
 	10, 9, 2, 6, 6, 11, 11, 17,
 	18, 255, 255, 255, 255, 255, 255, 255


### PR DESCRIPTION
Corrects an error in the country lookup table that caused French teletext subtitles to be displayed using the German character set.

See also https://github.com/oe-alliance/oe-alliance-enigma2/pull/4