### PR TITLE
Fix ConfigList.py to run onDeselect/onSelect only if

### DIFF
--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -67,9 +67,18 @@ class ConfigList(HTMLComponent, GUIComponent, object):
 	GUI_WIDGET = eListbox
 
 	def selectionChanged(self):
-		if isinstance(self.current,tuple) and len(self.current) >= 2:
-			self.current[1].onDeselect(self.session)
+# Only run onDeselect/onSelect if self.current != self.getCurrent()
+# i.e. if the selection has *actually* changed...
+# This means that Notifiers with immediate_feedback = False actually
+# do only get called once at the end of an item change, not for every
+# step along the way.
+#
+		orig_current = self.current;
 		self.current = self.getCurrent()
+		if (orig_current == self.current):
+			return
+		if isinstance(orig_current,tuple) and len(orig_current) >= 2:
+			orig_current[1].onDeselect(self.session)
 		if isinstance(self.current,tuple) and len(self.current) >= 2:
 			self.current[1].onSelect(self.session)
 		else:

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -115,13 +115,17 @@ class ConfigList(HTMLComponent, GUIComponent, object):
 		self.handleKey(KEY_TIMEOUT)
 
 	def isChanged(self):
-		is_changed = False
+#debug		is_changed = False
 		for x in self.list:
-			print 'X:',x
-			is_changed |= x[1].isChanged()
-			print 'is_changed1:',is_changed
-		print 'is_changed2:',is_changed
-		return is_changed
+			if x[1].isChanged():
+#
+#debug				print 'X', type(x[1]), 'changed (val, str(val), tostring(val)):', x[1], str(x[1]), x[1].tostring(x[1].value)
+#debug				is_changed = True
+#debug		print 'isChanged():', is_changed
+#debug		return is_changed
+#
+				return True
+		return False
 
 	def pageUp(self):
 		if self.instance is not None:

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -98,12 +98,18 @@ class ConfigElement(object):
 			self.changed()
 
 	def isChanged(self):
+# NOTE - sv should already be stringified!
+#        self.default may be a string or None
+#
 		sv = self.saved_value
-		if sv is None and str(self.value) == str(self.default):
-			return False
-		elif sv is None and self.tostring(self.value) != self.tostring(self.default):
-			return self.tostring(self.value) != self.tostring(self.default)
-		return self.tostring(self.value) != self.tostring(sv)
+		strv = self.tostring(self.value)
+		if sv is None:
+			retval = strv != self.tostring(self.default)
+		else:
+			retval = strv != sv
+#debug		if retval:
+#debug			print 'orig ConfigElement X (val, tostring(val)):', sv, self.tostring(sv)
+		return retval
 
 	def changed(self):
 		if self.__notifiers:
@@ -1275,11 +1281,17 @@ class ConfigNumber(ConfigText):
 	_value = property(getValue, setValue)
 
 	def isChanged(self):
+# NOTE - sv should already be stringified
+#        and self.default should *also* be a string value
 		sv = self.saved_value
 		strv = self.tostring(self.value)
-		if sv is None and strv == str(self.default):
-			return False
-		return strv != self.tostring(sv)
+		if sv is None:
+			retval = strv != self.default
+		else:
+			retval = strv != sv
+#debug		if retval:
+#debug			print 'orig ConfigNumber X (val, tostring(val)):', sv, self.tostring(sv)
+		return retval
 
 	def conform(self):
 		pos = len(self.text) - self.marked_pos
@@ -1551,7 +1563,10 @@ class ConfigLocations(ConfigElement):
 		locations = self.locations
 		if val is None and not locations:
 			return False
-		return self.tostring([x[0] for x in locations]) != sv
+		retval = self.tostring([x[0] for x in locations]) != sv
+#debug		if retval:
+#debug			print 'orig ConfigLocations X (val):', sv
+		return retval
 
 	def addedMount(self, mp):
 		for x in self.locations:


### PR DESCRIPTION
 only if self.current != self.getCurrent()
i.e. if the selection has *actually* changed...
This means that Notifiers with immediate_feedback = False actually
do only get called once at the end of an item change, not for every
step along the way.