### PR TITLE
[TimerEdit.py] Fix "state" undefined crash

### DIFF
--- a/lib/python/Screens/TimerEdit.py
+++ b/lib/python/Screens/TimerEdit.py
@@ -239,11 +239,13 @@ class TimerEditList(Screen):
 				time = ""
 				duration = ""
 				service = ""
+				state = ""
 		else:
 			name = ""
 			time = ""
 			duration = ""
 			service = ""
+			state = ""
 		for cb in self.onChangedEntry:
 			cb(name, time, duration, service, state)
 


### PR DESCRIPTION
If there are no timers or there is an error accessing a timer the local variable "state" is left undefined.  This causes a crash when the "state" variable is subsequently used.
