### PR TITLE
Add en_AU language to OpenViX

### DIFF
--- a/lib/python/Components/Language.py
+++ b/lib/python/Components/Language.py
@@ -24,6 +24,7 @@ class Language:
 		self.addLanguage("Dansk", "da", "DK", "ISO-8859-15")
 		self.addLanguage("Deutsch", "de", "DE", "ISO-8859-15")
 		self.addLanguage("Ελληνικά", "el", "GR", "ISO-8859-7")
+		self.addLanguage("English (AU)", "en", "AU", "ISO-8859-1")
 		self.addLanguage("English (UK)", "en", "GB", "ISO-8859-15")
 		self.addLanguage("English (US)", "en", "US", "ISO-8859-15")
 		self.addLanguage("Español", "es", "ES", "ISO-8859-15")

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -1,6 +1,6 @@
 dist_noinst_SCRIPTS = xml2po.py
 
-LANGS = ar bg ca cs da de el en en_GB es et fa fi fr fy he hr hu is it ku lt lv nl no nb pl pt pt_BR ro ru sv sk sl sr th tr uk
+LANGS = ar bg ca cs da de el en en_AU en_GB es et fa fi fr fy he hr hu is it ku lt lv nl no nb pl pt pt_BR ro ru sv sk sl sr th tr uk
 LANGMO = $(LANGS:=.mo)
 LANGPO = $(LANGS:=.po)
 

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -1,0 +1,11904 @@
+# English translations for enigma2 package.
+# Copyright (C) 2012 THE enigma2'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the enigma2 package.
+# Automatically generated, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: enigma2 3.0.0\n"
+"Report-Msgid-Bugs-To: OpenViX\n"
+"POT-Creation-Date: 2016-07-23 19:30+0200\n"
+"PO-Revision-Date: 2017-01-01 23:30+1100\n"
+"Last-Translator: IanSav\n"
+"Language-Team: OpenViX\n"
+"Language: en_AU\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Generator: Poedit 1.8.11\n"
+
+msgid ""
+"\n"
+"Advanced options and settings."
+msgstr ""
+"\n"
+"Advanced options and settings."
+
+msgid ""
+"\n"
+"After pressing OK, please wait!"
+msgstr ""
+"\n"
+"After pressing OK, please wait!"
+
+#, python-format
+msgid ""
+"\n"
+"Backup your %s %s settings."
+msgstr ""
+"\n"
+"Backup your %s %s settings."
+
+msgid ""
+"\n"
+"Edit the upgrade source address."
+msgstr ""
+"\n"
+"Edit the upgrade source address."
+
+#, python-format
+msgid ""
+"\n"
+"Manage extensions or plugins for your %s %s"
+msgstr ""
+"\n"
+"Manage extensions or plugins for your %s %s"
+
+#, python-format
+msgid ""
+"\n"
+"Online update of your %s %s software."
+msgstr ""
+"\n"
+"Online update of your %s %s software."
+
+msgid ""
+"\n"
+"Press OK on your remote control to continue."
+msgstr ""
+"\n"
+"Press OK on your remote control to continue."
+
+msgid ""
+"\n"
+"Recording in progress."
+msgstr ""
+"\n"
+"Recording in progress."
+
+#, python-format
+msgid ""
+"\n"
+"Restore your %s %s settings."
+msgstr ""
+"\n"
+"Restore your %s %s settings."
+
+#, python-format
+msgid ""
+"\n"
+"Restore your %s %s with a new firmware."
+msgstr ""
+"\n"
+"Restore your %s %s with a new firmware."
+
+msgid ""
+"\n"
+"Restore your backups by date."
+msgstr ""
+"\n"
+"Restore your backups by date."
+
+msgid ""
+"\n"
+"Scan for local extensions and install them."
+msgstr ""
+"\n"
+"Scan for local extensions and install them."
+
+msgid ""
+"\n"
+"Select your backup device.\n"
+"Current device: "
+msgstr ""
+"\n"
+"Select your backup device.\n"
+"Current device: "
+
+msgid ""
+"\n"
+"View, install and remove available or installed packages."
+msgstr ""
+"\n"
+"View, install and remove available or installed packages."
+
+#, python-format
+msgid " (Channel %s)"
+msgstr " (Channel %s)"
+
+#, python-format
+msgid " (Partition %d)"
+msgstr " (Partition %d)"
+
+msgid " (PiP)"
+msgstr " (PiP)"
+
+msgid " (Radio)"
+msgstr " (Radio)"
+
+msgid " (TV)"
+msgstr " (TV)"
+
+msgid " (disabled)"
+msgstr " (disabled)"
+
+msgid " (higher than any auto)"
+msgstr " (higher than any auto)"
+
+msgid " (higher than rotor any auto)"
+msgstr " (higher than rotor any auto)"
+
+msgid " (lower than any auto)"
+msgstr " (lower than any auto)"
+
+msgid " and"
+msgstr " and"
+
+msgid "%-H:%M"
+msgstr "%-H:%M"
+
+#, python-format
+msgid "%.0f GB"
+msgstr "%.0f GB"
+
+#, python-format
+msgid "%.0f MB"
+msgstr "%.0f MB"
+
+#, python-format
+msgid "%02d.%02d - %02d.%02d (%s%d min)"
+msgstr "%02d.%02d - %02d.%02d (%s%d min)"
+
+#, python-format
+msgid "%02d:%02d"
+msgstr "%02d:%02d"
+
+#. TRANSLATORS: short time representation hour:minute
+#, python-format
+msgid "%2d:%02d"
+msgstr "%2d:%02d"
+
+#. TRANSLATORS: full time representation hour:minute:seconds
+#, python-format
+msgid "%2d:%02d:%02d"
+msgstr "%2d:%02d:%02d"
+
+#. TRANSLATORS: long date representations dayname daynum monthname in strftime() format! See 'man strftime'
+msgid "%A %e %B"
+msgstr "%A %e %B"
+
+#. TRANSLATORS: full date representation dayname daynum monthname year in strftime() format! See 'man strftime'
+msgid "%A %e %B %Y"
+msgstr "%A %e %B %Y"
+
+msgid "%A %e %b"
+msgstr "%A %e %b"
+
+msgid "%H:%M"
+msgstr "%H:%M"
+
+#. TRANSLATORS: full date representations sort dayname daynum monthname long year in strftime() format! See 'man strftime'
+msgid "%a %e %B %Y"
+msgstr "%a %e %B %Y"
+
+#. TRANSLATORS: short date representation short dayname daynum short monthname in strftime() format! See 'man strftime'
+msgid "%a %e/%m"
+msgstr "%a %e/%m"
+
+#. TRANSLATORS: long date representation short dayname daynum short monthname hour:minute in strftime() format! See 'man strftime'
+msgid "%a %e/%m  %-H:%M"
+msgstr "%a %e/%m  %-H:%M"
+
+msgid "%d %B %Y"
+msgstr "%d %B %Y"
+
+#, python-format
+msgid "%d GB"
+msgstr "%d GB"
+
+#, python-format
+msgid "%d Gb"
+msgstr "%d Gb"
+
+#, python-format
+msgid "%d KB"
+msgstr "%d KB"
+
+#, python-format
+msgid "%d MB"
+msgstr "%d MB"
+
+#, python-format
+msgid "%d Min"
+msgid_plural "%d Mins"
+msgstr[0] "%d Min"
+msgstr[1] "%d Mins"
+
+#. TRANSLATORS: Intermediate scanning result, '%d' channel(s) have been found so far
+#, python-format
+msgid "%d channel found"
+msgid_plural "%d channels found"
+msgstr[0] "%d channel found"
+msgstr[1] "%d channels found"
+
+#, python-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d hour"
+msgstr[1] "%d hours"
+
+#, python-format
+msgid "%d job is running in the background!"
+msgid_plural "%d jobs are running in the background!"
+msgstr[0] "%d job is running in the background!"
+msgstr[1] "%d jobs are running in the background!"
+
+#, python-format
+msgid "%d jobs are running in the background!"
+msgstr "%d jobs are running in the background!"
+
+#, python-format
+msgid "%d kB"
+msgstr "%d kB"
+
+#, python-format
+msgid "%d min"
+msgstr "%d min"
+
+#, python-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minute"
+msgstr[1] "%d minutes"
+
+#, python-format
+msgid "%d minutes"
+msgstr "%d minutes"
+
+#, python-format
+msgid "%d pixel wide"
+msgid_plural "%d pixels wide"
+msgstr[0] "%d pixel wide"
+msgstr[1] "%d pixels wide"
+
+#, python-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d second"
+msgstr[1] "%d seconds"
+
+#, python-format
+msgid "%d wireless network found!"
+msgid_plural "%d wireless networks found!"
+msgstr[0] "%d wireless network found!"
+msgstr[1] "%d wireless networks found!"
+
+#, python-format
+msgid "%d.%02d. %02d:%02d"
+msgstr "%d.%02d. %02d:%02d"
+
+msgid "%d.%B %Y"
+msgstr "%d.%B %Y"
+
+#. TRANSLATORS: VFD hour:minute daynum short monthname in strftime() format! See 'man strftime'
+msgid "%k:%M %e/%m"
+msgstr "%k:%M %e/%m"
+
+#, python-format
+msgid "%s %s advanced remote control (native)"
+msgstr "%s %s advanced remote control (native)"
+
+#, python-format
+msgid "%s %s format data DVD (HDTV compatible)"
+msgstr "%s %s format data DVD (HDTV compatible)"
+
+#, python-format
+msgid "%s %s front panel"
+msgstr "%s %s front panel"
+
+#, python-format
+msgid "%s %s ir keyboard"
+msgstr "%s %s ir keyboard"
+
+#, python-format
+msgid "%s %s ir mouse"
+msgstr "%s %s ir mouse"
+
+#, python-format
+msgid "%s %s remote control (native)"
+msgstr "%s %s remote control (native)"
+
+#, python-format
+msgid "%s %s software because updates are available."
+msgstr "%s %s software because updates are available."
+
+#, python-format
+msgid "%s (%s)\n"
+msgstr "%s (%s)\n"
+
+#. TRANSLATORS: The satellite with name '%s' is no longer used after a configuration change. The user is asked whether or not the satellite should be deleted.
+#, python-format
+msgid "%s is no longer used. Should it be deleted?"
+msgstr "%s is no longer used. Should it be deleted?"
+
+#, python-format
+msgid "%s updated package available"
+msgid_plural "%s updated packages available"
+msgstr[0] "%s updated package available"
+msgstr[1] "%s updated packages available"
+
+#, python-format
+msgid "%s%d min"
+msgstr "%s%d min"
+
+#, python-format
+msgid "%s/%s: %s"
+msgstr "%s/%s: %s"
+
+#, python-format
+msgid "%s:%s"
+msgstr "%s:%s"
+
+#, python-format
+msgid "'%s' contains %d file(s) and %d sub-directories.\n"
+msgstr "'%s' contains %d file(s) and %d sub-directories.\n"
+
+msgid "( All readers)"
+msgstr "( All readers)"
+
+msgid "(Show only reader:"
+msgstr "(Show only reader:"
+
+msgid "(ZAP)"
+msgstr "(ZAP)"
+
+msgid "(empty)"
+msgstr "(empty)"
+
+msgid "(show optional DVD audio menu)"
+msgstr "(show optional DVD audio menu)"
+
+msgid "* = Restart Required"
+msgstr "* = Restart Required"
+
+msgid "* Only available if more than one interface is active."
+msgstr "* Only available if more than one interface is active."
+
+msgid "* current animation"
+msgstr "* current animation"
+
+msgid "/s"
+msgstr "/s"
+
+msgid "1.0"
+msgstr "1.0"
+
+msgid "1.1"
+msgstr "1.1"
+
+msgid "1.2"
+msgstr "1.2"
+
+msgid "1080i"
+msgstr "1080i"
+
+msgid "1080p 24Hz"
+msgstr "1080p 24Hz"
+
+msgid "1080p 25Hz"
+msgstr "1080p 25Hz"
+
+msgid "1080p 30Hz"
+msgstr "1080p 30Hz"
+
+msgid "1080p 50Hz"
+msgstr "1080p 50Hz"
+
+msgid "1080p 60Hz"
+msgstr "1080p 60Hz"
+
+msgid "12V output"
+msgstr "12V output"
+
+msgid "12V output."
+msgstr "12V output."
+
+msgid "13 V"
+msgstr "13 V"
+
+msgid "16:10"
+msgstr "16:10"
+
+msgid "16:10 Letterbox"
+msgstr "16:10 Letterbox"
+
+msgid "16:10 PanScan"
+msgstr "16:10 PanScan"
+
+msgid "16:9"
+msgstr "16:9"
+
+msgid "16:9 Letterbox"
+msgstr "16:9 Letterbox"
+
+msgid "16:9 always"
+msgstr "16:9 always"
+
+msgid "18 V"
+msgstr "18 V"
+
+msgid "1X"
+msgstr "1X"
+
+msgid "1st Infobar timeout"
+msgstr "1st Infobar timeout"
+
+msgid "2160p 24Hz"
+msgstr "2160p 24Hz"
+
+msgid "2160p 25Hz"
+msgstr "2160p 25Hz"
+
+msgid "2160p 30Hz"
+msgstr "2160p 30Hz"
+
+msgid "2160p 50Hz"
+msgstr "2160p 50Hz"
+
+msgid "2160p 60Hz"
+msgstr "2160p 60Hz"
+
+msgid "23.976"
+msgstr "23.976"
+
+msgid "24"
+msgstr "24"
+
+msgid "25"
+msgstr "25"
+
+msgid "29.97"
+msgstr "29.97"
+
+msgid "2X"
+msgstr "2X"
+
+msgid "30"
+msgstr "30"
+
+msgid "3D Mode"
+msgstr "3D Mode"
+
+msgid "3D Surround"
+msgstr "3D Surround"
+
+msgid "3D Surround Speaker Position"
+msgstr "3D Surround Speaker Position"
+
+msgid "3D setup"
+msgstr "3D setup"
+
+msgid "3X"
+msgstr "3X"
+
+msgid "480p 24Hz"
+msgstr "480p 24Hz"
+
+msgid "4:3"
+msgstr "4:3"
+
+msgid "4:3 Letterbox"
+msgstr "4:3 Letterbox"
+
+msgid "4:3 PanScan"
+msgstr "4:3 PanScan"
+
+msgid "4X"
+msgstr "4X"
+
+msgid "720p"
+msgstr "720p"
+
+msgid "720p 24Hz"
+msgstr "720p 24Hz"
+
+msgid "< Default >"
+msgstr "< Default >"
+
+msgid "< Default with Picon >"
+msgstr "< Default with Picon >"
+
+msgid "<Current movielist location>"
+msgstr "<Current movielist location>"
+
+msgid "<Default movie location>"
+msgstr "<Default movie location>"
+
+msgid "<Last timer location>"
+msgstr "<Last timer location>"
+
+msgid "<unknown>"
+msgstr "<unknown>"
+
+msgid "??"
+msgstr "??"
+
+msgid "A"
+msgstr "A"
+
+msgid ""
+"A background update check is in progress,\n"
+"please wait a few minutes and try again."
+msgstr ""
+"A background update check is in progress,\n"
+"please wait a few minutes and try again."
+
+msgid "A background update check is in progress, please wait a few minutes and then try again."
+msgstr "A background update check is in progress, please wait a few minutes and then try again."
+
+msgid "A background update check is in progress, please wait a few minutes and try again."
+msgstr "A background update check is in progress, please wait a few minutes and try again."
+
+#, python-format
+msgid ""
+"A configuration file (%s) has been modified since it was installed.\n"
+"Do you want to keep your modifications?"
+msgstr ""
+"A configuration file (%s) has been modified since it was installed.\n"
+"Do you want to keep your modifications?"
+
+#, python-format
+msgid ""
+"A configuration file (%s) was modified since Installation.\n"
+"Do you want to keep your version?"
+msgstr ""
+"A configuration file (%s) was modified since Installation.\n"
+"Do you want to keep your version?"
+
+#, python-format
+msgid ""
+"A finished power timer wants to shut down\n"
+"your %s %s. Shutdown now?"
+msgstr ""
+"A finished power timer wants to shut down\n"
+"your %s %s. Shutdown now?"
+
+#, python-format
+msgid ""
+"A finished powertimer wants to reboot your %s %s.\n"
+"Do that now?"
+msgstr ""
+"A finished powertimer wants to reboot your %s %s.\n"
+"Do that now?"
+
+msgid ""
+"A finished powertimer wants to restart the user interface.\n"
+"Do that now?"
+msgstr ""
+"A finished powertimer wants to restart the user interface.\n"
+"Do that now?"
+
+#, python-format
+msgid ""
+"A finished powertimer wants to set your\n"
+"%s %s to standby. Do that now?"
+msgstr ""
+"A finished powertimer wants to set your\n"
+"%s %s to standby. Do that now?"
+
+#, python-format
+msgid ""
+"A finished powertimer wants to shutdown your %s %s.\n"
+"Do that now?"
+msgstr ""
+"A finished powertimer wants to shutdown your %s %s.\n"
+"Do that now?"
+
+#, python-format
+msgid ""
+"A finished record timer wants to set your\n"
+"%s %s to standby. Do that now?"
+msgstr ""
+"A finished record timer wants to set your\n"
+"%s %s to standby. Do that now?"
+
+#, python-format
+msgid ""
+"A finished record timer wants to shut down\n"
+"your %s %s. Shutdown now?"
+msgstr ""
+"A finished record timer wants to shut down\n"
+"your %s %s. Shutdown now?"
+
+#, python-format
+msgid ""
+"A recording has been started:\n"
+"%s"
+msgstr ""
+"A recording has been started:\n"
+"%s"
+
+msgid ""
+"A recording is currently in progress.\n"
+"What do you want to do?"
+msgstr ""
+"A recording is currently in progress.\n"
+"What do you want to do?"
+
+msgid "A recording is currently running. Please stop the recording before trying to scan."
+msgstr "A recording is currently running. Please stop the recording before trying to scan."
+
+msgid "A repeating timer or just once?"
+msgstr "A repeating timer or just once?"
+
+#, python-format
+msgid "A required tool (%s) was not found."
+msgstr "A required tool (%s) was not found."
+
+msgid "A search for available updates is currently in progress."
+msgstr "A search for available updates is currently in progress."
+
+msgid ""
+"A second configured interface has been found.\n"
+"\n"
+"Do you want to disable the second network interface?"
+msgstr ""
+"A second configured interface has been found.\n"
+"\n"
+"Do you want to disable the second network interface?"
+
+#, python-format
+msgid ""
+"A sleep timer wants to set your\n"
+"%s %s to standby. Proceed?"
+msgstr ""
+"A sleep timer wants to set your\n"
+"%s %s to standby. Proceed?"
+
+#, python-format
+msgid ""
+"A sleep timer wants to shut down\n"
+"your %s %s. Proceed?"
+msgstr ""
+"A sleep timer wants to shut down\n"
+"your %s %s. Proceed?"
+
+msgid "A small overview of the available icon states and actions."
+msgstr "A small overview of the available icon states and actions."
+
+msgid ""
+"A timer failed to record!\n"
+"Disable TV and try again?\n"
+msgstr ""
+"A timer failed to record!\n"
+"Disable TV and try again?\n"
+
+msgid "AAC downmix"
+msgstr "AAC downmix"
+
+msgid "AAC transcoding"
+msgstr "AAC transcoding"
+
+msgid "AC3"
+msgstr "AC3"
+
+msgid "ACQUIRING TSID/ONID"
+msgstr "ACQUIRING TSID/ONID"
+
+msgid "AFP Setup"
+msgstr "AFP Setup"
+
+msgid "AFP setup"
+msgstr "AFP setup"
+
+#, python-format
+msgid "AV aspect is %s."
+msgstr "AV aspect is %s."
+
+msgid "AV settings"
+msgstr "AV settings"
+
+msgid "Abort"
+msgstr "Abort"
+
+msgid "Abort alternatives edit"
+msgstr "Abort alternatives edit"
+
+msgid "Abort bouquet edit"
+msgstr "Abort bouquet edit"
+
+msgid "Abort favourites edit"
+msgstr "Abort favourites edit"
+
+msgid "About"
+msgstr "About"
+
+msgid "About..."
+msgstr "About..."
+
+msgid "Accesspoint:"
+msgstr "Accesspoint:"
+
+msgid "Activate"
+msgstr "Activate"
+
+msgid "Activate HbbTV (RedButton)"
+msgstr "Activate HbbTV (RedButton)"
+
+msgid "Activate MAC address configuration"
+msgstr "Activate MAC address configuration"
+
+msgid "Activate Picture in Picture"
+msgstr "Activate Picture in Picture"
+
+msgid "Activate current configuration"
+msgstr "Activate current configuration"
+
+msgid "Activate network adapter configuration"
+msgstr "Activate network adapter configuration"
+
+msgid "Activate network settings"
+msgstr "Activate network settings"
+
+msgid "Activate the configured network settings."
+msgstr "Activate the configured network settings."
+
+msgid "Activate timeshift end"
+msgstr "Activate timeshift end"
+
+msgid "Activate timeshift end and pause"
+msgstr "Activate timeshift end and pause"
+
+msgid "Active"
+msgstr "Active"
+
+msgid "Active clients"
+msgstr "Active clients"
+
+msgid "Adapter settings"
+msgstr "Adapter settings"
+
+msgid "Add"
+msgstr "Add"
+
+msgid "Add AutoTimer"
+msgstr "Add AutoTimer"
+
+msgid "Add Timer"
+msgstr "Add Timer"
+
+msgid "Add a auto timer for current event"
+msgstr "Add a auto timer for current event"
+
+msgid "Add a mark"
+msgstr "Add a mark"
+
+msgid "Add a nameserver entry"
+msgstr "Add a nameserver entry"
+
+msgid "Add a new title"
+msgstr "Add a new title"
+
+msgid "Add a record timer"
+msgstr "Add a record timer"
+
+msgid "Add a record timer for current event"
+msgstr "Add a record timer for current event"
+
+msgid "Add a zap timer for current event"
+msgstr "Add a zap timer for current event"
+
+msgid "Add a zap timer for next event"
+msgstr "Add a zap timer for next event"
+
+msgid "Add alternatives"
+msgstr "Add alternatives"
+
+msgid "Add bookmark"
+msgstr "Add bookmark"
+
+msgid "Add bouquet"
+msgstr "Add bouquet"
+
+msgid "Add bouquet to parental protection"
+msgstr "Add bouquet to parental protection"
+
+msgid "Add directory to playlist"
+msgstr "Add directory to playlist"
+
+msgid "Add file to playlist"
+msgstr "Add file to playlist"
+
+msgid "Add files to playlist"
+msgstr "Add files to playlist"
+
+msgid "Add marker"
+msgstr "Add marker"
+
+msgid "Add provider"
+msgstr "Add provider"
+
+msgid "Add recording (enter recording duration)"
+msgstr "Add recording (enter recording duration)"
+
+msgid "Add recording (enter recording endtime)"
+msgstr "Add recording (enter recording endtime)"
+
+msgid "Add recording (indefinitely)"
+msgstr "Add recording (indefinitely)"
+
+msgid "Add recording (stop after current event)"
+msgstr "Add recording (stop after current event)"
+
+msgid "Add service"
+msgstr "Add service"
+
+msgid "Add service to bouquet"
+msgstr "Add service to bouquet"
+
+msgid "Add service to favourites"
+msgstr "Add service to favourites"
+
+msgid "Add timer"
+msgstr "Add timer"
+
+msgid "Add title"
+msgstr "Add title"
+
+msgid "Add to bouquet"
+msgstr "Add to bouquet"
+
+msgid "Add to favourites"
+msgstr "Add to favourites"
+
+msgid "Add to parental protection"
+msgstr "Add to parental protection"
+
+msgid "Add/Remove timer for current event"
+msgstr "Add/Remove timer for current event"
+
+msgid "Adding schedule..."
+msgstr "Adding schedule..."
+
+msgid "Additional Info"
+msgstr "Additional Info"
+
+msgid "Address"
+msgstr "Address"
+
+msgid "Adjust the color settings so that all the color shades are distinguishable, but appear as saturated as possible. If you are happy with the result, press OK to close the video fine-tuning, or use the number keys to select other test screens."
+msgstr "Adjust the color settings so that all the color shades are distinguishable, but appear as saturated as possible. If you are happy with the result, press OK to close the video fine-tuning, or use the number keys to select other test screens."
+
+msgid "Advanced"
+msgstr "Advanced"
+
+msgid "Advanced options"
+msgstr "Advanced options"
+
+msgid "Advanced restore"
+msgstr "Advanced restore"
+
+msgid "Advanced software"
+msgstr "Advanced software"
+
+msgid "Advanced software plugin"
+msgstr "Advanced software plugin"
+
+msgid "Advanced video enhancement setup"
+msgstr "Advanced video enhancement setup"
+
+msgid "After event"
+msgstr "After event"
+
+msgid "Album"
+msgstr "Album"
+
+msgid "Alias"
+msgstr "Alias"
+
+msgid "All"
+msgstr "All"
+
+msgid "All ages"
+msgstr "All ages"
+
+msgid "All frequency"
+msgstr "All frequency"
+
+msgid "All resolutions"
+msgstr "All resolutions"
+
+msgid "All satellites 1 (USALS)"
+msgstr "All satellites 1 (USALS)"
+
+msgid "All satellites 2 (USALS)"
+msgstr "All satellites 2 (USALS)"
+
+msgid "All satellites 3 (USALS)"
+msgstr "All satellites 3 (USALS)"
+
+msgid "All satellites 4 (USALS)"
+msgstr "All satellites 4 (USALS)"
+
+msgid "Allocate"
+msgstr "Allocate"
+
+msgid "Allocate unused memory index"
+msgstr "Allocate unused memory index"
+
+msgid "Allow subtitle language to equal audio language"
+msgstr "Allow subtitle language to equal audio language"
+
+msgid "Allow subtitles for hearing impaired"
+msgstr "Allow subtitles for hearing impaired"
+
+msgid "Allow unstable (experimental) updates"
+msgstr "Allow unstable (experimental) updates"
+
+msgid "Allows the %s %s to read the stored EPG data regularly."
+msgstr "Allows the %s %s to read the stored EPG data regularly."
+
+msgid "Allows the %s %s to store the EPG data regularly."
+msgstr "Allows the %s %s to store the EPG data regularly."
+
+msgid "Allows you to adjust the amount of time the resolution infomation display on screen."
+msgstr "Allows you to adjust the amount of time the resolution infomation display on screen."
+
+msgid "Allows you to enable the debug logs. They contain very detailed information about everything the system does. Reboot required to enable this!"
+msgstr "Allows you to enable the debug logs. They contain very detailed information about everything the system does. Reboot required to enable this!"
+
+msgid "Allows you to enable/disable displaying icons on the front panel."
+msgstr "Allows you to enable/disable displaying icons on the front panel."
+
+msgid "Allows you to hide the extensions of known file types."
+msgstr "Allows you to hide the extensions of known file types."
+
+msgid "Allows you to send a copy of the log to yourself."
+msgstr "Allows you to send a copy of the log to yourself."
+
+msgid "Allows you to set the maximum size (MB) of the individual debug logs. When that size is reached, a new file will be created."
+msgstr "Allows you to set the maximum size (MB) of the individual debug logs. When that size is reached, a new file will be created."
+
+msgid "Allows you to setup the button to do what you choose."
+msgstr "Allows you to setup the button to do what you choose."
+
+msgid "Allows you to show/hide CCcam Info in extensions (blue button)."
+msgstr "Allows you to show/hide CCcam Info in extensions (blue button)."
+
+msgid "Allows you to show/hide Log Manager in extensions (blue button)."
+msgstr "Allows you to show/hide Log Manager in extensions (blue button)."
+
+msgid "Allows you to show/hide OScam Info in extensions (blue button)."
+msgstr "Allows you to show/hide OScam Info in extensions (blue button)."
+
+msgid "Alpha"
+msgstr "Alpha"
+
+msgid "Alphanumeric"
+msgstr "Alphanumeric"
+
+msgid "Also on standby"
+msgstr "Also on standby"
+
+msgid "Alternative"
+msgstr "Alternative"
+
+msgid "Alternative numbering mode"
+msgstr "Alternative numbering mode"
+
+msgid "Alternative radio mode"
+msgstr "Alternative radio mode"
+
+msgid "Alternative services tuner priority"
+msgstr "Alternative services tuner priority"
+
+msgid "Always ask"
+msgstr "Always ask"
+
+msgid "Always hide infobar"
+msgstr "Always hide infobar"
+
+msgid "Always show bouquets"
+msgstr "Always show bouquets"
+
+msgid "An empty filename is illegal."
+msgstr "An empty filename is illegal."
+
+msgid "An error occurred while downloading the packetlist. Please try again."
+msgstr "An error occurred while downloading the packetlist. Please try again."
+
+msgid "An unknown error occurred!"
+msgstr "An unknown error occurred!"
+
+msgid "Animation Setup"
+msgstr "Animation Setup"
+
+msgid "Animation Speed"
+msgstr "Animation Speed"
+
+msgid "Animations"
+msgstr "Animations"
+
+msgid "Any activity"
+msgstr "Any activity"
+
+msgid "Arabic"
+msgstr "Arabic"
+
+#, python-format
+msgid "Are you ready to install \"%s\" ?"
+msgstr "Are you ready to install \"%s\" ?"
+
+#, python-format
+msgid "Are you ready to remove \"%s\" ?"
+msgstr "Are you ready to remove \"%s\" ?"
+
+msgid "Are you sure to remove this entry?"
+msgstr "Are you sure to remove this entry?"
+
+msgid ""
+"Are you sure you want to activate this network configuration?\n"
+"\n"
+msgstr ""
+"Are you sure you want to activate this network configuration?\n"
+"\n"
+
+msgid ""
+"Are you sure you want to delete\n"
+"the following backup:\n"
+msgstr ""
+"Are you sure you want to delete\n"
+"the following backup:\n"
+
+msgid "Are you sure you want to delete all the selected logs:\n"
+msgstr "Are you sure you want to delete all the selected logs:\n"
+
+msgid "Are you sure you want to delete the EPG data from:\n"
+msgstr "Are you sure you want to delete the EPG data from:\n"
+
+msgid "Are you sure you want to delete this log:\n"
+msgstr "Are you sure you want to delete this log:\n"
+
+msgid ""
+"Are you sure you want to delete this:\n"
+" "
+msgstr ""
+"Are you sure you want to delete this:\n"
+" "
+
+msgid "Are you sure you want to exit this wizard?"
+msgstr "Are you sure you want to exit this wizard?"
+
+msgid "Are you sure you want to purge all deleted user bouquets?"
+msgstr "Are you sure you want to purge all deleted user bouquets?"
+
+msgid "Are you sure you want to reload the EPG data from:\n"
+msgstr "Are you sure you want to reload the EPG data from:\n"
+
+#, python-format
+msgid "Are you sure you want to remove all %d.%d%s%s services?"
+msgstr "Are you sure you want to remove all %d.%d%s%s services?"
+
+msgid "Are you sure you want to remove all cable services?"
+msgstr "Are you sure you want to remove all cable services?"
+
+msgid "Are you sure you want to remove all terrestrial services?"
+msgstr "Are you sure you want to remove all terrestrial services?"
+
+msgid "Are you sure you want to remove this entry?"
+msgstr "Are you sure you want to remove this entry?"
+
+msgid ""
+"Are you sure you want to restart your network interfaces?\n"
+"\n"
+msgstr ""
+"Are you sure you want to restart your network interfaces?\n"
+"\n"
+
+#, python-format
+msgid ""
+"Are you sure you want to restore\n"
+"the following backup:\n"
+"%s\n"
+"Your receiver will restart after the backup has been restored!"
+msgstr ""
+"Are you sure you want to restore\n"
+"the following backup:\n"
+"%s\n"
+"Your receiver will restart after the backup has been restored!"
+
+msgid ""
+"Are you sure you want to restore the backup?\n"
+"Your receiver will restart after the backup has been restored!"
+msgstr ""
+"Are you sure you want to restore the backup?\n"
+"Your receiver will restart after the backup has been restored!"
+
+msgid "Are you sure you want to save the EPG Cache to:\n"
+msgstr "Are you sure you want to save the EPG Cache to:\n"
+
+msgid "Are you sure you want to send this log:\n"
+msgstr "Are you sure you want to send this log:\n"
+
+#, python-format
+msgid "Are you sure you want to update your %s %s ?"
+msgstr "Are you sure you want to update your %s %s ?"
+
+msgid "Artist"
+msgstr "Artist"
+
+msgid "Arts/Culture"
+msgstr "Arts/Culture"
+
+msgid "Ask user"
+msgstr "Ask user"
+
+msgid "Ask user (with default as 'no')"
+msgstr "Ask user (with default as 'no')"
+
+msgid "Ask user (with default as 'yes')"
+msgstr "Ask user (with default as 'yes')"
+
+msgid "Aspect ratio"
+msgstr "Aspect ratio"
+
+msgid "Assigned CAIds:"
+msgstr "Assigned CAIds:"
+
+msgid "Assigned services/provider:"
+msgstr "Assigned services/provider:"
+
+msgid "At End:"
+msgstr "At End:"
+
+msgid "Attach a file"
+msgstr "Attach a file"
+
+msgid "Attention, this is repeated timer!\n"
+msgstr "Attention, this is repeated timer!\n"
+
+msgid "Audio"
+msgstr "Audio"
+
+msgid "Audio PID"
+msgstr "Audio PID"
+
+msgid "Audio language selection 1"
+msgstr "Audio language selection 1"
+
+msgid "Audio language selection 2"
+msgstr "Audio language selection 2"
+
+msgid "Audio language selection 3"
+msgstr "Audio language selection 3"
+
+msgid "Audio language selection 4"
+msgstr "Audio language selection 4"
+
+msgid "Audio options..."
+msgstr "Audio options..."
+
+#, python-format
+msgid "Audio track (%s) format"
+msgstr "Audio track (%s) format"
+
+#, python-format
+msgid "Audio track (%s) language"
+msgstr "Audio track (%s) language"
+
+msgid "Author: "
+msgstr "Author: "
+
+msgid "Authoring mode"
+msgstr "Authoring mode"
+
+#. TRANSLATORS: (aspect ratio policy: always try to display as fullscreen, when there is no content (black bars) on left/right, even if this breaks the aspect.
+msgid "Auto"
+msgstr "Auto"
+
+msgid "Auto Deep Standby"
+msgstr "Auto Deep Standby"
+
+msgid "Auto EXIF Orientation rotation/flipping"
+msgstr "Auto EXIF Orientation rotation/flipping"
+
+msgid "Auto Standby"
+msgstr "Auto Standby"
+
+msgid "Auto Volume Level"
+msgstr "Auto Volume Level"
+
+msgid "Auto chapter split every ? minutes (0=never)"
+msgstr "Auto chapter split every ? minutes (0=never)"
+
+msgid "Auto flesh"
+msgstr "Auto flesh"
+
+msgid "Auto focus"
+msgstr "Auto focus"
+
+msgid "Auto focus commencing ..."
+msgstr "Auto focus commencing ..."
+
+msgid "Auto language selection"
+msgstr "Auto language selection"
+
+msgid "Auto play blu-ray file"
+msgstr "Auto play blu-ray file"
+
+msgid "Auto scart switching"
+msgstr "Auto scart switching"
+
+msgid "AutoTimer overview"
+msgstr "AutoTimer overview"
+
+msgid "Automatic"
+msgstr "Automatic"
+
+msgid "Automatic Scan"
+msgstr "Automatic Scan"
+
+msgid "Automatic image backup"
+msgstr "Automatic image backup"
+
+msgid "Automatic refresh"
+msgstr "Automatic refresh"
+
+msgid "Automatic resolution"
+msgstr "Automatic resolution"
+
+msgid "Automatic resolution label"
+msgstr "Automatic resolution label"
+
+msgid "Automatic save"
+msgstr "Automatic save"
+
+msgid "Automatic scan"
+msgstr "Automatic scan"
+
+msgid "Automatic settings backup"
+msgstr "Automatic settings backup"
+
+msgid "Automatically start timeshift after"
+msgstr "Automatically start timeshift after"
+
+msgid "Automatically turn on external subtitles"
+msgstr "Automatically turn on external subtitles"
+
+msgid "Automatically update Client/Server View?"
+msgstr "Automatically update Client/Server View?"
+
+msgid "Autostart"
+msgstr "Autostart"
+
+msgid "Autostart:"
+msgstr "Autostart:"
+
+msgid "Available format variables"
+msgstr "Available format variables"
+
+msgid "Available shares:"
+msgstr "Available shares:"
+
+msgid "B"
+msgstr "B"
+
+msgid "BER:"
+msgstr "BER:"
+
+msgid "Back"
+msgstr "Back"
+
+msgid "Back/Recall"
+msgstr "Back/Recall"
+
+msgid "Background"
+msgstr "Background"
+
+msgid "Background check"
+msgstr "Background check"
+
+msgid "Background color"
+msgstr "Background color"
+
+msgid "Background delete option"
+msgstr "Background delete option"
+
+msgid "Background delete speed"
+msgstr "Background delete speed"
+
+msgid "Backup Manager"
+msgstr "Backup Manager"
+
+msgid "Backup completed."
+msgstr "Backup completed."
+
+msgid "Backup failed."
+msgstr "Backup failed."
+
+msgid "Backup is running..."
+msgstr "Backup is running..."
+
+msgid "Backup system settings"
+msgstr "Backup system settings"
+
+msgid "Band"
+msgstr "Band"
+
+msgid "Bandwidth"
+msgstr "Bandwidth"
+
+msgid "Base time"
+msgstr "Base time"
+
+msgid "Basque"
+msgstr "Basque"
+
+msgid "Begin time"
+msgstr "Begin time"
+
+msgid "Behavior of 'pause' when paused"
+msgstr "Behavior of 'pause' when paused"
+
+msgid "Behavior of 0 key in PiP-mode"
+msgstr "Behavior of 0 key in PiP-mode"
+
+msgid "Behavior when a movie is started"
+msgstr "Behavior when a movie is started"
+
+msgid "Behavior when a movie is stopped"
+msgstr "Behavior when a movie is stopped"
+
+msgid "Behavior when a movie reaches the end"
+msgstr "Behavior when a movie reaches the end"
+
+msgid "Big PiP"
+msgstr "Big PiP"
+
+msgid "Bitrate:"
+msgstr "Bitrate:"
+
+msgid "Black"
+msgstr "Black"
+
+msgid "Black screen"
+msgstr "Black screen"
+
+msgid "Black screen till locked"
+msgstr "Black screen till locked"
+
+msgid "Block noise reduction"
+msgstr "Block noise reduction"
+
+msgid "Blue"
+msgstr "Blue"
+
+msgid "Blue long"
+msgstr "Blue long"
+
+msgid "Bookmarks"
+msgstr "Bookmarks"
+
+msgid "Boost blue"
+msgstr "Boost blue"
+
+msgid "Boost green"
+msgstr "Boost green"
+
+msgid "Bouquet List"
+msgstr "Bouquet List"
+
+msgid "Brightness"
+msgstr "Brightness"
+
+msgid "Brightness (Normal)"
+msgstr "Brightness (Normal)"
+
+msgid "Brightness (Standby)"
+msgstr "Brightness (Standby)"
+
+#, python-format
+msgid "Buffering %d%%"
+msgstr "Buffering %d%%"
+
+msgid "Buffers:"
+msgstr "Buffers:"
+
+#, python-format
+msgid "Build:\t%s.%s%s (%s)\n"
+msgstr "Build:\t%s.%s%s (%s)\n"
+
+#, python-format
+msgid "Build: %s"
+msgstr "Build: %s"
+
+msgid "Bulgarian"
+msgstr "Bulgarian"
+
+msgid "Burn DVD"
+msgstr "Burn DVD"
+
+#, python-format
+msgid "Burn audio track (%s)"
+msgstr "Burn audio track (%s)"
+
+msgid "Burn existing image to DVD"
+msgstr "Burn existing image to DVD"
+
+msgid "Burn to DVD"
+msgstr "Burn to DVD"
+
+msgid "Bus: "
+msgstr "Bus: "
+
+msgid "Button"
+msgstr "Button"
+
+msgid "Button setup"
+msgstr "Button setup"
+
+msgid "Button setup for"
+msgstr "Button setup for"
+
+msgid "ButtonSetup"
+msgstr "ButtonSetup"
+
+msgid "By Team ViX"
+msgstr "By Team ViX"
+
+msgid "Bypass HDMI EDID Check"
+msgstr "Bypass HDMI EDID Check"
+
+msgid "Bytes received:"
+msgstr "Bytes received:"
+
+msgid "Bytes sent:"
+msgstr "Bytes sent:"
+
+msgid "C-Band"
+msgstr "C-Band"
+
+msgid "CAID"
+msgstr "CAID"
+
+msgid "CCcam Client Info"
+msgstr "CCcam Client Info"
+
+msgid "CCcam Config Switcher"
+msgstr "CCcam Config Switcher"
+
+msgid "CCcam ECM Info"
+msgstr "CCcam ECM Info"
+
+msgid "CCcam Info"
+msgstr "CCcam Info"
+
+#, python-format
+msgid ""
+"CCcam Info %s\n"
+"by AliAbdul %s\n"
+"\n"
+"This plugin shows you the status of your CCcam."
+msgstr ""
+"CCcam Info %s\n"
+"by AliAbdul %s\n"
+"\n"
+"This plugin shows you the status of your CCcam."
+
+msgid "CCcam Info Config"
+msgstr "CCcam Info Config"
+
+msgid "CCcam Info Setup"
+msgstr "CCcam Info Setup"
+
+msgid "CCcam Provider Info"
+msgstr "CCcam Provider Info"
+
+msgid "CCcam Remote Info"
+msgstr "CCcam Remote Info"
+
+msgid "CCcam Server Info"
+msgstr "CCcam Server Info"
+
+msgid "CCcam Share Info"
+msgstr "CCcam Share Info"
+
+msgid "CCcam Shares Info"
+msgstr "CCcam Shares Info"
+
+msgid "CCcam info"
+msgstr "CCcam info"
+
+msgid "CH"
+msgstr "CH"
+
+#, python-format
+msgid "CH%s"
+msgstr "CH%s"
+
+msgid "CHANGE BOUQUET"
+msgstr "CHANGE BOUQUET"
+
+msgid "CI (Common Interface) Setup"
+msgstr "CI (Common Interface) Setup"
+
+msgid "CI assignment"
+msgstr "CI assignment"
+
+#, python-format
+msgid "CPU speed:\t%s\n"
+msgstr "CPU speed:\t%s\n"
+
+#, python-format
+msgid "CPU:\t%s\n"
+msgstr "CPU:\t%s\n"
+
+msgid "CVBS"
+msgstr "CVBS"
+
+msgid "CaID: "
+msgstr "CaID: "
+
+msgid "Cable"
+msgstr "Cable"
+
+msgid "Cable Scan"
+msgstr "Cable Scan"
+
+msgid "Cache thumbnails"
+msgstr "Cache thumbnails"
+
+msgid "Cached:"
+msgstr "Cached:"
+
+msgid "Calculate"
+msgstr "Calculate"
+
+msgid "Calculate all positions"
+msgstr "Calculate all positions"
+
+msgid "Calculation complete"
+msgstr "Calculation complete"
+
+msgid "Calibrate"
+msgstr "Calibrate"
+
+msgid "Can be used for different fps between external subtitles and video."
+msgstr "Can be used for different fps between external subtitles and video."
+
+msgid "Cancel"
+msgstr "Cancel"
+
+msgid "Cancel save timeshift as movie"
+msgstr "Cancel save timeshift as movie"
+
+msgid "Cannot delete file"
+msgstr "Cannot delete file"
+
+msgid "Cannot determine"
+msgstr "Cannot determine"
+
+msgid "Cannot find any signal ..., aborting !"
+msgstr "Cannot find any signal ..., aborting !"
+
+msgid "Cannot move to the trash can"
+msgstr "Cannot move to the trash can"
+
+msgid "Capabilities: "
+msgstr "Capabilities: "
+
+msgid "Capacity: "
+msgstr "Capacity: "
+
+msgid "Card infos (CCcam-Reader)"
+msgstr "Card infos (CCcam-Reader)"
+
+msgid "Cards:"
+msgstr "Cards:"
+
+msgid "Cards: "
+msgstr "Cards: "
+
+msgid "Cards: 0"
+msgstr "Cards: 0"
+
+msgid "Cardserial"
+msgstr "Cardserial"
+
+msgid "Cascade PiP"
+msgstr "Cascade PiP"
+
+msgid "Center DVB subtitles"
+msgstr "Center DVB subtitles"
+
+msgid "Change PIN"
+msgstr "Change PIN"
+
+msgid "Change bouquets in quickzap"
+msgstr "Change bouquets in quickzap"
+
+msgid "Change next timer"
+msgstr "Change next timer"
+
+msgid "Change recording (add time)"
+msgstr "Change recording (add time)"
+
+msgid "Change recording (duration)"
+msgstr "Change recording (duration)"
+
+msgid "Change recording (end time)"
+msgstr "Change recording (end time)"
+
+msgid "Change repeat and delay settings?"
+msgstr "Change repeat and delay settings?"
+
+msgid "Change step size"
+msgstr "Change step size"
+
+msgid "Change timer"
+msgstr "Change timer"
+
+msgid "Change to bouquet"
+msgstr "Change to bouquet"
+
+msgid "Channel"
+msgstr "Channel"
+
+msgid "Channel 1 at start"
+msgstr "Channel 1 at start"
+
+msgid "Channel Info"
+msgstr "Channel Info"
+
+msgid "Channel List"
+msgstr "Channel List"
+
+msgid "Channel down"
+msgstr "Channel down"
+
+msgid "Channel info"
+msgstr "Channel info"
+
+msgid "Channel list context menu"
+msgstr "Channel list context menu"
+
+msgid "Channel list cursor behavior"
+msgstr "Channel list cursor behavior"
+
+msgid "Channel list on mode change"
+msgstr "Channel list on mode change"
+
+msgid "Channel list preview"
+msgstr "Channel list preview"
+
+msgid "Channel list service mode*"
+msgstr "Channel list service mode*"
+
+msgid "Channel list type"
+msgstr "Channel list type"
+
+msgid "Channel not in services list"
+msgstr "Channel not in services list"
+
+msgid "Channel preview mode"
+msgstr "Channel preview mode"
+
+msgid "Channel selection"
+msgstr "Channel selection"
+
+msgid "Channel selection settings"
+msgstr "Channel selection settings"
+
+msgid "Channel up"
+msgstr "Channel up"
+
+msgid "Channel:"
+msgstr "Channel:"
+
+msgid "ChannelEPG settings"
+msgstr "ChannelEPG settings"
+
+msgid "Chap."
+msgstr "Chap."
+
+msgid "Chapter"
+msgstr "Chapter"
+
+msgid "Chapter:"
+msgstr "Chapter:"
+
+msgid "Check"
+msgstr "Check"
+
+msgid "Check every (hours)"
+msgstr "Check every (hours)"
+
+msgid "Check the internet connection"
+msgstr "Check the internet connection"
+
+msgid "Check the internet connection again"
+msgstr "Check the internet connection again"
+
+msgid "Checking Logs..."
+msgstr "Checking Logs..."
+
+msgid "Checking filesystem..."
+msgstr "Checking filesystem..."
+
+msgid "Checking for Updates..."
+msgstr "Checking for Updates..."
+
+msgid "Checking the internet connection"
+msgstr "Checking the internet connection"
+
+#, python-format
+msgid ""
+"Checking tuner %s\n"
+"DiSEqC port %s for %s"
+msgstr ""
+"Checking tuner %s\n"
+"DiSEqC port %s for %s"
+
+msgid "Children/Youth"
+msgstr "Children/Youth"
+
+#, python-format
+msgid "Chipset:\tBCM%s\n"
+msgstr "Chipset:\tBCM%s\n"
+
+#, python-format
+msgid "Chipset: BCM%s"
+msgstr "Chipset: BCM%s"
+
+msgid "Choose Bouquet"
+msgstr "Choose Bouquet"
+
+msgid "Choose a tag for easy finding a recording."
+msgstr "Choose a tag for easy finding a recording."
+
+msgid "Choose between Daily, Weekly, Weekdays or user defined."
+msgstr "Choose between Daily, Weekly, Weekdays or user defined."
+
+msgid "Choose the location for crash and debug logs folder."
+msgstr "Choose the location for crash and debug logs folder."
+
+msgid "Choose the location where the EPG data will be stored when the %s %s is shut down. The location must be available at boot time."
+msgstr "Choose the location where the EPG data will be stored when the %s %s is shut down. The location must be available at boot time."
+
+msgid "Choose the name of the file that holds the EPG data when the %s %s is shut down. This can be handy to differentiate between several boxes."
+msgstr "Choose the name of the file that holds the EPG data when the %s %s is shut down. This can be handy to differentiate between several boxes."
+
+msgid "Choose time interval to which the graphics will be rounded off."
+msgstr "Choose time interval to which the graphics will be rounded off."
+
+msgid "Choose what you want the '0' button to do when PIP is active."
+msgstr "Choose what you want the '0' button to do when PIP is active."
+
+msgid "Choose whether AAC sound tracks should be transcoded."
+msgstr "Choose whether AAC sound tracks should be transcoded."
+
+msgid "Choose whether multi channel sound tracks should be downmixed to stereo."
+msgstr "Choose whether multi channel sound tracks should be downmixed to stereo."
+
+msgid "Choose whether multi channel sound tracks should be output as PCM."
+msgstr "Choose whether multi channel sound tracks should be output as PCM."
+
+msgid "Choose whether or not to show an icon when a motorised dish is moving."
+msgstr "Choose whether or not to show an icon when a motorised dish is moving."
+
+msgid "Choose which level of menu/settings to display. 'Expert' level shows all items."
+msgstr "Choose which level of menu/settings to display. 'Expert' level shows all items."
+
+msgid "Choose which tuner to configure."
+msgstr "Choose which tuner to configure."
+
+msgid "Chose between record and ZAP."
+msgstr "Chose between record and ZAP."
+
+msgid "Circular LNB"
+msgstr "Circular LNB"
+
+msgid "Circular left"
+msgstr "Circular left"
+
+msgid "Circular right"
+msgstr "Circular right"
+
+msgid "Clean network trash cans"
+msgstr "Clean network trash cans"
+
+msgid "Cleaning Trashes"
+msgstr "Cleaning Trashes"
+
+msgid "Cleanup"
+msgstr "Cleanup"
+
+msgid "Clear"
+msgstr "Clear"
+
+msgid "Clear before scan"
+msgstr "Clear before scan"
+
+msgid "Clear fixed"
+msgstr "Clear fixed"
+
+msgid "Clear log"
+msgstr "Clear log"
+
+msgid "Clear playlist"
+msgstr "Clear playlist"
+
+msgid "Clients"
+msgstr "Clients"
+
+msgid "Clone TV screen to LCD"
+msgstr "Clone TV screen to LCD"
+
+msgid "Close"
+msgstr "Close"
+
+msgid "Close PiP on exit"
+msgstr "Close PiP on exit"
+
+msgid "Close bouquet list."
+msgstr "Close bouquet list."
+
+msgid "Close dialog"
+msgstr "Close dialog"
+
+msgid "Close title selection"
+msgstr "Close title selection"
+
+msgid "Code rate HP"
+msgstr "Code rate HP"
+
+msgid "Code rate LP"
+msgstr "Code rate LP"
+
+msgid "Coderate HP"
+msgstr "Coderate HP"
+
+msgid "Coderate LP"
+msgstr "Coderate LP"
+
+msgid "Collection name"
+msgstr "Collection name"
+
+msgid "Collection settings"
+msgstr "Collection settings"
+
+msgid "Color format"
+msgstr "Color format"
+
+msgid "Color space"
+msgstr "Color space"
+
+msgid "Command To Run"
+msgstr "Command To Run"
+
+msgid "Command order"
+msgstr "Command order"
+
+msgid "Command type"
+msgstr "Command type"
+
+msgid "Common Interface"
+msgstr "Common Interface"
+
+msgid "Common Interface Assignment"
+msgstr "Common Interface Assignment"
+
+msgid "Common Interface assignment"
+msgstr "Common Interface assignment"
+
+msgid "Common interface"
+msgstr "Common interface"
+
+msgid "Communication"
+msgstr "Communication"
+
+msgid "Complete"
+msgstr "Complete"
+
+msgid "Complex (allows mixing audio tracks and aspects)"
+msgstr "Complex (allows mixing audio tracks and aspects)"
+
+msgid "Composition of the recording filenames"
+msgstr "Composition of the recording filenames"
+
+#, python-format
+msgid "Configfile %s saved."
+msgstr "Configfile %s saved."
+
+msgid "Configuration mode"
+msgstr "Configuration mode"
+
+#, python-format
+msgid "Configuration mode: %s"
+msgstr "Configuration mode: %s"
+
+msgid "Configure an additional delay to improve external subtitle synchronisation."
+msgstr "Configure an additional delay to improve external subtitle synchronisation."
+
+msgid "Configure an additional delay to improve subtitle synchronisation."
+msgstr "Configure an additional delay to improve subtitle synchronisation."
+
+msgid "Configure duration of inactivity before the hard disk drive goes to standby"
+msgstr "Configure duration of inactivity before the hard disk drive goes to standby"
+
+msgid "Configure for how many minutes finished events should remain visible in the EPG. Useful when you need information about an event which has just finished, or has been delayed."
+msgstr "Configure for how many minutes finished events should remain visible in the EPG. Useful when you need information about an event which has just finished, or has been delayed."
+
+msgid "Configure how recording filenames are constructed."
+msgstr "Configure how recording filenames are constructed."
+
+msgid "Configure if and how crypto icons will be shown in the channel selection list."
+msgstr "Configure if and how crypto icons will be shown in the channel selection list."
+
+msgid "Configure if and how service type icons will be shown."
+msgstr "Configure if and how service type icons will be shown."
+
+msgid "Configure if and how the record indicator will be shown in the channel selection list."
+msgstr "Configure if and how the record indicator will be shown in the channel selection list."
+
+msgid "Configure if and how wide the service name column will be shown in the channel selection list."
+msgstr "Configure if and how wide the service name column will be shown in the channel selection list."
+
+msgid "Configure if behind the subtitles a background is shown."
+msgstr "Configure if behind the subtitles a background is shown."
+
+msgid "Configure if picons will be shown in the service list."
+msgstr "Configure if picons will be shown in the service list."
+
+msgid "Configure if the subtitle should switch between normal, italic, bold and bolditalic"
+msgstr "Configure if the subtitle should switch between normal, italic, bold and bolditalic"
+
+msgid "Configure interface"
+msgstr "Configure interface"
+
+msgid "Configure nameservers"
+msgstr "Configure nameservers"
+
+msgid "Configure on which devices the background delete option should be used."
+msgstr "Configure on which devices the background delete option should be used."
+
+msgid "Configure remote control type"
+msgstr "Configure remote control type"
+
+msgid "Configure the DiSEqC mode for this LNB."
+msgstr "Configure the DiSEqC mode for this LNB."
+
+msgid "Configure the IP address."
+msgstr "Configure the IP address."
+
+msgid "Configure the amount of time that will be presented."
+msgstr "Configure the amount of time that will be presented."
+
+msgid "Configure the behavior of the 'pause' key when movie playback is already paused."
+msgstr "Configure the behavior of the 'pause' key when movie playback is already paused."
+
+msgid "Configure the behavior when movie playback is manually stopped."
+msgstr "Configure the behavior when movie playback is manually stopped."
+
+msgid "Configure the behavior when movie playback is started."
+msgstr "Configure the behavior when movie playback is started."
+
+msgid "Configure the behavior when reaching the end of a movie, during movie playback."
+msgstr "Configure the behavior when reaching the end of a movie, during movie playback."
+
+msgid "Configure the border width of the subtitles. The dark border makes the subtitles easier to read on a light background."
+msgstr "Configure the border width of the subtitles. The dark border makes the subtitles easier to read on a light background."
+
+msgid "Configure the brightness level of the front panel display for normal operation."
+msgstr "Configure the brightness level of the front panel display for normal operation."
+
+msgid "Configure the brightness level of the front panel display for standby."
+msgstr "Configure the brightness level of the front panel display for standby."
+
+msgid "Configure the color of the external subtitles, alternative (normal in white, italic in yellow, bold in cyan, underscore in green), white or yellow."
+msgstr "Configure the color of the external subtitles, alternative (normal in white, italic in yellow, bold in cyan, underscore in green), white or yellow."
+
+msgid "Configure the color of the teletext subtitles."
+msgstr "Configure the color of the teletext subtitles."
+
+msgid "Configure the contrast level of the front panel display."
+msgstr "Configure the contrast level of the front panel display."
+
+msgid "Configure the cursor behavior in the channel selection list. When opening the channel selection list you can remain on the current service or already select up/down and you are able to revert the B+/B- buttons."
+msgstr "Configure the cursor behavior in the channel selection list. When opening the channel selection list you can remain on the current service or already select up/down and you are able to revert the B+/B- buttons."
+
+msgid "Configure the duration (in minutes) for the screensaver."
+msgstr "Configure the duration (in minutes) for the screensaver."
+
+msgid "Configure the first audio language (highest priority)."
+msgstr "Configure the first audio language (highest priority)."
+
+msgid "Configure the first subtitle language (highest priority)."
+msgstr "Configure the first subtitle language (highest priority)."
+
+msgid "Configure the font size of the subtitles."
+msgstr "Configure the font size of the subtitles."
+
+msgid "Configure the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size."
+msgstr "Configure the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size."
+
+msgid "Configure the fourth audio language."
+msgstr "Configure the fourth audio language."
+
+msgid "Configure the fourth subtitle language."
+msgstr "Configure the fourth subtitle language."
+
+msgid "Configure the function of the <  > buttons."
+msgstr "Configure the function of the <  > buttons."
+
+msgid "Configure the gateway."
+msgstr "Configure the gateway."
+
+msgid "Configure the horizontal alignment of the subtitles."
+msgstr "Configure the horizontal alignment of the subtitles."
+
+msgid "Configure the infobar fading speed"
+msgstr "Configure the infobar fading speed"
+
+msgid "Configure the initial fast forward speed. When you press the fast forward button, winding will start at this speed."
+msgstr "Configure the initial fast forward speed. When you press the fast forward button, winding will start at this speed."
+
+msgid "Configure the initial rewind speed. When you press the rewind button, rewinding will start at this speed."
+msgstr "Configure the initial rewind speed. When you press the rewind button, rewinding will start at this speed."
+
+msgid "Configure the latitude of your location."
+msgstr "Configure the latitude of your location."
+
+msgid "Configure the longitude of your location."
+msgstr "Configure the longitude of your location."
+
+msgid "Configure the minimum amount of disk space to be available for recordings. When the amount of space drops below this value, deleted items will be removed from the trash can."
+msgstr "Configure the minimum amount of disk space to be available for recordings. When the amount of space drops below this value, deleted items will be removed from the trash can."
+
+msgid "Configure the minimum width before showing the 'i' icon, '0' is equal to not showing the icon at all."
+msgstr "Configure the minimum width before showing the 'i' icon, '0' is equal to not showing the icon at all."
+
+msgid "Configure the nameserver (DNS)."
+msgstr "Configure the nameserver (DNS)."
+
+msgid "Configure the netmask."
+msgstr "Configure the netmask."
+
+msgid ""
+"Configure the number of days after which items are automatically removed from the trash can.\n"
+"A setting of 0 disables this."
+msgstr ""
+"Configure the number of days after which items are automatically removed from the trash can.\n"
+"A setting of 0 disables this."
+
+msgid "Configure the number of days old timers are kept before they are automatically removed from the timer list."
+msgstr "Configure the number of days old timers are kept before they are automatically removed from the timer list."
+
+msgid "Configure the number of rows shown."
+msgstr "Configure the number of rows shown."
+
+msgid "Configure the offline decoding delay (in milliseconds). The configured delay is observed at each control word parity change."
+msgstr "Configure the offline decoding delay (in milliseconds). The configured delay is observed at each control word parity change."
+
+msgid "Configure the possible fast forward speeds."
+msgstr "Configure the possible fast forward speeds."
+
+msgid "Configure the possible rewind speeds."
+msgstr "Configure the possible rewind speeds."
+
+msgid "Configure the primary EPG language."
+msgstr "Configure the primary EPG language."
+
+msgid "Configure the refresh rate of the screen. Multi means refresh rate depends on the source 24/50/60Hz"
+msgstr "Configure the refresh rate of the screen. Multi means refresh rate depends on the source 24/50/60Hz"
+
+msgid "Configure the second audio language."
+msgstr "Configure the second audio language."
+
+msgid "Configure the second subtitle language."
+msgstr "Configure the second subtitle language."
+
+msgid "Configure the secondary EPG language."
+msgstr "Configure the secondary EPG language."
+
+msgid "Configure the skip time interval for the 1 and 3 buttons."
+msgstr "Configure the skip time interval for the 1 and 3 buttons."
+
+msgid "Configure the skip time interval for the 4 and 6 buttons."
+msgstr "Configure the skip time interval for the 4 and 6 buttons."
+
+msgid "Configure the skip time interval for the 7 and 9 buttons."
+msgstr "Configure the skip time interval for the 7 and 9 buttons."
+
+msgid "Configure the slow motion speeds."
+msgstr "Configure the slow motion speeds."
+
+msgid "Configure the source of the frontend data as shown on the infobars. 'Settings' is as stored on the settings. 'Tuner' is as reported by the tuner."
+msgstr "Configure the source of the frontend data as shown on the infobars. 'Settings' is as stored on the settings. 'Tuner' is as reported by the tuner."
+
+msgid "Configure the speed of the background deletion process. Lower speed will consume less hard disk drive performance."
+msgstr "Configure the speed of the background deletion process. Lower speed will consume less hard disk drive performance."
+
+msgid "Configure the subtitle delay when timing information is not available."
+msgstr "Configure the subtitle delay when timing information is not available."
+
+msgid "Configure the third audio language."
+msgstr "Configure the third audio language."
+
+msgid "Configure the third subtitle language."
+msgstr "Configure the third subtitle language."
+
+msgid "Configure the transparency of the black background of graphical DVB subtitles."
+msgstr "Configure the transparency of the black background of graphical DVB subtitles."
+
+msgid "Configure the tuner mode."
+msgstr "Configure the tuner mode."
+
+msgid "Configure the type of status indication icons shown in the movie list."
+msgstr "Configure the type of status indication icons shown in the movie list."
+
+msgid "Configure the vertical position of the subtitles, measured from the bottom of the screen."
+msgstr "Configure the vertical position of the subtitles, measured from the bottom of the screen."
+
+msgid "Configure the width allocated to the picon."
+msgstr "Configure the width allocated to the picon."
+
+msgid "Configure the width allocated to the service name."
+msgstr "Configure the width allocated to the service name."
+
+msgid "Configure to show the channel names, picons, or both in the EPG."
+msgstr "Configure to show the channel names, picons, or both in the EPG."
+
+msgid "Configure whether (and for how long) a second infobar will be shown when OK is pressed twice. The second infobar contains additional information about the current channel."
+msgstr "Configure whether (and for how long) a second infobar will be shown when OK is pressed twice. The second infobar contains additional information about the current channel."
+
+msgid "Configure whether or not an rotor position will be displayed on infobar"
+msgstr "Configure whether or not an rotor position will be displayed on infobar"
+
+msgid "Configure which color format should be used on the SCART output."
+msgstr "Configure which color format should be used on the SCART output."
+
+msgid "Configure which tuner for recordings will be preferred, when more than one tuner is available."
+msgstr "Configure which tuner for recordings will be preferred, when more than one tuner is available."
+
+msgid "Configure which tuner type will be preferred, when the same service is available on different types of tuners."
+msgstr "Configure which tuner type will be preferred, when the same service is available on different types of tuners."
+
+msgid "Configure which tuner will be preferred, when more than one tuner is available. If set to 'auto' the system will give priority to the tuner having the lowest number of channels/satellites."
+msgstr "Configure which tuner will be preferred, when more than one tuner is available. If set to 'auto' the system will give priority to the tuner having the lowest number of channels/satellites."
+
+msgid "Configure your NTP server."
+msgstr "Configure your NTP server."
+
+msgid "Configure your internal LAN"
+msgstr "Configure your internal LAN"
+
+msgid "Configure your network again"
+msgstr "Configure your network again"
+
+msgid "Configure your network settings, and press OK to start the scan"
+msgstr "Configure your network settings, and press OK to start the scan"
+
+msgid "Configure your wireless LAN again"
+msgstr "Configure your wireless LAN again"
+
+msgid "Configures which video output connector will be used."
+msgstr "Configures which video output connector will be used."
+
+msgid "Configuring"
+msgstr "Configuring"
+
+msgid "Conflicting timer"
+msgstr "Conflicting timer"
+
+msgid "Connect"
+msgstr "Connect"
+
+msgid "Connect to a wireless network"
+msgstr "Connect to a wireless network"
+
+msgid "Connected clients"
+msgstr "Connected clients"
+
+msgid "Connected satellites"
+msgstr "Connected satellites"
+
+msgid "Connected to"
+msgstr "Connected to"
+
+msgid "Connected: "
+msgstr "Connected: "
+
+msgid "Constellation"
+msgstr "Constellation"
+
+msgid "Content"
+msgstr "Content"
+
+msgid "Content does not fit on DVD!"
+msgstr "Content does not fit on DVD!"
+
+msgid "Context"
+msgstr "Context"
+
+msgid "Continue"
+msgstr "Continue"
+
+msgid "Continue playback"
+msgstr "Continue playback"
+
+msgid "Continue playing"
+msgstr "Continue playing"
+
+msgid "Continues"
+msgstr "Continues"
+
+msgid "Continues play (loop)"
+msgstr "Continues play (loop)"
+
+msgid "Contrast"
+msgstr "Contrast"
+
+msgid "Control of the position how finished timers are shown in the Timer List."
+msgstr "Control of the position how finished timers are shown in the Timer List."
+
+msgid "Convert ext3 filesystem to ext4"
+msgstr "Convert ext3 filesystem to ext4"
+
+msgid "Convert ext3 to ext4"
+msgstr "Convert ext3 to ext4"
+
+msgid "Convert filesystem ext3 to ext4"
+msgstr "Convert filesystem ext3 to ext4"
+
+msgid "Converting ext3 to ext4..."
+msgstr "Converting ext3 to ext4..."
+
+msgid "Cool TV Guide"
+msgstr "Cool TV Guide"
+
+msgid "Copy"
+msgstr "Copy"
+
+msgid "Copy to bouquets"
+msgstr "Copy to bouquets"
+
+msgid "Copying files"
+msgstr "Copying files"
+
+#, python-format
+msgid "Cores:\t%s\n"
+msgstr "Cores:\t%s\n"
+
+msgid "Could not find installed channel list."
+msgstr "Could not find installed channel list."
+
+msgid "Could not load medium! No disc inserted?"
+msgstr "Could not load medium! No disc inserted?"
+
+msgid "Could not open Picture in Picture"
+msgstr "Could not open Picture in Picture"
+
+#, python-format
+msgid "Could not open the file %s!"
+msgstr "Could not open the file %s!"
+
+#, python-format
+msgid "Could not record due to a conflicting timer %s"
+msgstr "Could not record due to a conflicting timer %s"
+
+#, python-format
+msgid "Could not record due to an invalid service %s"
+msgstr "Could not record due to an invalid service %s"
+
+#, python-format
+msgid "Could not save configfile %s!"
+msgstr "Could not save configfile %s!"
+
+msgid "Crash Logs"
+msgstr "Crash Logs"
+
+msgid "Create DVD-ISO"
+msgstr "Create DVD-ISO"
+
+msgid "Create directory"
+msgstr "Create directory"
+
+msgid "Creating AP and SC Files"
+msgstr "Creating AP and SC Files"
+
+msgid "Creating Hardlink to Timeshift file failed!"
+msgstr "Creating Hardlink to Timeshift file failed!"
+
+#, python-format
+msgid "Creating directory %s failed."
+msgstr "Creating directory %s failed."
+
+msgid "Creating filesystem"
+msgstr "Creating filesystem"
+
+msgid "Creating partition"
+msgstr "Creating partition"
+
+msgid "Croatian"
+msgstr "Croatian"
+
+msgid "Cron Manager"
+msgstr "Cron Manager"
+
+msgid "CronTimers"
+msgstr "CronTimers"
+
+msgid "Current CEC address"
+msgstr "Current CEC address"
+
+msgid "Current Event:"
+msgstr "Current Event:"
+
+msgid "Current Status:"
+msgstr "Current Status:"
+
+msgid "Current device: "
+msgstr "Current device: "
+
+#, python-format
+msgid "Current mode: %s \n"
+msgstr "Current mode: %s \n"
+
+msgid "Current rotor position: "
+msgstr "Current rotor position: "
+
+msgid "Current settings:"
+msgstr "Current settings:"
+
+msgid "Current time"
+msgstr "Current time"
+
+msgid "Current transponder"
+msgstr "Current transponder"
+
+msgid "Current value: "
+msgstr "Current value: "
+
+msgid "Current version:"
+msgstr "Current version:"
+
+msgid "Custom"
+msgstr "Custom"
+
+msgid "Custom skip time for '1''3' buttons"
+msgstr "Custom skip time for '1''3' buttons"
+
+msgid "Custom skip time for '4'/'6' buttons"
+msgstr "Custom skip time for '4'/'6' buttons"
+
+msgid "Custom skip time for '7'/'9' buttons"
+msgstr "Custom skip time for '7'/'9' buttons"
+
+msgid "Customize"
+msgstr "Customise"
+
+msgid "Cut"
+msgstr "Cut"
+
+msgid "Cutlist editor"
+msgstr "Cutlist editor"
+
+msgid "Cutlist editor..."
+msgstr "Cutlist editor..."
+
+msgid "Czech"
+msgstr "Czech"
+
+msgid "DAC"
+msgstr "DAC"
+
+msgid "DHCP"
+msgstr "DHCP"
+
+msgid "DLNA support"
+msgstr "DLNA support"
+
+msgid "DMM advanced"
+msgstr "DMM advanced"
+
+msgid "DMM normal"
+msgstr "DMM normal"
+
+msgid "DTS"
+msgstr "DTS"
+
+msgid "DUAL LAYER DVD"
+msgstr "DUAL LAYER DVD"
+
+msgid "DVB subtitle black transparency"
+msgstr "DVB subtitle black transparency"
+
+msgid "DVB-C"
+msgstr "DVB-C"
+
+msgid "DVB-C ANNEX C"
+msgstr "DVB-C ANNEX C"
+
+msgid "DVB-S"
+msgstr "DVB-S"
+
+msgid "DVB-S2"
+msgstr "DVB-S2"
+
+msgid "DVB-T"
+msgstr "DVB-T"
+
+msgid "DVB-T2"
+msgstr "DVB-T2"
+
+msgid "DVD data format"
+msgstr "DVD data format"
+
+msgid "DVD file browser"
+msgstr "DVD file browser"
+
+msgid "DVD media toolbox"
+msgstr "DVD media toolbox"
+
+msgid "DVD player"
+msgstr "DVD player"
+
+msgid "DVD titlelist"
+msgstr "DVD titlelist"
+
+msgid "Daily"
+msgstr "Daily"
+
+msgid "Danish"
+msgstr "Danish"
+
+msgid "Date"
+msgstr "Date"
+
+msgid "De-select"
+msgstr "De-select"
+
+msgid "Debug Logs"
+msgstr "Debug Logs"
+
+msgid "Deep Standby"
+msgstr "Deep Standby"
+
+msgid "Deep standby"
+msgstr "Deep standby"
+
+msgid "Default"
+msgstr "Default"
+
+msgid "Default movie location"
+msgstr "Default movie location"
+
+msgid "Default recording type"
+msgstr "Default recording type"
+
+msgid "Default settings"
+msgstr "Default settings"
+
+msgid "Defaults"
+msgstr "Defaults"
+
+msgid "Delay after change voltage before switch command"
+msgstr "Delay after change voltage before switch command"
+
+msgid "Delay after continuous tone disable before diseqc"
+msgstr "Delay after continuous tone disable before diseqc"
+
+msgid "Delay after diseqc peripherial poweron command"
+msgstr "Delay after diseqc peripherial poweron command"
+
+msgid "Delay after diseqc reset command"
+msgstr "Delay after diseqc reset command"
+
+msgid "Delay after enable voltage before motor command"
+msgstr "Delay after enable voltage before motor command"
+
+msgid "Delay after enable voltage before switch command"
+msgstr "Delay after enable voltage before switch command"
+
+msgid "Delay after final continuous tone change"
+msgstr "Delay after final continuous tone change"
+
+msgid "Delay after last diseqc command"
+msgstr "Delay after last diseqc command"
+
+msgid "Delay after last voltage change"
+msgstr "Delay after last voltage change"
+
+msgid "Delay after motor stop command"
+msgstr "Delay after motor stop command"
+
+msgid "Delay after set voltage before measure motor power"
+msgstr "Delay after set voltage before measure motor power"
+
+msgid "Delay after toneburst"
+msgstr "Delay after toneburst"
+
+msgid "Delay after voltage change before motor command"
+msgstr "Delay after voltage change before motor command"
+
+msgid "Delay before key repeat starts:"
+msgstr "Delay before key repeat starts:"
+
+msgid "Delay before sequence repeat"
+msgstr "Delay before sequence repeat"
+
+msgid "Delay between diseqc commands"
+msgstr "Delay between diseqc commands"
+
+msgid "Delay between switch and motor command"
+msgstr "Delay between switch and motor command"
+
+msgid "Delay for external subtitles"
+msgstr "Delay for external subtitles"
+
+msgid "Delay in miliseconds after finish scrolling text on display."
+msgstr "Delay in miliseconds after finish scrolling text on display."
+
+msgid "Delay in miliseconds before start of scrolling text on display."
+msgstr "Delay in miliseconds before start of scrolling text on display."
+
+msgid "Delay time"
+msgstr "Delay time"
+
+msgid "Delay:"
+msgstr "Delay:"
+
+msgid "Delete"
+msgstr "Delete"
+
+#, python-format
+msgid "Delete %s?"
+msgstr "Delete %s?"
+
+msgid "Delete Confirmation"
+msgstr "Delete Confirmation"
+
+msgid "Delete EPG"
+msgstr "Delete EPG"
+
+msgid "Delete entry"
+msgstr "Delete entry"
+
+msgid "Delete failed!"
+msgstr "Delete failed!"
+
+msgid "Delete file"
+msgstr "Delete file"
+
+msgid "Delete playlist entry"
+msgstr "Delete playlist entry"
+
+msgid "Delete saved playlist"
+msgstr "Delete saved playlist"
+
+msgid "Delete timer"
+msgstr "Delete timer"
+
+msgid "Deleted"
+msgstr "Deleted"
+
+#, python-format
+msgid "Deleted %s!"
+msgstr "Deleted %s!"
+
+msgid "Deleted items"
+msgstr "Deleted items"
+
+msgid "Deleting files"
+msgstr "Deleting files"
+
+msgid "Depth"
+msgstr "Depth"
+
+msgid "Descramble & record ECM' gives the option to descramble afterwards if descrambling on recording failed. 'Don't descramble, record ECM' save a scramble recording that can be descrambled on playback. 'Normal' means descramble the recording and don't record ECM."
+msgstr "Descramble & record ECM' gives the option to descramble afterwards if descrambling on recording failed. 'Don't descramble, record ECM' save a scramble recording that can be descrambled on playback. 'Normal' means descramble the recording and don't record ECM."
+
+msgid "Descramble receiving http streams"
+msgstr "Descramble receiving http streams"
+
+msgid "Descramble sending http streams"
+msgstr "Descramble sending http streams"
+
+msgid "Description"
+msgstr "Description"
+
+msgid "Deselect"
+msgstr "Deselect"
+
+msgid "Details for plugin: "
+msgstr "Details for plugin: "
+
+msgid "Detected devices:"
+msgstr "Detected devices:"
+
+msgid "Detected tuners:"
+msgstr "Detected tuners:"
+
+msgid "Device mounts"
+msgstr "Device mounts"
+
+msgid "Device setup"
+msgstr "Device setup"
+
+msgid "Devicename:"
+msgstr "Devicename:"
+
+msgid "Devices"
+msgstr "Devices"
+
+msgid "DiSEqC"
+msgstr "DiSEqC"
+
+msgid "DiSEqC 1.0 command"
+msgstr "DiSEqC 1.0 command"
+
+msgid "DiSEqC 1.1 command"
+msgstr "DiSEqC 1.1 command"
+
+msgid "DiSEqC 1.1 repeats"
+msgstr "DiSEqC 1.1 repeats"
+
+msgid "DiSEqC A/B"
+msgstr "DiSEqC A/B"
+
+msgid "DiSEqC A/B/C/D"
+msgstr "DiSEqC A/B/C/D"
+
+msgid "DiSEqC mode"
+msgstr "DiSEqC mode"
+
+#, python-format
+msgid "DiSEqC port %s: %s"
+msgstr "DiSEqC port %s: %s"
+
+msgid "DiSEqC-tester settings"
+msgstr "DiSEqC-tester settings"
+
+msgid "Diction"
+msgstr "Diction"
+
+msgid "Digital contour removal"
+msgstr "Digital contour removal"
+
+msgid "Digital downmix"
+msgstr "Digital downmix"
+
+msgid "Direct playback of linked titles without menu"
+msgstr "Direct playback of linked titles without menu"
+
+msgid "Directory"
+msgstr "Directory"
+
+#, python-format
+msgid "Directory %s does not exist."
+msgstr "Directory %s does not exist."
+
+msgid "Directory browser"
+msgstr "Directory browser"
+
+msgid "Disable"
+msgstr "Disable"
+
+msgid "Disable Animations"
+msgstr "Disable Animations"
+
+msgid "Disable Picture in Picture"
+msgstr "Disable Picture in Picture"
+
+msgid "Disable background scanning"
+msgstr "Disable background scanning"
+
+msgid "Disable move mode"
+msgstr "Disable move mode"
+
+msgid "Disable timer"
+msgstr "Disable timer"
+
+msgid "Disabled"
+msgstr "Disabled"
+
+msgid "Disk space to reserve for recordings (in GB)"
+msgstr "Disk space to reserve for recordings (in GB)"
+
+msgid "Display 16:9 content as"
+msgstr "Display 16:9 content as"
+
+msgid "Display 4:3 content as"
+msgstr "Display 4:3 content as"
+
+msgid "Display >16:9 content as"
+msgstr "Display >16:9 content as"
+
+msgid "Display and user interface"
+msgstr "Display and user interface"
+
+msgid "Display message before playing next movie"
+msgstr "Display message before playing next movie"
+
+msgid "Display the EIT now/next eventdata in infobar."
+msgstr "Display the EIT now/next eventdata in infobar."
+
+msgid "Do not change"
+msgstr "Do not change"
+
+msgid "Do not record"
+msgstr "Do not record"
+
+msgid "Do nothing"
+msgstr "Do nothing"
+
+msgid ""
+"Do you really want to check the filesystem?\n"
+"This could take a long time!"
+msgstr ""
+"Do you really want to check the filesystem?\n"
+"This could take a long time!"
+
+msgid ""
+"Do you really want to convert the filesystem?\n"
+"You cannot go back!"
+msgstr ""
+"Do you really want to convert the filesystem?\n"
+"You cannot go back!"
+
+#, python-format
+msgid "Do you really want to delete %s ?"
+msgstr "Do you really want to delete %s ?"
+
+#, python-format
+msgid "Do you really want to delete %s?"
+msgstr "Do you really want to delete %s?"
+
+msgid "Do you really want to delete ?"
+msgstr "Do you really want to delete ?"
+
+msgid "Do you really want to delete this timer ?"
+msgstr "Do you really want to delete this timer ?"
+
+#, python-format
+msgid "Do you really want to download the plugin \"%s\"?"
+msgstr "Do you really want to download the plugin \"%s\"?"
+
+msgid "Do you really want to exit?"
+msgstr "Do you really want to exit?"
+
+msgid ""
+"Do you really want to initialize this device?\n"
+"All the data on the device will be lost!"
+msgstr ""
+"Do you really want to initialise this device?\n"
+"All the data on the device will be lost!"
+
+msgid "Do you really want to move to the trash can ?"
+msgstr "Do you really want to move to the trash can ?"
+
+#, python-format
+msgid "Do you really want to permamently remove '%s' from the trash can ?"
+msgstr "Do you really want to permanently remove '%s' from the trash can ?"
+
+msgid "Do you really want to permanently remove from the trash can ?"
+msgstr "Do you really want to permanently remove from the trash can ?"
+
+#, python-format
+msgid "Do you really want to remove directory %s from the disk?"
+msgstr "Do you really want to remove directory %s from the disk?"
+
+#, python-format
+msgid "Do you really want to remove the plugin \"%s\"?"
+msgstr "Do you really want to remove the plugin \"%s\"?"
+
+#, python-format
+msgid "Do you really want to remove the timer for %s?"
+msgstr "Do you really want to remove the timer for %s?"
+
+#, python-format
+msgid "Do you really want to remove your bookmark of %s?"
+msgstr "Do you really want to remove your bookmark of %s?"
+
+msgid "Do you want to add any additional information ?"
+msgstr "Do you want to add any additional information ?"
+
+msgid ""
+"Do you want to attach a text file to explain the log ?\n"
+"(choose 'No' to type message using virtual keyboard.)"
+msgstr ""
+"Do you want to attach a text file to explain the log ?\n"
+"(choose 'No' to type message using virtual keyboard.)"
+
+msgid "Do you want to burn this collection to DVD medium?"
+msgstr "Do you want to burn this collection to DVD medium?"
+
+msgid "Do you want to continue?"
+msgstr "Do you want to continue?"
+
+msgid ""
+"Do you want to delete all the selected files:\n"
+"(choose 'No' to only delete the currently selected file.)"
+msgstr ""
+"Do you want to delete all the selected files:\n"
+"(choose 'No' to only delete the currently selected file.)"
+
+msgid "Do you want to do a service scan?"
+msgstr "Do you want to do a service scan?"
+
+msgid "Do you want to do another manual service scan?"
+msgstr "Do you want to do another manual service scan?"
+
+msgid "Do you want to install the package:\n"
+msgstr "Do you want to install the package:\n"
+
+msgid ""
+"Do you want to install the samba client aswell?\n"
+"This will allow you to mount your windows shares on this device."
+msgstr ""
+"Do you want to install the samba client aswell?\n"
+"This will allow you to mount your windows shares on this device."
+
+msgid "Do you want to play DVD in drive?"
+msgstr "Do you want to play DVD in drive?"
+
+msgid "Do you want to preview this DVD before burning?"
+msgstr "Do you want to preview this DVD before burning?"
+
+#, python-format
+msgid "Do you want to reboot your %s %s"
+msgstr "Do you want to reboot your %s %s"
+
+msgid "Do you want to reboot your receiver?"
+msgstr "Do you want to reboot your receiver?"
+
+msgid "Do you want to remove the package:\n"
+msgstr "Do you want to remove the package:\n"
+
+msgid "Do you want to restore your settings?"
+msgstr "Do you want to restore your settings?"
+
+msgid "Do you want to resume playback?"
+msgstr "Do you want to resume playback?"
+
+msgid ""
+"Do you want to send all the selected files:\n"
+"(choose 'No' to only send the currently selected file.)"
+msgstr ""
+"Do you want to send all the selected files:\n"
+"(choose 'No' to only send the currently selected file.)"
+
+#, python-format
+msgid "Do you want to update your %s %s ?"
+msgstr "Do you want to update your %s %s ?"
+
+msgid "Do you want to upgrade the package:\n"
+msgstr "Do you want to upgrade the package:\n"
+
+msgid "Dobly Digital downmix is now"
+msgstr "Dobly Digital downmix is now"
+
+msgid "Dolby Digital / DTS downmix"
+msgstr "Dolby Digital / DTS downmix"
+
+msgid "Don't save"
+msgstr "Don't save"
+
+msgid "Don't stop current event but disable future events"
+msgstr "Don't stop current event but disable future events"
+
+msgid "Don't zap"
+msgstr "Don't zap"
+
+msgid "Don't zap and disable timer"
+msgstr "Don't zap and disable timer"
+
+msgid "Don't zap and remove timer"
+msgstr "Don't zap and remove timer"
+
+#, python-format
+msgid "Done - Installed, upgraded or removed %d package (%s)"
+msgid_plural "Done - Installed, upgraded or removed %d packages (%s)"
+msgstr[0] "Done - Installed, upgraded or removed %d package (%s)"
+msgstr[1] "Done - Installed, upgraded or removed %d packages (%s)"
+
+msgid "Down"
+msgstr "Down"
+
+msgid "Download plugins"
+msgstr "Download plugins"
+
+msgid "Downloading"
+msgstr "Downloading"
+
+msgid "Downloading plugin information. Please wait..."
+msgstr "Downloading plugin information. Please wait..."
+
+#, python-format
+msgid "Drivers:\t%s\n"
+msgstr "Drivers:\t%s\n"
+
+#, python-format
+msgid "Drivers: %s"
+msgstr "Drivers: %s"
+
+msgid "Dutch"
+msgstr "Dutch"
+
+msgid "Dynamic contrast"
+msgstr "Dynamic contrast"
+
+msgid "E"
+msgstr "E"
+
+msgid "ECM Statistics"
+msgstr "ECM Statistics"
+
+msgid "ECM Time"
+msgstr "ECM Time"
+
+msgid "ECM avg"
+msgstr "ECM avg"
+
+msgid "ECM data will be included in the stream. This enables a client receiver to decode it."
+msgstr "ECM data will be included in the stream. This enables a client receiver to decode it."
+
+msgid "ECM last"
+msgstr "ECM last"
+
+msgid "ECM-Time"
+msgstr "ECM-Time"
+
+msgid "EPG"
+msgstr "EPG"
+
+msgid "EPG Cache Check"
+msgstr "EPG Cache Check"
+
+msgid "EPG Search"
+msgstr "EPG Search"
+
+msgid "EPG filename"
+msgstr "EPG filename"
+
+msgid "EPG language selection 1"
+msgstr "EPG language selection 1"
+
+msgid "EPG language selection 2"
+msgstr "EPG language selection 2"
+
+msgid "EPG location"
+msgstr "EPG location"
+
+msgid "EPG settings"
+msgstr "EPG settings"
+
+#, python-format
+msgid "ERROR - failed to scan (%s)!"
+msgstr "ERROR - failed to scan (%s)!"
+
+msgid "ERROR:   Check is already running in background, please wait a few minutes and try again"
+msgstr "ERROR:   Check is already running in background, please wait a few minutes and try again"
+
+msgid "ERROR:   No internet found"
+msgstr "ERROR:   No internet found"
+
+msgid "ERROR:   No network found"
+msgstr "ERROR:   No network found"
+
+msgid "ERROR: Check is already running in background"
+msgstr "ERROR: Check is already running in background"
+
+msgid "East"
+msgstr "East"
+
+msgid "East limit set"
+msgstr "East limit set"
+
+msgid "Ecm:"
+msgstr "Ecm:"
+
+msgid "Edit"
+msgstr "Edit"
+
+msgid "Edit DNS"
+msgstr "Edit DNS"
+
+msgid "Edit alternatives"
+msgstr "Edit alternatives"
+
+msgid "Edit chapters of current title"
+msgstr "Edit chapters of current title"
+
+msgid "Edit new entry"
+msgstr "Edit new entry"
+
+msgid "Edit settings"
+msgstr "Edit settings"
+
+#, python-format
+msgid "Edit the Nameserver configuration of your %s %s.\n"
+msgstr "Edit the Nameserver configuration of your %s %s.\n"
+
+#, python-format
+msgid "Edit the network configuration of your %s %s.\n"
+msgstr "Edit the network configuration of your %s %s.\n"
+
+msgid "Edit timer"
+msgstr "Edit timer"
+
+msgid "Edit title"
+msgstr "Edit title"
+
+msgid "Edit upgrade source url."
+msgstr "Edit upgrade source url."
+
+msgid "Education/Science/..."
+msgstr "Education/Science/..."
+
+msgid "Elapsed"
+msgstr "Elapsed"
+
+msgid "Elapsed & Remaining"
+msgstr "Elapsed & Remaining"
+
+msgid "Electronic Program Guide"
+msgstr "Electronic Program Guide"
+
+msgid "Enable"
+msgstr "Enable"
+
+msgid "Enable 5V for active antenna"
+msgstr "Enable 5V for active antenna"
+
+msgid "Enable EIT EPG"
+msgstr "Enable EIT EPG"
+
+msgid "Enable FreeSat EPG"
+msgstr "Enable FreeSat EPG"
+
+msgid "Enable MHW EPG"
+msgstr "Enable MHW EPG"
+
+msgid "Enable Netmed EPG"
+msgstr "Enable Netmed EPG"
+
+msgid "Enable ViaSat EPG"
+msgstr "Enable ViaSat EPG"
+
+msgid "Enable Virgin EPG"
+msgstr "Enable Virgin EPG"
+
+msgid "Enable Wake On LAN"
+msgstr "Enable Wake On LAN"
+
+msgid "Enable auto cable scan"
+msgstr "Enable auto cable scan"
+
+msgid "Enable auto fast scan"
+msgstr "Enable auto fast scan"
+
+msgid "Enable bouquet edit"
+msgstr "Enable bouquet edit"
+
+msgid "Enable debug logs *"
+msgstr "Enable debug logs *"
+
+msgid "Enable fallback remote receiver"
+msgstr "Enable fallback remote receiver"
+
+msgid "Enable favourite edit"
+msgstr "Enable favourite edit"
+
+msgid "Enable infobar fade-out"
+msgstr "Enable infobar fade-out"
+
+msgid "Enable move mode"
+msgstr "Enable move mode"
+
+msgid "Enable multiple bouquets"
+msgstr "Enable multiple bouquets"
+
+msgid "Enable panic button"
+msgstr "Enable panic button"
+
+msgid "Enable parental protection"
+msgstr "Enable parental protection"
+
+msgid "Enable teletext caching"
+msgstr "Enable teletext caching"
+
+msgid "Enable the use of the tuners of a remote enigma2 receiver when no local tuner is available (e.g. when the tuner is occupied or service type is unavailable on the local tuner)."
+msgstr "Enable the use of the tuners of a remote enigma2 receiver when no local tuner is available (e.g. when the tuner is occupied or service type is unavailable on the local tuner)."
+
+msgid "Enable timer conflict detection"
+msgstr "Enable timer conflict detection"
+
+msgid "Enabled"
+msgstr "Enabled"
+
+msgid "Encrypted: "
+msgstr "Encrypted: "
+
+msgid "Encryption"
+msgstr "Encryption"
+
+msgid "Encryption key"
+msgstr "Encryption key"
+
+msgid "Encryption key type"
+msgstr "Encryption key type"
+
+msgid "Encryption:"
+msgstr "Encryption:"
+
+msgid "End"
+msgstr "End"
+
+msgid "End alternatives edit"
+msgstr "End alternatives edit"
+
+msgid "End bouquet edit"
+msgstr "End bouquet edit"
+
+msgid "End favourites edit"
+msgstr "End favourites edit"
+
+msgid "End time"
+msgstr "End time"
+
+msgid "English"
+msgstr "English"
+
+msgid "Enigma2 Changes"
+msgstr "Enigma2 Changes"
+
+msgid "Enigma2 skin selector"
+msgstr "Enigma2 skin selector"
+
+msgid "Enter main menu..."
+msgstr "Enter main menu..."
+
+msgid "Enter pin code"
+msgstr "Enter pin code"
+
+msgid "Enter the service pin"
+msgstr "Enter the service pin"
+
+msgid "Enter your e-mail address to send a copy of the log to."
+msgstr "Enter your e-mail address to send a copy of the log to."
+
+msgid "Enter your forum user name, to make it easier to trace logs."
+msgstr "Enter your forum user name, to make it easier to trace logs."
+
+msgid "Entitlements"
+msgstr "Entitlements"
+
+msgid "Epg/Guide"
+msgstr "Epg/Guide"
+
+msgid "Epg/Guide long"
+msgstr "Epg/Guide long"
+
+msgid "Equal to"
+msgstr "Equal to"
+
+msgid "Error"
+msgstr "Error"
+
+msgid "Error code"
+msgstr "Error code"
+
+msgid "Error downloading the change log."
+msgstr "Error downloading the change log."
+
+msgid "Error executing plugin"
+msgstr "Error executing plugin"
+
+msgid "Error reading webpage!"
+msgstr "Error reading webpage!"
+
+#, python-format
+msgid ""
+"Error:\n"
+"%s"
+msgstr ""
+"Error:\n"
+"%s"
+
+#, python-format
+msgid ""
+"Error: %s\n"
+"Retry?"
+msgstr ""
+"Error: %s\n"
+"Retry?"
+
+msgid "Estonian"
+msgstr "Estonian"
+
+msgid "Ethernet network interface"
+msgstr "Ethernet network interface"
+
+msgid "Event Info"
+msgstr "Event Info"
+
+msgid "Event font size"
+msgstr "Event font size"
+
+msgid "Event name first"
+msgstr "Event name first"
+
+msgid "Event view"
+msgstr "Event view"
+
+msgid "Event view menu"
+msgstr "Event view menu"
+
+msgid "Everyday"
+msgstr "Everyday"
+
+msgid "Everywhere"
+msgstr "Everywhere"
+
+msgid "Exceeds dual layer medium!"
+msgstr "Exceeds dual layer medium!"
+
+msgid "Execution finished!!"
+msgstr "Execution finished!!"
+
+msgid "Execution progress:"
+msgstr "Execution progress:"
+
+msgid "Exif"
+msgstr "Exif"
+
+msgid "Exit"
+msgstr "Exit"
+
+msgid "Exit EPG"
+msgstr "Exit EPG"
+
+msgid "Exit MAC address configuration"
+msgstr "Exit MAC address configuration"
+
+msgid "Exit editor"
+msgstr "Exit editor"
+
+msgid "Exit input device selection."
+msgstr "Exit input device selection."
+
+msgid "Exit media player?"
+msgstr "Exit media player?"
+
+msgid "Exit mediaplayer"
+msgstr "Exit mediaplayer"
+
+msgid "Exit mounts setup menu"
+msgstr "Exit mounts setup menu"
+
+msgid "Exit movie list"
+msgstr "Exit movie list"
+
+msgid "Exit movie player..."
+msgstr "Exit movie player..."
+
+msgid "Exit movie player?"
+msgstr "Exit movie player?"
+
+msgid "Exit nameserver configuration"
+msgstr "Exit nameserver configuration"
+
+msgid "Exit network adapter configuration"
+msgstr "Exit network adapter configuration"
+
+msgid "Exit network adapter setup menu"
+msgstr "Exit network adapter setup menu"
+
+msgid "Exit network interface list"
+msgstr "Exit network interface list"
+
+msgid "Exit network wizard"
+msgstr "Exit network wizard"
+
+msgid "Exit networkadapter setup menu"
+msgstr "Exit networkadapter setup menu"
+
+msgid "Exit the wizard"
+msgstr "Exit the wizard"
+
+msgid "Exit/OK"
+msgstr "Exit/OK"
+
+msgid "Expert"
+msgstr "Expert"
+
+msgid "Extended"
+msgstr "Extended"
+
+msgid "Extended Networksetup Plugin..."
+msgstr "Extended Networksetup Plugin..."
+
+msgid "Extended Setup..."
+msgstr "Extended Setup..."
+
+msgid "Extended Shares"
+msgstr "Extended Shares"
+
+msgid "Extended Software"
+msgstr "Extended Software"
+
+msgid "Extended Software Plugin"
+msgstr "Extended Software Plugin"
+
+msgid "Extended network setup plugin..."
+msgstr "Extended network setup plugin..."
+
+msgid "Extended setup..."
+msgstr "Extended setup..."
+
+msgid "Extensions"
+msgstr "Extensions"
+
+msgid "Extensions management"
+msgstr "Extensions management"
+
+msgid "External"
+msgstr "External"
+
+msgid "External PiP"
+msgstr "External PiP"
+
+#, python-format
+msgid "External Storage %s"
+msgstr "External Storage %s"
+
+msgid "External subtitle color"
+msgstr "External subtitle color"
+
+msgid "External subtitle dialog colorisation"
+msgstr "External subtitle dialog colorisation"
+
+msgid "External subtitle switch fonts"
+msgstr "External subtitle switch fonts"
+
+msgid "Extra motor options"
+msgstr "Extra motor options"
+
+msgid "Extrude from left"
+msgstr "Extrude from left"
+
+msgid "F1"
+msgstr "F1"
+
+msgid "F1/F3"
+msgstr "F1/F3"
+
+msgid "F1/LAN"
+msgstr "F1/LAN"
+
+msgid "F1/LAN long"
+msgstr "F1/LAN long"
+
+msgid "F2"
+msgstr "F2"
+
+msgid "F2 long"
+msgstr "F2 long"
+
+msgid "F3"
+msgstr "F3"
+
+msgid "F3 long"
+msgstr "F3 long"
+
+msgid "FAILED"
+msgstr "FAILED"
+
+msgid "FBC Unicable"
+msgstr "FBC Unicable"
+
+msgid "FBC automatic loop through"
+msgstr "FBC automatic loop through"
+
+msgid ""
+"FBC automatic loop through\n"
+"inactive"
+msgstr ""
+"FBC automatic loop through\n"
+"inactive"
+
+#, python-format
+msgid ""
+"FBC automatic loop through\n"
+"linked to %s"
+msgstr ""
+"FBC automatic loop through\n"
+"linked to %s"
+
+msgid "FEC"
+msgstr "FEC"
+
+msgid "FEC:"
+msgstr "FEC:"
+
+msgid "FLASH"
+msgstr "FLASH"
+
+msgid "FTP Setup"
+msgstr "FTP Setup"
+
+msgid "FTP setup"
+msgstr "FTP setup"
+
+msgid "Factory reset"
+msgstr "Factory reset"
+
+msgid "Fade the infobar when hiding"
+msgstr "Fade the infobar when hiding"
+
+msgid "Failed"
+msgstr "Failed"
+
+msgid "Failed to write /tmp/positionersetup.log: "
+msgstr "Failed to write /tmp/positionersetup.log: "
+
+msgid "Fallback remote receiver URL"
+msgstr "Fallback remote receiver URL"
+
+msgid "Fallback remote receiver streaming port"
+msgstr "Fallback remote receiver streaming port"
+
+#, python-format
+msgid "Fan %d"
+msgstr "Fan %d"
+
+msgid "Fast"
+msgstr "Fast"
+
+msgid "Fast DiSEqC"
+msgstr "Fast DiSEqC"
+
+msgid "Fast Scan"
+msgstr "Fast Scan"
+
+msgid "Fast epoch"
+msgstr "Fast epoch"
+
+msgid "Fast forward speeds"
+msgstr "Fast forward speeds"
+
+msgid "Fastforward"
+msgstr "Fastforward"
+
+msgid "Favourites"
+msgstr "Favourites"
+
+msgid "Feeds status:   Stable"
+msgstr "Feeds status:   Stable"
+
+msgid "Feeds status:   Unknown"
+msgstr "Feeds status:   Unknown"
+
+msgid "Feeds status:   Unstable"
+msgstr "Feeds status:   Unstable"
+
+msgid "Feeds status:   Updating"
+msgstr "Feeds status:   Updating"
+
+msgid "File appears to be busy.\n"
+msgstr "File appears to be busy.\n"
+
+msgid ""
+"File oscam.conf not found.\n"
+"Please enter username/password manually."
+msgstr ""
+"File oscam.conf not found.\n"
+"Please enter username/password manually."
+
+msgid "Filesystem Check"
+msgstr "Filesystem Check"
+
+msgid "Filesystem check"
+msgstr "Filesystem check"
+
+msgid "Final position at"
+msgstr "Final position at"
+
+msgid "Final position at index"
+msgstr "Final position at index"
+
+msgid "Final scroll delay"
+msgstr "Final scroll delay"
+
+msgid "Find currently played service"
+msgstr "Find currently played service"
+
+msgid "Fine movement"
+msgstr "Fine movement"
+
+msgid "Finetune"
+msgstr "Finetune"
+
+msgid "Finished"
+msgstr "Finished"
+
+msgid "Finished configuring your network"
+msgstr "Finished configuring your network"
+
+msgid "Finnish"
+msgstr "Finnish"
+
+msgid "Fixed"
+msgstr "Fixed"
+
+msgid "Flashing"
+msgstr "Flashing"
+
+msgid "Following tasks will be done after you press OK!"
+msgstr "Following tasks will be done after you press OK!"
+
+msgid "Font size"
+msgstr "Font size"
+
+msgid "Force LNB Power"
+msgstr "Force LNB Power"
+
+msgid "Force ToneBurst"
+msgstr "Force ToneBurst"
+
+msgid "Force de-interlace"
+msgstr "Force de-interlace"
+
+msgid "Format"
+msgstr "Format"
+
+msgid "Forward volume keys"
+msgstr "Forward volume keys"
+
+msgid "Frame size in full view"
+msgstr "Frame size in full view"
+
+msgid "Free To Air"
+msgstr "Free To Air"
+
+msgid "Free memory"
+msgstr "Free memory"
+
+msgid "Free memory:"
+msgstr "Free memory:"
+
+msgid "Free swap:"
+msgstr "Free swap:"
+
+msgid "Free:"
+msgstr "Free:"
+
+msgid "Free: "
+msgstr "Free: "
+
+msgid "French"
+msgstr "French"
+
+msgid "Frequency"
+msgstr "Frequency"
+
+msgid "Frequency bands"
+msgstr "Frequency bands"
+
+msgid "Frequency scan step size(khz)"
+msgstr "Frequency scan step size(khz)"
+
+msgid "Frequency steps"
+msgstr "Frequency steps"
+
+msgid "Frequency:"
+msgstr "Frequency:"
+
+msgid "Fri"
+msgstr "Fri"
+
+msgid "Friday"
+msgstr "Friday"
+
+msgid "From :"
+msgstr "From :"
+
+msgid "Front Display Panel"
+msgstr "Front Display Panel"
+
+#, python-format
+msgid "Frontprocessor version: %d"
+msgstr "Frontprocessor version: %d"
+
+msgid "Full screen"
+msgstr "Full screen"
+
+msgid "Full transparency"
+msgstr "Full transparency"
+
+msgid "Fulview resulution"
+msgstr "Fulview resulution"
+
+msgid "GB"
+msgstr "GB"
+
+#, python-format
+msgid "GStreamer:\t%s\n"
+msgstr "GStreamer:\t%s\n"
+
+msgid ""
+"GUI needs a restart to apply a new skin\n"
+"Do you want to restart the GUI now?"
+msgstr ""
+"GUI needs a restart to apply a new skin\n"
+"Do you want to restart the GUI now?"
+
+msgid "Gateway"
+msgstr "Gateway"
+
+msgid "General"
+msgstr "General"
+
+msgid "General AC3 delay"
+msgstr "General AC3 delay"
+
+msgid "General PCM delay"
+msgstr "General PCM delay"
+
+msgid "Genre"
+msgstr "Genre"
+
+msgid "German"
+msgstr "German"
+
+msgid "Getting Event Info failed!"
+msgstr "Getting Event Info failed!"
+
+msgid "Getting plugin information. Please wait..."
+msgstr "Getting plugin information. Please wait..."
+
+msgid "Go down the list"
+msgstr "Go down the list"
+
+msgid "Go to first movie or last item"
+msgstr "Go to first movie or last item"
+
+msgid "Go to first movie or top of list"
+msgstr "Go to first movie or top of list"
+
+msgid "Go to next bouquet"
+msgstr "Go to next bouquet"
+
+msgid "Go to next channel"
+msgstr "Go to next channel"
+
+msgid "Go to next event"
+msgstr "Go to next event"
+
+msgid "Go to previous bouquet"
+msgstr "Go to previous bouquet"
+
+msgid "Go to previous channel"
+msgstr "Go to previous channel"
+
+msgid "Go to previous event"
+msgstr "Go to previous event"
+
+msgid "Go to specific data/time"
+msgstr "Go to specific data/time"
+
+msgid "Go up the list"
+msgstr "Go up the list"
+
+msgid "Goto"
+msgstr "Goto"
+
+msgid "Goto 0"
+msgstr "Goto 0"
+
+msgid "Goto :"
+msgstr "Goto :"
+
+msgid "Goto X"
+msgstr "Goto X"
+
+msgid "Goto index position"
+msgstr "Goto index position"
+
+msgid "Goto position"
+msgstr "Goto position"
+
+msgid "GotoX calibration"
+msgstr "GotoX calibration"
+
+msgid "Graphical EPG"
+msgstr "Graphical EPG"
+
+msgid "Graphical Infobar EPG settings"
+msgstr "Graphical Infobar EPG settings"
+
+msgid "GraphicalEPG settings"
+msgstr "GraphicalEPG settings"
+
+msgid "Graphics"
+msgstr "Graphics"
+
+msgid "Greek"
+msgstr "Greek"
+
+msgid "Green"
+msgstr "Green"
+
+msgid "Green long"
+msgstr "Green long"
+
+msgid "Grey"
+msgstr "Grey"
+
+msgid "Grow drop"
+msgstr "Grow drop"
+
+msgid "Grow from left"
+msgstr "Grow from left"
+
+msgid "Guard interval"
+msgstr "Guard interval"
+
+msgid "H: = Hourly / D: = Daily / W: = Weekly / M: = Monthly"
+msgstr "H: = Hourly / D: = Daily / W: = Weekly / M: = Monthly"
+
+msgid "HD list"
+msgstr "HD list"
+
+msgid "HD1100/et7x00/et8500"
+msgstr "HD1100/et7x00/et8500"
+
+msgid "HD2400"
+msgstr "HD2400"
+
+msgid "HDMI"
+msgstr "HDMI"
+
+msgid "HDMI CEC"
+msgstr "HDMI CEC"
+
+msgid "HDMI CEC Setup"
+msgstr "HDMI CEC Setup"
+
+msgid "HDMI Colorspace"
+msgstr "HDMI Colorspace"
+
+msgid "HDMIin"
+msgstr "HDMIin"
+
+msgid "Handle standby from TV"
+msgstr "Handle standby from TV"
+
+msgid "Handle wakeup from TV"
+msgstr "Handle wakeup from TV"
+
+msgid "Hard disk setup"
+msgstr "Hard disk setup"
+
+msgid "Hard disk standby after"
+msgstr "Hard disk standby after"
+
+msgid "Harddisk setup"
+msgstr "Harddisk setup"
+
+msgid "Hebrew"
+msgstr "Hebrew"
+
+msgid "Height"
+msgstr "Height"
+
+msgid "Help"
+msgstr "Help"
+
+msgid "Help long"
+msgstr "Help long"
+
+msgid "Helps setting up your antenna"
+msgstr "Helps setting up your antenna"
+
+msgid "Hidden network"
+msgstr "Hidden network"
+
+msgid "Hide CI messages"
+msgstr "Hide CI messages"
+
+msgid "Hide any zap error messages."
+msgstr "Hide any zap error messages."
+
+msgid "Hide error messages from the Common Interface module."
+msgstr "Hide error messages from the Common Interface module."
+
+msgid "Hide known extensions"
+msgstr "Hide known extensions"
+
+msgid "Hide parental locked services"
+msgstr "Hide parental locked services"
+
+msgid "Hide player"
+msgstr "Hide player"
+
+msgid "Hide zap errors"
+msgstr "Hide zap errors"
+
+msgid "Hierarchy info"
+msgstr "Hierarchy info"
+
+msgid "Hierarchy information"
+msgstr "Hierarchy information"
+
+msgid "High bitrate support"
+msgstr "High bitrate support"
+
+msgid "History back"
+msgstr "History back"
+
+msgid "History buttons mode"
+msgstr "History buttons mode"
+
+msgid "History next"
+msgstr "History next"
+
+msgid "History zap..."
+msgstr "History zap..."
+
+msgid "Hold screen"
+msgstr "Hold screen"
+
+msgid "Hold till locked"
+msgstr "Hold till locked"
+
+msgid "Home"
+msgstr "Home"
+
+msgid "Hops:"
+msgstr "Hops:"
+
+msgid "Horizontal"
+msgstr "Horizontal"
+
+msgid "Horizontal turning speed"
+msgstr "Horizontal turning speed"
+
+msgid "Hostname:"
+msgstr "Hostname:"
+
+msgid "Hostname: "
+msgstr "Hostname: "
+
+msgid "Hour"
+msgstr "Hour"
+
+msgid "Hourly"
+msgstr "Hourly"
+
+msgid "Hours Mins"
+msgstr "Hours Mins"
+
+msgid "Hours Mins Secs"
+msgstr "Hours Mins Secs"
+
+msgid "How many minutes do you want add to the recording?"
+msgstr "How many minutes do you want add to the recording?"
+
+msgid "How many minutes do you want to record for?"
+msgstr "How many minutes do you want to record for?"
+
+msgid "Hue"
+msgstr "Hue"
+
+msgid "Hungarian"
+msgstr "Hungarian"
+
+msgid "IMDB search for current event"
+msgstr "IMDB search for current event"
+
+msgid "IMDb Search"
+msgstr "IMDb Search"
+
+msgid "IP address"
+msgstr "IP address"
+
+msgid "IP-Address"
+msgstr "IP-Address"
+
+msgid "IP:"
+msgstr "IP:"
+
+msgid "ISO file is too large for this filesystem!"
+msgstr "ISO file is too large for this filesystem!"
+
+msgid "ISO path"
+msgstr "ISO path"
+
+msgid "Icons"
+msgstr "Icons"
+
+msgid "Idle Time: "
+msgstr "Idle Time: "
+
+msgid "If enabled the output resolution of the box will try to match the resolution of the video content"
+msgstr "If enabled the output resolution of the box will try to match the resolution of the video content"
+
+msgid "If enabled the video will always be de-interlaced."
+msgstr "If enabled the video will always be de-interlaced."
+
+msgid "If set to 'yes' channels without EPG will not be shown."
+msgstr "If set to 'yes' channels without EPG will not be shown."
+
+msgid "If set to 'yes' it will show the 'PO' packages in browser."
+msgstr "If set to 'yes' it will show the 'PO' packages in browser."
+
+msgid "If set to 'yes' it will show the 'SRC' packages in browser."
+msgstr "If set to 'yes' it will show the 'SRC' packages in browser."
+
+msgid "If set to 'yes' shows a small TV-screen in the EPG."
+msgstr "If set to 'yes' shows a small TV-screen in the EPG."
+
+msgid "If set to 'yes' the EPG will always open at the first channel of bouquet. If set to 'no' the EPG will open on the current channel."
+msgstr "If set to 'yes' the EPG will always open at the first channel of bouquet. If set to 'no' the EPG will open on the current channel."
+
+msgid "If set to 'yes' the bouquets will be shown each time you open the EPG."
+msgstr "If set to 'yes' the bouquets will be shown each time you open the EPG."
+
+msgid "If set to 'yes' the channel list will be shown after switching between radio and TV modes."
+msgstr "If set to 'yes' the channel list will be shown after switching between radio and TV modes."
+
+msgid "If set to 'yes' the channel number will be displayed in the infobar."
+msgstr "If set to 'yes' the channel number will be displayed in the infobar."
+
+msgid "If set to 'yes' the infobar will be displayed when a new event starts."
+msgstr "If set to 'yes' the infobar will be displayed when a new event starts."
+
+msgid "If set to 'yes' the infobar will be displayed when changing channels."
+msgstr "If set to 'yes' the infobar will be displayed when changing channels."
+
+msgid "If set to 'yes' you can preview channels in the EPG list."
+msgstr "If set to 'yes' you can preview channels in the EPG list."
+
+msgid "If set to 'yes' you can preview channels in the channel list. Press 'OK' to preview the selected channel, press a 2nd 'OK' to exit and zap to that channel, pressing 'EXIT' to return to the channel you started at."
+msgstr "If set to 'yes' you can preview channels in the channel list. Press 'OK' to preview the selected channel, press a 2nd 'OK' to exit and zap to that channel, pressing 'EXIT' to return to the channel you started at."
+
+msgid "If set to 'yes', allows you to use the seekbar to jump to a point within the event."
+msgstr "If set to 'yes', allows you to use the seekbar to jump to a point within the event."
+
+msgid "If set to 'yes', the infobar will be displayed when Fast Forwarding or Rewinding during media playback."
+msgstr "If set to 'yes', the infobar will be displayed when Fast Forwarding or Rewinding during media playback."
+
+msgid "If the text is too long to be displayed on the front panel, it will be repeated (number of times):"
+msgstr "If the text is too long to be displayed on the front panel, it will be repeated (number of times):"
+
+msgid ""
+"If you can see this, something is wrong with\n"
+"your scart connection. Press OK to return."
+msgstr ""
+"If you can see this, something is wrong with\n"
+"your scart connection. Press OK to return."
+
+msgid ""
+"If your TV has a brightness or contrast enhancement, disable it. If there is something called \"dynamic\", set it to standard. Adjust the backlight level to a value suiting your taste. Turn down contrast on your TV as much as possible.\n"
+"Then turn the brightness setting as low as possible, but make sure that the two lowermost shades of gray stay distinguishable.\n"
+"Do not care about the bright shades now. They will be set up in the next step.\n"
+"If you are happy with the result, press OK."
+msgstr ""
+"If your TV has a brightness or contrast enhancement, disable it. If there is something called \"dynamic\", set it to standard. Adjust the backlight level to a value suiting your taste. Turn down contrast on your TV as much as possible.\n"
+"Then turn the brightness setting as low as possible, but make sure that the two lowermost shades of gray stay distinguishable.\n"
+"Do not care about the bright shades now. They will be set up in the next step.\n"
+"If you are happy with the result, press OK."
+
+msgid "Image Manager"
+msgstr "Image Manager"
+
+msgid "Immediate shutdown"
+msgstr "Immediate shutdown"
+
+msgid "In order to record a timer, the TV was switched to the recording service!\n"
+msgstr "In order to record a timer, the TV was switched to the recording service!\n"
+
+msgid "In progress"
+msgstr "In progress"
+
+msgid "Inadyn Setup"
+msgstr "Inadyn Setup"
+
+msgid "Inadyn setup"
+msgstr "Inadyn setup"
+
+msgid "Include AIT in http streams"
+msgstr "Include AIT in http streams"
+
+msgid "Include ECM in http streams"
+msgstr "Include ECM in http streams"
+
+msgid "Include EIT in http streams"
+msgstr "Include EIT in http streams"
+
+msgid "Incorrect service type for PiP!"
+msgstr "Incorrect service type for PiP!"
+
+msgid "Increase time scale"
+msgstr "Increase time scale"
+
+msgid "Increased voltage"
+msgstr "Increased voltage"
+
+msgid "Index allocated:"
+msgstr "Index allocated:"
+
+msgid "Info"
+msgstr "Info"
+
+msgid "Info (EPG)"
+msgstr "Info (EPG)"
+
+msgid "Info (EPG) Long"
+msgstr "Info (EPG) Long"
+
+msgid "Info button (long)"
+msgstr "Info button (long)"
+
+msgid "Info button (short)"
+msgstr "Info button (short)"
+
+msgid "Info icon width"
+msgstr "Info icon width"
+
+msgid "InfoBar EPG"
+msgstr "InfoBar EPG"
+
+msgid "InfoBar EPG mode"
+msgstr "InfoBar EPG mode"
+
+msgid "Infobar EPG"
+msgstr "Infobar EPG"
+
+msgid "Infobar fade-out speed"
+msgstr "Infobar fade-out speed"
+
+msgid "Infobar frontend data source"
+msgstr "Infobar frontend data source"
+
+msgid "InfobarEPG settings"
+msgstr "InfobarEPG settings"
+
+msgid "Information"
+msgstr "Information"
+
+msgid "Init"
+msgstr "Init"
+
+msgid "Initial fast forward speed"
+msgstr "Initial fast forward speed"
+
+msgid "Initial lock ratio"
+msgstr "Initial lock ratio"
+
+msgid "Initial rewind speed"
+msgstr "Initial rewind speed"
+
+msgid "Initial scroll delay"
+msgstr "Initial scroll delay"
+
+msgid "Initial signal quality"
+msgstr "Initial signal quality"
+
+msgid "Initial signal quality:"
+msgstr "Initial signal quality:"
+
+msgid "Initialization"
+msgstr "Initialisation"
+
+msgid "Initialize"
+msgstr "Initialise"
+
+msgid "Initializing storage device..."
+msgstr "Initializing storage device..."
+
+msgid "Inotify Monitoring"
+msgstr "Inotify Monitoring"
+
+msgid "Inotify monitoring"
+msgstr "Inotify monitoring"
+
+msgid "Input"
+msgstr "Input"
+
+msgid "Input device setup"
+msgstr "Input device setup"
+
+msgid "Input devices"
+msgstr "Input devices"
+
+msgid "Install"
+msgstr "Install"
+
+msgid "Install a new image with a USB stick"
+msgstr "Install a new image with a USB stick"
+
+msgid "Install a new image with your web browser"
+msgstr "Install a new image with your web browser"
+
+msgid "Install channel list"
+msgstr "Install channel list"
+
+msgid "Install extensions"
+msgstr "Install extensions"
+
+msgid "Install extensions."
+msgstr "Install extensions."
+
+msgid "Install lcd picons on"
+msgstr "Install lcd picons on"
+
+msgid "Install local extension"
+msgstr "Install local extension"
+
+msgid "Install or remove finished."
+msgstr "Install or remove finished."
+
+msgid "Install picons on"
+msgstr "Install picons on"
+
+msgid "Install plugins"
+msgstr "Install plugins"
+
+msgid "Installation finished."
+msgstr "Installation finished."
+
+#, python-format
+msgid "Installed:\t%s\n"
+msgstr "Installed:\t%s\n"
+
+msgid "Installing"
+msgstr "Installing"
+
+msgid "Installing Service"
+msgstr "Installing Service"
+
+msgid "Installing service"
+msgstr "Installing service"
+
+msgid "Instant record"
+msgstr "Instant record"
+
+msgid "Instant record location"
+msgstr "Instant record location"
+
+msgid "Instant recording location"
+msgstr "Instant recording location"
+
+msgid "Instant recording..."
+msgstr "Instant recording..."
+
+msgid "Instant recordings location"
+msgstr "Instant recordings location"
+
+msgid "Interface"
+msgstr "Interface"
+
+msgid "Interface: "
+msgstr "Interface: "
+
+msgid "Intermediate"
+msgstr "Intermediate"
+
+msgid "Internal"
+msgstr "Internal"
+
+msgid "Internal flash"
+msgstr "Internal flash"
+
+msgid "Internal hdd only"
+msgstr "Internal hdd only"
+
+msgid "Internet"
+msgstr "Internet"
+
+msgid "Interval between keys when repeating:"
+msgstr "Interval between keys when repeating:"
+
+#, python-format
+msgid "Invalid directory selected: %s"
+msgstr "Invalid directory selected: %s"
+
+msgid "Invalid location"
+msgstr "Invalid location"
+
+msgid "Invalid transponder data"
+msgstr "Invalid transponder data"
+
+msgid "Inversion"
+msgstr "Inversion"
+
+msgid "Invert"
+msgstr "Invert"
+
+msgid "Ipkg"
+msgstr "Ipkg"
+
+msgid "Is this setting ok?"
+msgstr "Is this setting ok?"
+
+msgid "Is this video mode ok?"
+msgstr "Is this video mode ok?"
+
+msgid "Italian"
+msgstr "Italian"
+
+msgid "JUMP 24 HOURS"
+msgstr "JUMP 24 HOURS"
+
+msgid "Job View"
+msgstr "Job View"
+
+msgid "Jump back 24 hours"
+msgstr "Jump back 24 hours"
+
+msgid "Jump first press in channel selection"
+msgstr "Jump first press in channel selection"
+
+msgid "Jump forward 24 hours"
+msgstr "Jump forward 24 hours"
+
+msgid "Jump to beginning of list"
+msgstr "Jump to beginning of list"
+
+msgid "Jump to current time"
+msgstr "Jump to current time"
+
+msgid "Jump to end of list"
+msgstr "Jump to end of list"
+
+msgid "Jump to prime time"
+msgstr "Jump to prime time"
+
+msgid "Jump to the next marked position"
+msgstr "Jump to the next marked position"
+
+msgid "Jump to the previous marked position"
+msgstr "Jump to the previous marked position"
+
+msgid "Just change channels"
+msgstr "Just change channels"
+
+#. TRANSLATORS: (aspect ratio policy: display as fullscreen, even if this breaks the aspect)
+#. TRANSLATORS: (aspect ratio policy: display as fullscreen, with stretching the left/right)
+#. "nonlinear": _("Nonlinear"),
+#. TRANSLATORS: (aspect ratio policy: display as fullscreen, even if this breaks the aspect)
+msgid "Just scale"
+msgstr "Just scale"
+
+msgid "Just zap"
+msgstr "Just zap"
+
+msgid "Keep service"
+msgstr "Keep service"
+
+msgid "Keeps the movie list open whilst playing audio files."
+msgstr "Keeps the movie list open whilst playing audio files."
+
+#, python-format
+msgid "Kernel:\t%s\n"
+msgstr "Kernel:\t%s\n"
+
+#, python-format
+msgid "Kernel: %s"
+msgstr "Kernel: %s"
+
+msgid "Keyboard"
+msgstr "Keyboard"
+
+msgid "Keyboard map"
+msgstr "Keyboard map"
+
+msgid "Keyboard setup"
+msgstr "Keyboard setup"
+
+msgid "LAN adapter"
+msgstr "LAN adapter"
+
+msgid "LAN connection"
+msgstr "LAN connection"
+
+msgid "LED Deep Standby"
+msgstr "LED Deep Standby"
+
+msgid "LED Display Panel"
+msgstr "LED Display Panel"
+
+msgid "LED Normal"
+msgstr "LED Normal"
+
+msgid "LED Standby"
+msgstr "LED Standby"
+
+msgid "LED brightness during deep standby."
+msgstr "LED brightness during deep standby."
+
+msgid "LED brightness during normal operations."
+msgstr "LED brightness during normal operations."
+
+msgid "LED brightness during standby."
+msgstr "LED brightness during standby."
+
+msgid "LNB"
+msgstr "LNB"
+
+msgid "Label"
+msgstr "Label"
+
+msgid "Language"
+msgstr "Language"
+
+msgid "Language selection"
+msgstr "Language selection"
+
+msgid "Large"
+msgstr "Large"
+
+msgid "Last Req."
+msgstr "Last Req."
+
+msgid "Last config"
+msgstr "Last config"
+
+msgid "Last speed"
+msgstr "Last speed"
+
+#, python-format
+msgid ""
+"Last update:\t%s\n"
+"\n"
+msgstr ""
+"Last update:\t%s\n"
+"\n"
+
+#, python-format
+msgid "Last update: %s"
+msgstr "Last update: %s"
+
+msgid "Last used share: "
+msgstr "Last used share: "
+
+msgctxt "third event: 'third' event label"
+msgid "Later"
+msgstr "Later"
+
+msgid "Latitude"
+msgstr "Latitude"
+
+msgid "Latvian"
+msgstr "Latvian"
+
+msgid "Leave DVD player?"
+msgstr "Leave DVD player?"
+
+msgid "Left"
+msgstr "Left"
+
+msgid "Left from servicename"
+msgstr "Left from servicename"
+
+msgid "Leisure hobbies"
+msgstr "Leisure hobbies"
+
+#. TRANSLATORS: (aspect ratio policy: black bars on top/bottom) in doubt, keep english term.
+msgid "Letterbox"
+msgstr "Letterbox"
+
+msgid "Letterbox zoom"
+msgstr "Letterbox zoom"
+
+msgid "Light Grey"
+msgstr "Light Grey"
+
+msgid "Limit character set for recording filenames"
+msgstr "Limit character set for recording filenames"
+
+msgid "Limit debug log size (MB)"
+msgstr "Limit debug log size (MB)"
+
+msgid "Limit east"
+msgstr "Limit east"
+
+msgid "Limit the characters that can be used in recording filenames to (7 bit) ascii. This ensures compatibility with operating systems or file systems with limited character sets."
+msgstr "Limit the characters that can be used in recording filenames to (7 bit) ascii. This ensures compatibility with operating systems or file systems with limited character sets."
+
+msgid "Limit west"
+msgstr "Limit west"
+
+msgid "Limits cancelled"
+msgstr "Limits cancelled"
+
+msgid "Limits enabled"
+msgstr "Limits enabled"
+
+msgid "Limits off"
+msgstr "Limits off"
+
+msgid "Limits on"
+msgstr "Limits on"
+
+msgid "Link Quality:"
+msgstr "Link Quality:"
+
+msgid "Link quality:"
+msgstr "Link quality:"
+
+msgid "Link:"
+msgstr "Link:"
+
+msgid "Linked titles with a DVD menu"
+msgstr "Linked titles with a DVD menu"
+
+msgid "List EPG functions..."
+msgstr "List EPG functions..."
+
+msgid "List available networks"
+msgstr "List available networks"
+
+msgid "List of storage devices"
+msgstr "List of storage devices"
+
+#, python-format
+msgid "List version %d, found %d channel"
+msgid_plural "List version %d, found %d channels"
+msgstr[0] "List version %d, found %d channel"
+msgstr[1] "List version %d, found %d channels"
+
+msgid "List/Fav/PVR"
+msgstr "List/Fav/PVR"
+
+msgid "Listen to the radio..."
+msgstr "Listen to the radio..."
+
+msgid "Lists reloaded!"
+msgstr "Lists reloaded!"
+
+msgid "Lithuanian"
+msgstr "Lithuanian"
+
+msgid "Load"
+msgstr "Load"
+
+msgid "Load EPG"
+msgstr "Load EPG"
+
+msgid "Load playlist"
+msgstr "Load playlist"
+
+msgid "Load unlinked userbouquets"
+msgstr "Load unlinked userbouquets"
+
+msgid "Load-Save-Delete"
+msgstr "Load-Save-Delete"
+
+msgid "Local box"
+msgstr "Local box"
+
+msgid "Local network"
+msgstr "Local network"
+
+msgid "Location"
+msgstr "Location"
+
+msgid "Lock ratio"
+msgstr "Lock ratio"
+
+msgid "Lock:"
+msgstr "Lock:"
+
+msgid "Log"
+msgstr "Log"
+
+msgid "Log Manager"
+msgstr "Log Manager"
+
+msgid "Log results to harddisk"
+msgstr "Log results to harddisk"
+
+msgid "LogManager"
+msgstr "LogManager"
+
+msgid "Logs"
+msgstr "Logs"
+
+msgid "Logs folder location"
+msgstr "Logs folder location"
+
+msgid "Logs manager"
+msgstr "Logs manager"
+
+msgid "Logs older than the specified number of days will be deleted."
+msgstr "Logs older than the specified number of days will be deleted."
+
+msgid "Logs settings"
+msgstr "Logs settings"
+
+msgid "Long << / >>"
+msgstr "Long << / >>"
+
+msgid "Long Left/Right"
+msgstr "Long Left/Right"
+
+msgid "Long filenames"
+msgstr "Long filenames"
+
+msgid "Long key press"
+msgstr "Long key press"
+
+msgid "Longitude"
+msgstr "Longitude"
+
+msgid "Loop through to"
+msgstr "Loop through to"
+
+msgid "Lower Framerate save CPU Time"
+msgstr "Lower Framerate save CPU Time"
+
+msgid "Luxembourgish"
+msgstr "Luxembourgish"
+
+msgid "MAC address"
+msgstr "MAC address"
+
+msgid "MAC address settings"
+msgstr "MAC address settings"
+
+msgid "MAC:"
+msgstr "MAC:"
+
+msgid "MB"
+msgstr "MB"
+
+msgid "Main menu"
+msgstr "Main menu"
+
+msgid "Mainmenu"
+msgstr "Mainmenu"
+
+msgid "Maintain old EPG data for"
+msgstr "Maintain old EPG data for"
+
+msgid "Make this mark an 'in' point"
+msgstr "Make this mark an 'in' point"
+
+msgid "Make this mark an 'out' point"
+msgstr "Make this mark an 'out' point"
+
+msgid "Make this mark just a mark"
+msgstr "Make this mark just a mark"
+
+msgid "Manage extensions"
+msgstr "Manage extensions"
+
+#, python-format
+msgid "Manage your %s %s's software"
+msgstr "Manage your %s %s's software"
+
+msgid "Manual"
+msgstr "Manual"
+
+msgid "Manual Scan"
+msgstr "Manual Scan"
+
+msgid "Manual configuration"
+msgstr "Manual configuration"
+
+msgid "Manual scan"
+msgstr "Manual scan"
+
+msgid "Manual transponder"
+msgstr "Manual transponder"
+
+msgid "Manufacturer"
+msgstr "Manufacturer"
+
+msgid "Margin after recording (minutes)"
+msgstr "Margin after recording (minutes)"
+
+msgid "Margin before recording (minutes)"
+msgstr "Margin before recording (minutes)"
+
+msgid "Mark service as a dedicated 3D service"
+msgstr "Mark service as a dedicated 3D service"
+
+msgid "Mark/Portal/Playlist"
+msgstr "Mark/Portal/Playlist"
+
+msgid "Max memory positions"
+msgstr "Max memory positions"
+
+msgid "Max. bitrate: "
+msgstr "Max. bitrate: "
+
+msgid "Maxdown +"
+msgstr "Maxdown +"
+
+msgid "Maxdown -"
+msgstr "Maxdown -"
+
+msgid "Maxdown: "
+msgstr "Maxdown: "
+
+msgid "Maximum number of days"
+msgstr "Maximum number of days"
+
+msgid "Maximum total space used (MB)"
+msgstr "Maximum total space used (MB)"
+
+msgid "Maybe the reason that recording is currently running. Please stop the recording before trying to configure the positioner."
+msgstr "Maybe the reason that recording is currently running. Please stop the recording before trying to configure the positioner."
+
+msgid "Media playback Remaining/Elapsed as"
+msgstr "Media playback Remaining/Elapsed as"
+
+msgid "Media player"
+msgstr "Media player"
+
+msgid "Media scanner"
+msgstr "Media scanner"
+
+msgid "Medium is not a writeable DVD!"
+msgstr "Medium is not a writeable DVD!"
+
+msgid "Medium is not empty!"
+msgstr "Medium is not empty!"
+
+msgid "Memory"
+msgstr "Memory"
+
+msgid "Memory index"
+msgstr "Memory index"
+
+msgid "Menu"
+msgstr "Menu"
+
+msgid "Menu config"
+msgstr "Menu config"
+
+msgid "Merging Timeshift files"
+msgstr "Merging Timeshift files"
+
+msgid "MiniDLNA Setup"
+msgstr "MiniDLNA Setup"
+
+msgid "MiniDLNA setup"
+msgstr "MiniDLNA setup"
+
+msgid "MiniTV"
+msgstr "MiniTV"
+
+msgid "MiniTV with OSD"
+msgstr "MiniTV with OSD"
+
+#, python-format
+msgid "Minimum age %d years"
+msgstr "Minimum age %d years"
+
+msgid "Minimum send interval"
+msgstr "Minimum send interval"
+
+msgid "Mins"
+msgstr "Mins"
+
+msgid "Mins Secs"
+msgstr "Mins Secs"
+
+#, python-format
+msgid ""
+"Misconfigured unicable connection from tuner %s to tuner %s!\n"
+"Tuner %s option \"connected to\" are disabled now"
+msgstr ""
+"Misconfigured unicable connection from tuner %s to tuner %s!\n"
+"Tuner %s option \"connected to\" are disabled now"
+
+msgid "Missing "
+msgstr "Missing "
+
+msgctxt "Satellite configuration mode"
+msgid "Mode"
+msgstr "Mode"
+
+msgctxt "Video output mode"
+msgid "Mode"
+msgstr "Mode"
+
+#, python-format
+msgid "Model:\t%s %s\n"
+msgstr "Model:\t%s %s\n"
+
+msgid "Model: "
+msgstr "Model: "
+
+#, python-format
+msgid "Model: %s %s\n"
+msgstr "Model: %s %s\n"
+
+msgid "Modulation"
+msgstr "Modulation"
+
+msgid "Modulator"
+msgstr "Modulator"
+
+msgid "Mon"
+msgstr "Mon"
+
+msgid "Mon-Fri"
+msgstr "Mon-Fri"
+
+msgid "Monday"
+msgstr "Monday"
+
+msgid "Monthly"
+msgstr "Monthly"
+
+msgid "Mosquito noise reduction"
+msgstr "Mosquito noise reduction"
+
+msgid "Motor command retries"
+msgstr "Motor command retries"
+
+msgid "Motor running timeout"
+msgstr "Motor running timeout"
+
+msgid "Mount"
+msgstr "Mount"
+
+msgid "Mounts Setup"
+msgstr "Mounts Setup"
+
+msgid "Mounts setup"
+msgstr "Mounts setup"
+
+msgid "Move"
+msgstr "Move"
+
+msgid "Move Left/Right"
+msgstr "Move Left/Right"
+
+msgid "Move PIP"
+msgstr "Move PIP"
+
+msgid "Move PiP to main picture"
+msgstr "Move PiP to main picture"
+
+msgid "Move Picture in Picture"
+msgstr "Move Picture in Picture"
+
+msgid "Move Up/Down"
+msgstr "Move Up/Down"
+
+msgid "Move down a page"
+msgstr "Move down a page"
+
+msgid "Move down to last entry"
+msgstr "Move down to last entry"
+
+msgid "Move down to next entry"
+msgstr "Move down to next entry"
+
+msgid "Move east"
+msgstr "Move east"
+
+msgid "Move to home of list"
+msgstr "Move to home of list"
+
+msgid "Move to position X"
+msgstr "Move to position X"
+
+msgid "Move up a page"
+msgstr "Move up a page"
+
+msgid "Move up to first entry"
+msgstr "Move up to first entry"
+
+msgid "Move up to previous entry"
+msgstr "Move up to previous entry"
+
+msgid "Move west"
+msgstr "Move west"
+
+msgid "Moved to position 0"
+msgstr "Moved to position 0"
+
+msgid "Moved to position at index"
+msgstr "Moved to position at index"
+
+msgid "Movement"
+msgstr "Movement"
+
+msgid "Movie List"
+msgstr "Movie List"
+
+msgid "Movie List Setup"
+msgstr "Movie List Setup"
+
+msgid "Movie location"
+msgstr "Movie location"
+
+msgid "Movie selection"
+msgstr "Movie selection"
+
+msgid "Movie/Drama"
+msgstr "Movie/Drama"
+
+msgid "Moving"
+msgstr "Moving"
+
+msgid "Moving east ..."
+msgstr "Moving east ..."
+
+msgid "Moving files"
+msgstr "Moving files"
+
+msgid "Moving to position"
+msgstr "Moving to position"
+
+msgid "Moving west ..."
+msgstr "Moving west ..."
+
+msgid "Multi EPG"
+msgstr "Multi EPG"
+
+msgid "MultiEPG settings"
+msgstr "MultiEPG settings"
+
+msgid "Multimedia"
+msgstr "Multimedia"
+
+msgid "Multiple service support"
+msgstr "Multiple service support"
+
+msgid "Multiplex"
+msgstr "Multiplex"
+
+msgid "Multisat"
+msgstr "Multisat"
+
+msgid "Multisat all select"
+msgstr "Multisat all select"
+
+msgid "Music/Ballet/Dance"
+msgstr "Music/Ballet/Dance"
+
+msgid "N"
+msgstr "N"
+
+msgid "N/A"
+msgstr "N/A"
+
+msgid "NFS Setup"
+msgstr "NFS Setup"
+
+msgid "NFS setup"
+msgstr "NFS setup"
+
+msgid "NIM"
+msgstr "NIM"
+
+msgid "NO"
+msgstr "NO"
+
+msgid "NTP"
+msgstr "NTP"
+
+msgid "NTP server"
+msgstr "NTP server"
+
+msgid "NTSC"
+msgstr "NTSC"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "Name:"
+msgstr "Name:"
+
+msgid "Nameserver"
+msgstr "Nameserver"
+
+#, python-format
+msgid "Nameserver %d"
+msgstr "Nameserver %d"
+
+msgid "Nameserver settings"
+msgstr "Nameserver settings"
+
+msgid "Namespace"
+msgstr "Namespace"
+
+msgid "Netmask"
+msgstr "Netmask"
+
+msgid "Netmask:"
+msgstr "Netmask:"
+
+msgid "Network"
+msgstr "Network"
+
+msgid "Network ID"
+msgstr "Network ID"
+
+msgid "Network MAC settings"
+msgstr "Network MAC settings"
+
+msgid "Network Setup"
+msgstr "Network Setup"
+
+msgid "Network Test"
+msgstr "Network Test"
+
+msgid "Network menu"
+msgstr "Network menu"
+
+msgid "Network mounts"
+msgstr "Network mounts"
+
+msgid "Network name (SSID)"
+msgstr "Network name (SSID)"
+
+msgid "Network scan"
+msgstr "Network scan"
+
+msgid "Network servers:"
+msgstr "Network servers:"
+
+msgid "Network setup"
+msgstr "Network setup"
+
+msgid "Network test"
+msgstr "Network test"
+
+msgid "Network test: "
+msgstr "Network test: "
+
+msgid "Network wizard"
+msgstr "Network wizard"
+
+msgid "Network:"
+msgstr "Network:"
+
+msgid "New"
+msgstr "New"
+
+msgid "New profile: "
+msgstr "New profile: "
+
+msgid "New timers location"
+msgstr "New timers location"
+
+msgid "New version:"
+msgstr "New version:"
+
+msgid "News Current Affairs"
+msgstr "News Current Affairs"
+
+msgid "Next"
+msgstr "Next"
+
+msgctxt "now/next: 'next' event label"
+msgid "Next"
+msgstr "Next"
+
+msgid "No"
+msgstr "No"
+
+msgid "No (supported) DVDROM found!"
+msgstr "No (supported) DVDROM found!"
+
+msgid "No Connection"
+msgstr "No Connection"
+
+msgid "No HDD found or HDD not initialized!"
+msgstr "No HDD found or HDD not initialised!"
+
+msgid "No Timeshift found to save as recording!"
+msgstr "No Timeshift found to save as recording!"
+
+msgid "No active channel found."
+msgstr "No active channel found."
+
+msgid "No age block"
+msgstr "No age block"
+
+msgid "No backup needed"
+msgstr "No backup needed"
+
+msgid "No cable tuner found!"
+msgstr "No cable tuner found!"
+
+msgid "No card inserted!"
+msgstr "No card inserted!"
+
+msgid "No connection"
+msgstr "No connection"
+
+msgid ""
+"No data on transponder!\n"
+"(Timeout reading PAT)"
+msgstr ""
+"No data on transponder!\n"
+"(Timeout reading PAT)"
+
+msgid "No delay"
+msgstr "No delay"
+
+msgid "No description available."
+msgstr "No description available."
+
+msgid "No displayable files on this medium found!"
+msgstr "No displayable files on this medium found!"
+
+msgid "No event info found, recording indefinitely."
+msgstr "No event info found, recording indefinitely."
+
+msgid "No fast winding possible yet.. but you can use the number buttons to skip forward/backward!"
+msgstr "No fast winding possible yet.. but you can use the number buttons to skip forward/backward!"
+
+msgid "No free index available"
+msgstr "No free index available"
+
+msgid "No free tuner available!"
+msgstr "No free tuner available!"
+
+msgid "No free tuner!"
+msgstr "No free tuner!"
+
+msgid "No httpport defined in oscam.conf. This value is required!"
+msgstr "No httpport defined in oscam.conf. This value is required!"
+
+msgid "No httppwd defined in oscam.conf"
+msgstr "No httppwd defined in oscam.conf"
+
+msgid "No httpuser defined in oscam.conf"
+msgstr "No httpuser defined in oscam.conf"
+
+msgid "No network connection available."
+msgstr "No network connection available."
+
+msgid "No networks found"
+msgstr "No networks found"
+
+msgid "No new plugins found"
+msgstr "No new plugins found"
+
+msgid "No of items switch (increase or reduced)"
+msgstr "No of items switch (increase or reduced)"
+
+msgid "No positioner capable frontend found."
+msgstr "No positioner capable frontend found."
+
+msgid "No priority"
+msgstr "No priority"
+
+msgid "No satellite, terrestrial or cable tuner is configured. Please check your tuner setup."
+msgstr "No satellite, terrestrial or cable tuner is configured. Please check your tuner setup."
+
+msgid "No service"
+msgstr "No service"
+
+msgid "No services/providers selected"
+msgstr "No services/providers selected"
+
+msgid "No standby"
+msgstr "No standby"
+
+msgid "No stream clients"
+msgstr "No stream clients"
+
+msgid "No suitable sat tuner found!"
+msgstr "No suitable sat tuner found!"
+
+msgid "No tags are set on these movies."
+msgstr "No tags are set on these movies."
+
+msgid "No timeout"
+msgstr "No timeout"
+
+msgid "No to all"
+msgstr "No to all"
+
+msgid "No transparency"
+msgstr "No transparency"
+
+msgid "No tuner is configured for use with a diseqc positioner!"
+msgstr "No tuner is configured for use with a diseqc positioner!"
+
+msgid ""
+"No tuner is enabled!\n"
+"Please setup your tuner settings before you start a service scan."
+msgstr ""
+"No tuner is enabled!\n"
+"Please setup your tuner settings before you start a service scan."
+
+msgid "No wireless networks found! Searching..."
+msgstr "No wireless networks found! Searching..."
+
+msgid ""
+"No working local network adapter found.\n"
+"Please verify that you have attached a network cable and your network is configured correctly."
+msgstr ""
+"No working local network adapter found.\n"
+"Please verify that you have attached a network cable and your network is configured correctly."
+
+msgid ""
+"No working wireless network adapter found.\n"
+"Please verify that you have attached a compatible WLAN device and your network is configured correctly."
+msgstr ""
+"No working wireless network adapter found.\n"
+"Please verify that you have attached a compatible WLAN device and your network is configured correctly."
+
+msgid ""
+"No working wireless network interface found.\n"
+" Please verify that you have attached a compatible WLAN device or enable your local network interface."
+msgstr ""
+"No working wireless network interface found.\n"
+" Please verify that you have attached a compatible WLAN device or enable your local network interface."
+
+msgid "No, but restart from the beginning"
+msgstr "No, but restart from the beginning"
+
+msgid "No, do nothing."
+msgstr "No, do nothing."
+
+msgid "No, just start my %s %s"
+msgstr "No, just start my %s %s"
+
+msgid "No, never"
+msgstr "No, never"
+
+msgid "No, scan later manually"
+msgstr "No, scan later manually"
+
+msgid "NodeID"
+msgstr "NodeID"
+
+msgid "NodeID: "
+msgstr "NodeID: "
+
+msgid "None"
+msgstr "None"
+
+msgid "North"
+msgstr "North"
+
+msgid "Norwegian"
+msgstr "Norwegian"
+
+msgid "Not Defined"
+msgstr "Not Defined"
+
+msgid "Not Flashing"
+msgstr "Not Flashing"
+
+msgid "Not Shown"
+msgstr "Not Shown"
+
+msgid "Not associated"
+msgstr "Not associated"
+
+msgid "Not configured"
+msgstr "Not configured"
+
+#, python-format
+msgid "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
+msgstr "Not enough disk space. Please free up some disk space and try again. (%d MB required, %d MB available)"
+
+#, python-format
+msgid ""
+"Not enough free Diskspace!\n"
+"\n"
+"Filesize: %sMB\n"
+"Free Space: %sMB\n"
+"Path: %s"
+msgstr ""
+"Not enough free Diskspace!\n"
+"\n"
+"Filesize: %sMB\n"
+"Free Space: %sMB\n"
+"Path: %s"
+
+msgid "Not mounted"
+msgstr "Not mounted"
+
+msgid "Not-Associated"
+msgstr "Not-Associated"
+
+msgid "Nothing"
+msgstr "Nothing"
+
+msgid "Nothing connected"
+msgstr "Nothing connected"
+
+msgid ""
+"Nothing to scan!\n"
+"Please setup your tuner settings before starting a service scan."
+msgstr ""
+"Nothing to scan!\n"
+"Please setup your tuner settings before starting a service scan."
+
+msgid ""
+"Nothing to scan!\n"
+"Please setup your tuner settings before you start a service scan."
+msgstr ""
+"Nothing to scan!\n"
+"Please setup your tuner settings before you start a service scan."
+
+msgid "Nothing to upgrade"
+msgstr "Nothing to upgrade"
+
+msgid "Nothing, just leave this menu"
+msgstr "Nothing, just leave this menu"
+
+msgctxt "now/next: 'now' event label"
+msgid "Now"
+msgstr "Now"
+
+msgid "Now, use the contrast setting to turn up the brightness of the background as much as possible, but make sure that you can still see the difference between the two brightest levels of shades.If you have done that, press OK."
+msgstr "Now, use the contrast setting to turn up the brightness of the background as much as possible, but make sure that you can still see the difference between the two brightest levels of shades.If you have done that, press OK."
+
+msgid "Number"
+msgstr "Number"
+
+msgid "Number of rows"
+msgstr "Number of rows"
+
+msgid "Number of rows to display"
+msgstr "Number of rows to display"
+
+msgid "OE Changes"
+msgstr "OE Changes"
+
+msgid "OE-A Changes"
+msgstr "OE-A Changes"
+
+msgid "OK"
+msgstr "OK"
+
+msgid "OK button (long)"
+msgstr "OK button (long)"
+
+msgid "OK button (short)"
+msgstr "OK button (short)"
+
+msgid "OK, guide me through the upgrade process"
+msgstr "OK, guide me through the upgrade process"
+
+msgid "ONID"
+msgstr "ONID"
+
+msgid "OSD"
+msgstr "OSD"
+
+msgid "OSD 3D Setup"
+msgstr "OSD 3D Setup"
+
+msgid "OSD name request"
+msgstr "OSD name request"
+
+msgid "OSD settings"
+msgstr "OSD settings"
+
+msgid "OScam Info"
+msgstr "OScam Info"
+
+msgid "OScam info"
+msgstr "OScam info"
+
+msgid "Off"
+msgstr "Off"
+
+msgid "Offline decode delay (ms)"
+msgstr "Offline decode delay (ms)"
+
+msgid "On"
+msgstr "On"
+
+msgid "On end of movie"
+msgstr "On end of movie"
+
+msgid "On end of movie (as menu)"
+msgstr "On end of movie (as menu)"
+
+msgid "On reaching the end of a file during playback, you can choose the box's behavior."
+msgstr "On reaching the end of a file during playback, you can choose the box's behavior."
+
+msgid "On your remote, click on the button you want to change"
+msgstr "On your remote, click on the button you want to change"
+
+msgid "Once per day"
+msgstr "Once per day"
+
+msgid "One"
+msgstr "One"
+
+msgid "One line"
+msgstr "One line"
+
+msgid "OnlineVersionCheck"
+msgstr "OnlineVersionCheck"
+
+msgid "Only active when in standby"
+msgstr "Only active when in standby"
+
+msgid "Only extensions."
+msgstr "Only extensions."
+
+msgid "Only free scan"
+msgstr "Only free scan"
+
+msgid "Only on startup"
+msgstr "Only on startup"
+
+msgid "Open bouquet list"
+msgstr "Open bouquet list"
+
+msgid "Open nameserver configuration"
+msgstr "Open nameserver configuration"
+
+msgid "Open service list and select the next channel"
+msgstr "Open service list and select the next channel"
+
+msgid "Open service list and select the next channel for PiP"
+msgstr "Open service list and select the next channel for PiP"
+
+msgid "Open service list and select the previous channel"
+msgstr "Open service list and select the previous channel"
+
+msgid "Open service list and select the previous channel for PiP"
+msgstr "Open service list and select the previous channel for PiP"
+
+msgid "Open setup tuner "
+msgstr "Open setup tuner "
+
+msgid "Open the favourites list"
+msgstr "Open the favourites list"
+
+msgid "Open the movie list"
+msgstr "Open the movie list"
+
+msgid "Open the satellites list"
+msgstr "Open the satellites list"
+
+msgid "Open the service list"
+msgstr "Open the service list"
+
+msgid "OpenVPN setup"
+msgstr "OpenVPN setup"
+
+msgid "OpenVpn Setup"
+msgstr "OpenVpn Setup"
+
+msgid "Orbital position"
+msgstr "Orbital position"
+
+msgid "Original"
+msgstr "Original"
+
+msgid "Oscam Info - Configuration"
+msgstr "Oscam Info - Configuration"
+
+msgid "Oscam Info - Main Menu"
+msgstr "Oscam Info - Main Menu"
+
+msgid "Other"
+msgstr "Other"
+
+msgid "Output"
+msgstr "Output"
+
+msgid "Overwrite configuration files during software upgrade?"
+msgstr "Overwrite configuration files during software upgrade?"
+
+msgid "Overwrite configuration files?"
+msgstr "Overwrite configuration files?"
+
+msgid "PAGE UP/DOWN"
+msgstr "PAGE UP/DOWN"
+
+msgid "PAL"
+msgstr "PAL"
+
+msgid "PCM Multichannel"
+msgstr "PCM Multichannel"
+
+msgid "PCR PID"
+msgstr "PCR PID"
+
+msgid "PDC"
+msgstr "PDC"
+
+msgid "PIDs"
+msgstr "PIDs"
+
+msgid "PIP"
+msgstr "PIP"
+
+msgid "PIP with OSD"
+msgstr "PIP with OSD"
+
+msgid "PLP ID"
+msgstr "PLP ID"
+
+msgid "PMT PID"
+msgstr "PMT PID"
+
+msgid "PRIMETIME"
+msgstr "PRIMETIME"
+
+msgid "Package list update"
+msgstr "Package list update"
+
+msgid "Packages"
+msgstr "Packages"
+
+msgid "Packet management"
+msgstr "Packet management"
+
+msgid "Packet manager"
+msgstr "Packet manager"
+
+msgid "Page down"
+msgstr "Page down"
+
+msgid "Page right"
+msgstr "Page right"
+
+msgid "Page up"
+msgstr "Page up"
+
+#. TRANSLATORS: (aspect ratio policy: cropped content on left/right) in doubt, keep english term
+msgid "Pan&scan"
+msgstr "Pan&scan"
+
+msgid "Panic to"
+msgstr "Panic to"
+
+msgid "Parent directory"
+msgstr "Parent directory"
+
+msgid "Parental control"
+msgstr "Parental control"
+
+msgid "Password"
+msgstr "Password"
+
+msgid "Password (httpwd)"
+msgstr "Password (httpwd)"
+
+msgid "Password:"
+msgstr "Password:"
+
+msgid "Pause"
+msgstr "Pause"
+
+msgid "Pause movie at end"
+msgstr "Pause movie at end"
+
+msgid "Pause playback"
+msgstr "Pause playback"
+
+msgid "Pause/Continue playback"
+msgstr "Pause/Continue playback"
+
+msgid "Peak load (max queued requests per workerthread)"
+msgstr "Peak load (max queued requests per workerthread)"
+
+msgid "Percentage"
+msgstr "Percentage"
+
+msgid "Percentage left"
+msgstr "Percentage left"
+
+msgid "Percentage right"
+msgstr "Percentage right"
+
+msgid "Perform a complete image backup before updating."
+msgstr "Perform a complete image backup before updating."
+
+msgid "Perform a full image backup"
+msgstr "Perform a full image backup"
+
+msgid "Perform a settings backup before updating."
+msgstr "Perform a settings backup before updating."
+
+msgid "Perform a settings backup,"
+msgstr "Perform a settings backup,"
+
+msgid "Perform a settings backup, making a backup before updating is strongly advised."
+msgstr "Perform a settings backup, making a backup before updating is strongly advised."
+
+msgid "Perform an online update check in the background"
+msgstr "Perform an online update check in the background"
+
+msgid "Permanently delete all recordings in the trash can?"
+msgstr "Permanently delete all recordings in the trash can?"
+
+msgid "Permanently remove all deleted items"
+msgstr "Permanently remove all deleted items"
+
+msgid "Persian"
+msgstr "Persian"
+
+msgid "PiP"
+msgstr "PiP"
+
+msgid "Picon"
+msgstr "Picon"
+
+msgid "Picon and Service Name"
+msgstr "Picon and Service Name"
+
+msgid "Picon width"
+msgstr "Picon width"
+
+msgid "Picture in graphics"
+msgstr "Picture in graphics"
+
+msgid "Picture player"
+msgstr "Picture player"
+
+#. TRANSLATORS: (aspect ratio policy: black bars on left/right) in doubt, keep english term.
+msgid "Pillarbox"
+msgstr "Pillarbox"
+
+msgid "Pilot"
+msgstr "Pilot"
+
+msgid "Play"
+msgstr "Play"
+
+msgid "Play Audio-CD..."
+msgstr "Play Audio-CD..."
+
+msgid "Play DVD"
+msgstr "Play DVD"
+
+msgid "Play Music..."
+msgstr "Play Music..."
+
+msgid "Play as picture in picture"
+msgstr "Play as picture in picture"
+
+msgid "Play audio in background"
+msgstr "Play audio in background"
+
+msgid "Play audio-CD..."
+msgstr "Play audio-CD..."
+
+msgid "Play back media files"
+msgstr "Play back media files"
+
+msgid "Play entry"
+msgstr "Play entry"
+
+msgid "Play from next mark or playlist entry"
+msgstr "Play from next mark or playlist entry"
+
+msgid "Play from previous mark or playlist entry"
+msgstr "Play from previous mark or playlist entry"
+
+msgid "Play in main window"
+msgstr "Play in main window"
+
+msgid "Play music..."
+msgstr "Play music..."
+
+msgid "Play next"
+msgstr "Play next"
+
+msgid "Play next (return to movie list)"
+msgstr "Play next (return to movie list)"
+
+msgid "Play next (return to previous service)"
+msgstr "Play next (return to previous service)"
+
+msgid "Play previous"
+msgstr "Play previous"
+
+msgid "Play recorded movies..."
+msgstr "Play recorded movies..."
+
+msgid ""
+"Playback information missing\n"
+"Playback aborted to avoid crash\n"
+"Please retry"
+msgstr ""
+"Playback information missing\n"
+"Playback aborted to avoid crash\n"
+"Please retry"
+
+msgid "Playlist"
+msgstr "Playlist"
+
+msgid "Playpause"
+msgstr "Playpause"
+
+msgid "Please add titles to the compilation."
+msgstr "Please add titles to the compilation."
+
+msgid "Please change the recording end time"
+msgstr "Please change the recording end time"
+
+msgid "Please choose CCcam reader"
+msgstr "Please choose CCcam reader"
+
+msgid "Please choose an extension..."
+msgstr "Please choose an extension..."
+
+msgid "Please choose reader"
+msgstr "Please choose reader"
+
+msgid ""
+"Please configure or verify your Nameservers by filling out the required values.\n"
+"When you are ready press OK to continue."
+msgstr ""
+"Please configure or verify your Nameservers by filling out the required values.\n"
+"When you are ready press OK to continue."
+
+msgid ""
+"Please configure your internet connection by filling out the required values.\n"
+"When you are ready press OK to continue."
+msgstr ""
+"Please configure your internet connection by filling out the required values.\n"
+"When you are ready press OK to continue."
+
+msgid "Please connect your receiver to the internet"
+msgstr "Please connect your receiver to the internet"
+
+msgid "Please do not change any values unless you know what you are doing!"
+msgstr "Please do not change any values unless you know what you are doing!"
+
+msgid "Please enter a name for the new bouquet"
+msgstr "Please enter a name for the new bouquet"
+
+msgid "Please enter a name for the new marker"
+msgstr "Please enter a name for the new marker"
+
+msgid "Please enter a new filename"
+msgstr "Please enter a new filename"
+
+msgid "Please enter a new name:"
+msgstr "Please enter a new name:"
+
+msgid "Please enter filename (empty = use current date)"
+msgstr "Please enter filename (empty = use current date)"
+
+msgid "Please enter new description:"
+msgstr "Please enter new description:"
+
+msgid "Please enter new name:"
+msgstr "Please enter new name:"
+
+msgid "Please enter the correct pin code"
+msgstr "Please enter the correct pin code"
+
+msgid "Please enter the name of the new directory"
+msgstr "Please enter the name of the new directory"
+
+msgid "Please enter the new PIN code"
+msgstr "Please enter the new PIN code"
+
+msgid "Please enter the old PIN code"
+msgstr "Please enter the old PIN code"
+
+msgid "Please follow the instructions on the TV"
+msgstr "Please follow the instructions on the TV"
+
+msgid "Please note that the previously selected media could not be accessed and therefore the default directory is being used instead."
+msgstr "Please note that the previously selected media could not be accessed and therefore the default directory is being used instead."
+
+msgid "Please open Picture in Picture first"
+msgstr "Please open Picture in Picture first"
+
+msgid "Please press OK to continue."
+msgstr "Please press OK to continue."
+
+msgid "Please re-enter the new PIN code"
+msgstr "Please re-enter the new PIN code"
+
+msgid "Please select a default EPG type..."
+msgstr "Please select a default EPG type..."
+
+msgid "Please select a playlist to delete..."
+msgstr "Please select a playlist to delete..."
+
+msgid "Please select a playlist..."
+msgstr "Please select a playlist..."
+
+msgid "Please select a sub service..."
+msgstr "Please select a sub service..."
+
+msgid "Please select a subservice to record..."
+msgstr "Please select a subservice to record..."
+
+msgid "Please select a subservice..."
+msgstr "Please select a subservice..."
+
+msgid "Please select medium to be scanned"
+msgstr "Please select medium to be scanned"
+
+msgid "Please select medium to use as backup location"
+msgstr "Please select medium to use as backup location"
+
+msgid "Please select the movie path..."
+msgstr "Please select the movie path..."
+
+msgid ""
+"Please select the network interface that you want to use for your internet connection.\n"
+"\n"
+"Please press OK to continue."
+msgstr ""
+"Please select the network interface that you want to use for your internet connection.\n"
+"\n"
+"Please press OK to continue."
+
+msgid "Please select the tag to filter..."
+msgstr "Please select the tag to filter..."
+
+msgid ""
+"Please select the wireless network that you want to connect to.\n"
+"\n"
+"Please press OK to continue."
+msgstr ""
+"Please select the wireless network that you want to connect to.\n"
+"\n"
+"Please press OK to continue."
+
+msgid "Please set up tuner A"
+msgstr "Please set up tuner A"
+
+msgid "Please set up tuner B"
+msgstr "Please set up tuner B"
+
+msgid "Please set up tuner C"
+msgstr "Please set up tuner C"
+
+msgid "Please set up tuner D"
+msgstr "Please set up tuner D"
+
+msgid "Please set up tuner E"
+msgstr "Please set up tuner E"
+
+msgid "Please set up tuner F"
+msgstr "Please set up tuner F"
+
+msgid "Please set up tuner G"
+msgstr "Please set up tuner G"
+
+msgid "Please set up tuner H"
+msgstr "Please set up tuner H"
+
+msgid "Please set up tuner I"
+msgstr "Please set up tuner I"
+
+msgid "Please set up tuner J"
+msgstr "Please set up tuner J"
+
+msgid "Please set up tuner K"
+msgstr "Please set up tuner K"
+
+msgid ""
+"Please setup your user interface by adjusting the values till the edges of the blue box are touching the edges of your TV.\n"
+"When you are ready press OK to continue."
+msgstr ""
+"Please setup your user interface by adjusting the values till the edges of the blue box are touching the edges of your TV.\n"
+"When you are ready press OK to continue."
+
+msgid "Please use the UP/DOWN keys to select your language. Then press the OK button to select it."
+msgstr "Please use the UP/DOWN keys to select your language. Then press the OK button to select it."
+
+msgid ""
+"Please use the direction keys to move the PiP window.\n"
+"Press Bouquet +/- to resize the window.\n"
+"Press OK to go back to the TV mode or EXIT to cancel the moving."
+msgstr ""
+"Please use the direction keys to move the PiP window.\n"
+"Press Bouquet +/- to resize the window.\n"
+"Press OK to go back to the TV mode or EXIT to cancel the moving."
+
+msgid "Please wait (downloading channel list)"
+msgstr "Please wait (downloading channel list)"
+
+msgid "Please wait (updating packages)"
+msgstr "Please wait (updating packages)"
+
+msgid "Please wait while gathering EPG data..."
+msgstr "Please wait while gathering EPG data..."
+
+msgid "Please wait while scanning for devices..."
+msgstr "Please wait while scanning for devices..."
+
+msgid "Please wait while scanning is in progress..."
+msgstr "Please wait while scanning is in progress..."
+
+msgid "Please wait while we configure your network..."
+msgstr "Please wait while we configure your network..."
+
+msgid "Please wait while we prepare your network interfaces..."
+msgstr "Please wait while we prepare your network interfaces..."
+
+msgid "Please wait while we test your network..."
+msgstr "Please wait while we test your network..."
+
+msgid "Please wait while your network configuration is activated..."
+msgstr "Please wait while your network configuration is activated..."
+
+msgid "Please wait..."
+msgstr "Please wait..."
+
+msgid "Please wait... Loading list..."
+msgstr "Please wait... Loading list..."
+
+msgid "Plugin Browser"
+msgstr "Plugin Browser"
+
+msgid "Plugin browser"
+msgstr "Plugin browser"
+
+msgid "Plugin details"
+msgstr "Plugin details"
+
+msgid "Plugin manager activity information"
+msgstr "Plugin manager activity information"
+
+msgid "Plugin manager help"
+msgstr "Plugin manager help"
+
+msgid "Plugins"
+msgstr "Plugins"
+
+msgid "Polarisation"
+msgstr "Polarisation"
+
+msgid "Polarisation:"
+msgstr "Polarisation:"
+
+msgid "Polarization"
+msgstr "Polarization"
+
+msgid "Polish"
+msgstr "Polish"
+
+msgid "Popup"
+msgstr "Popup"
+
+msgid "Port"
+msgstr "Port"
+
+msgid "Port A"
+msgstr "Port A"
+
+msgid "Port B"
+msgstr "Port B"
+
+msgid "Port C"
+msgstr "Port C"
+
+msgid "Port D"
+msgstr "Port D"
+
+msgid "Port:"
+msgstr "Port:"
+
+msgid "Portuguese"
+msgstr "Portuguese"
+
+msgid "Position Setup"
+msgstr "Position Setup"
+
+msgid "Position of finished Timers in the Timer list"
+msgstr "Position of finished Timers in the Timer list"
+
+msgid "Position setup"
+msgstr "Position setup"
+
+msgid "Position stored at index"
+msgstr "Position stored at index"
+
+msgid "Positioner"
+msgstr "Positioner"
+
+msgid "Positioner (selecting satellites)"
+msgstr "Positioner (selecting satellites)"
+
+msgid "Positioner setup"
+msgstr "Positioner setup"
+
+msgid "Positioner setup log"
+msgstr "Positioner setup log"
+
+msgid "Power"
+msgstr "Power"
+
+msgid "Power LCD Display"
+msgstr "Power LCD Display"
+
+msgid "Power long"
+msgstr "Power long"
+
+msgid "Power threshold in mA"
+msgstr "Power threshold in mA"
+
+msgid "PowerManager entry"
+msgstr "PowerManager entry"
+
+msgid "PowerMenu"
+msgstr "PowerMenu"
+
+msgid "PowerTimer List"
+msgstr "PowerTimer List"
+
+msgid "PowerTimers"
+msgstr "PowerTimers"
+
+msgid "Predefined"
+msgstr "Predefined"
+
+msgid "Predefined transponder"
+msgstr "Predefined transponder"
+
+msgid "Prefer AC3 track"
+msgstr "Prefer AC3 track"
+
+msgid "Prefer AC3+ track"
+msgstr "Prefer AC3+ track"
+
+msgid "Prefer audio track stored by service"
+msgstr "Prefer audio track stored by service"
+
+msgid "Prefer graphical DVB subtitles"
+msgstr "Prefer graphical DVB subtitles"
+
+msgid "Prefer subtitles for hearing impaired"
+msgstr "Prefer subtitles for hearing impaired"
+
+msgid "Prefer subtitles stored by service"
+msgstr "Prefer subtitles stored by service"
+
+msgid "Preferred tuner"
+msgstr "Preferred tuner"
+
+msgid "Preferred tuner DVB-C"
+msgstr "Preferred tuner DVB-C"
+
+msgid "Preferred tuner DVB-C for recordings"
+msgstr "Preferred tuner DVB-C for recordings"
+
+msgid "Preferred tuner DVB-S"
+msgstr "Preferred tuner DVB-S"
+
+msgid "Preferred tuner DVB-S for recordings"
+msgstr "Preferred tuner DVB-S for recordings"
+
+msgid "Preferred tuner DVB-T"
+msgstr "Preferred tuner DVB-T"
+
+msgid "Preferred tuner DVB-T for recordings"
+msgstr "Preferred tuner DVB-T for recordings"
+
+msgid "Preferred tuner for recordings"
+msgstr "Preferred tuner for recordings"
+
+msgid "Preparing... Please wait"
+msgstr "Preparing... Please wait"
+
+msgid "Press '0' to toggle PiP mode"
+msgstr "Press '0' to toggle PiP mode"
+
+msgid "Press INFO on your remote control for additional information."
+msgstr "Press INFO on your remote control for additional information."
+
+msgid "Press MENU on your remote control for additional options."
+msgstr "Press MENU on your remote control for additional options."
+
+msgid "Press OK on your remote control to continue."
+msgstr "Press OK on your remote control to continue."
+
+msgid "Press OK to activate the selected skin."
+msgstr "Press OK to activate the selected skin."
+
+msgid "Press OK to activate the settings."
+msgstr "Press OK to activate the settings."
+
+msgid "Press OK to edit the settings."
+msgstr "Press OK to edit the settings."
+
+#, python-format
+msgid "Press OK to get further details for %s"
+msgstr "Press OK to get further details for %s"
+
+msgid "Press OK to scan"
+msgstr "Press OK to scan"
+
+msgid "Press OK to select a provider."
+msgstr "Press OK to select a provider."
+
+msgid "Press OK to select satellites"
+msgstr "Press OK to select satellites"
+
+msgid "Press OK to select/deselect a CAId."
+msgstr "Press OK to select/deselect a CAId."
+
+msgid "Press OK to set the MAC address."
+msgstr "Press OK to set the MAC address."
+
+msgid "Press OK to start the scan"
+msgstr "Press OK to start the scan"
+
+msgid "Press OK to toggle the selection"
+msgstr "Press OK to toggle the selection"
+
+msgid "Press OK to toggle the selection."
+msgstr "Press OK to toggle the selection."
+
+msgid "Press OK, save and exit..."
+msgstr "Press OK, save and exit..."
+
+msgid "Press yellow to set this interface as the default interface."
+msgstr "Press yellow to set this interface as the default interface."
+
+msgid "Preview"
+msgstr "Preview"
+
+msgid "Preview menu"
+msgstr "Preview menu"
+
+msgid "Previous"
+msgstr "Previous"
+
+msgid "Primary DNS"
+msgstr "Primary DNS"
+
+msgid "Primetime hour"
+msgstr "Primetime hour"
+
+msgid "Primetime minute"
+msgstr "Primetime minute"
+
+msgid "Priority"
+msgstr "Priority"
+
+msgid "Process"
+msgstr "Process"
+
+msgid "Profile"
+msgstr "Profile"
+
+msgid "Profile: Local box"
+msgstr "Profile: Local box"
+
+msgid "Progress"
+msgstr "Progress"
+
+msgid "Progress bar left"
+msgstr "Progress bar left"
+
+msgid "Progress bar right"
+msgstr "Progress bar right"
+
+msgid "Properties of current title"
+msgstr "Properties of current title"
+
+msgid "Protect configuration"
+msgstr "Protect configuration"
+
+msgid "Protect context menus"
+msgstr "Protect context menus"
+
+msgid "Protect main menu"
+msgstr "Protect main menu"
+
+msgid "Protect manufacturer reset screen"
+msgstr "Protect manufacturer reset screen"
+
+msgid "Protect movie list"
+msgstr "Protect movie list"
+
+msgid "Protect on epg age"
+msgstr "Protect on epg age"
+
+msgid "Protect plugin browser"
+msgstr "Protect plugin browser"
+
+msgid "Protect screens"
+msgstr "Protect screens"
+
+msgid "Protect services"
+msgstr "Protect services"
+
+msgid "Protect software update screen"
+msgstr "Protect software update screen"
+
+msgid "Protect standby menu"
+msgstr "Protect standby menu"
+
+msgid "Protect timer menu"
+msgstr "Protect timer menu"
+
+msgid "Protect vix menu"
+msgstr "Protect vix menu"
+
+msgid "Protocol"
+msgstr "Protocol"
+
+msgid "Protocol:"
+msgstr "Protocol:"
+
+msgid "Provider"
+msgstr "Provider"
+
+msgid "Provider Name: "
+msgstr "Provider Name: "
+
+msgid "Provider to scan"
+msgstr "Provider to scan"
+
+msgid "Provider: "
+msgstr "Provider: "
+
+msgid "Providers"
+msgstr "Providers"
+
+msgid "Providers:"
+msgstr "Providers:"
+
+msgid "Providers: "
+msgstr "Providers: "
+
+msgid "Purge deleted user bouquets"
+msgstr "Purge deleted user bouquets"
+
+msgid "Put TV in standby"
+msgstr "Put TV in standby"
+
+#, python-format
+msgid "Put your %s %s in standby"
+msgstr "Put your %s %s in standby"
+
+msgid "Python frontend for /tmp/mmi.socket"
+msgstr "Python frontend for /tmp/mmi.socket"
+
+#, python-format
+msgid "Python:\t%s\n"
+msgstr "Python:\t%s\n"
+
+msgid "Question"
+msgstr "Question"
+
+msgid "Quick"
+msgstr "Quick"
+
+msgid "Quick Actions"
+msgstr "Quick Actions"
+
+msgid "Quick zap"
+msgstr "Quick zap"
+
+msgid "Quit Movie Player with EXIT button"
+msgstr "Quit Movie Player with EXIT button"
+
+msgid "RAM"
+msgstr "RAM"
+
+msgid "RF output"
+msgstr "RF output"
+
+msgid "RGB"
+msgstr "RGB"
+
+msgid "Radio"
+msgstr "Radio"
+
+msgid "Random"
+msgstr "Random"
+
+#, python-format
+msgid "Rating defined by broadcaster - %d"
+msgstr "Rating defined by broadcaster - %d"
+
+msgid "Rating undefined"
+msgstr "Rating undefined"
+
+msgid "Read user data from oscam.conf"
+msgstr "Read user data from oscam.conf"
+
+msgid "Reader"
+msgstr "Reader"
+
+msgid "Reader Statistics"
+msgstr "Reader Statistics"
+
+#, python-format
+msgid "Ready to install \"%s\" ?"
+msgstr "Ready to install \"%s\" ?"
+
+#, python-format
+msgid "Ready to remove \"%s\" ?"
+msgstr "Ready to remove \"%s\" ?"
+
+msgid "Really close without saving settings?"
+msgstr "Really close without saving settings?"
+
+msgid "Really delete completed timers?"
+msgstr "Really delete completed timers?"
+
+msgid "Really exit the subservices quickzap?"
+msgstr "Really exit the subservices quickzap?"
+
+msgid "Really reboot now?"
+msgstr "Really reboot now?"
+
+#, python-format
+msgid "Really reflash your %s %s and reboot now?"
+msgstr "Really reflash your %s %s and reboot now?"
+
+msgid "Really restart now?"
+msgstr "Really restart now?"
+
+msgid "Really shutdown now?"
+msgstr "Really shutdown now?"
+
+#, python-format
+msgid "Really store at index %2d for current position?"
+msgstr "Really store at index %2d for current position?"
+
+msgid "Really upgrade the frontprocessor and reboot now?"
+msgstr "Really upgrade the frontprocessor and reboot now?"
+
+#, python-format
+msgid "Really upgrade your %s %s and reboot now?"
+msgstr "Really upgrade your %s %s and reboot now?"
+
+msgid "Reboot"
+msgstr "Reboot"
+
+msgid "Rec"
+msgstr "Rec"
+
+msgid "Reception Settings"
+msgstr "Reception Settings"
+
+msgid "Record"
+msgstr "Record"
+
+msgid "Record next"
+msgstr "Record next"
+
+msgid "Record now"
+msgstr "Record now"
+
+msgid "Record started! Stopping timeshift now ..."
+msgstr "Record started! Stopping timeshift now ..."
+
+#, python-format
+msgid "Record time limited due to conflicting timer %s"
+msgstr "Record time limited due to conflicting timer %s"
+
+msgid "Recording"
+msgstr "Recording"
+
+msgid "Recording and playback settings"
+msgstr "Recording and playback settings"
+
+msgid "Recording in progress"
+msgstr "Recording in progress"
+
+msgid "Recording type"
+msgstr "Recording type"
+
+msgid "Recording(s) are in progress or coming up in few seconds!"
+msgstr "Recording(s) are in progress or coming up in few seconds!"
+
+msgid "Recordings"
+msgstr "Recordings"
+
+msgid "Recordings always have priority"
+msgstr "Recordings always have priority"
+
+msgid "Red"
+msgstr "Red"
+
+msgid "Red button..."
+msgstr "Red button..."
+
+msgid "Red colored"
+msgstr "Red colored"
+
+msgid "Red long"
+msgstr "Red long"
+
+msgid "Reduce time scale"
+msgstr "Reduce time scale"
+
+#, python-format
+msgid ""
+"Reflash in progress\n"
+"Please wait until your %s %s reboots\n"
+"This may take a few minutes"
+msgstr ""
+"Reflash in progress\n"
+"Please wait until your %s %s reboots\n"
+"This may take a few minutes"
+
+msgid "Reflash recommended!"
+msgstr "Reflash recommended!"
+
+msgid "Refresh every (in hours)"
+msgstr "Refresh every (in hours)"
+
+msgid "Refresh rate"
+msgstr "Refresh rate"
+
+msgid "Refresh rate selection."
+msgstr "Refresh rate selection."
+
+msgid "Regard deep standby as standby"
+msgstr "Regard deep standby as standby"
+
+msgid "Region"
+msgstr "Region"
+
+msgid "Relative"
+msgstr "Relative"
+
+msgid "Reload"
+msgstr "Reload"
+
+msgid "Reload blacklists"
+msgstr "Reload blacklists"
+
+msgid "Reloading EPG Cache..."
+msgstr "Reloading EPG Cache..."
+
+msgid "Reloading bouquets and services..."
+msgstr "Reloading bouquets and services..."
+
+msgid "Remaining"
+msgstr "Remaining"
+
+msgid "Remaining & Elapsed"
+msgstr "Remaining & Elapsed"
+
+msgid "Remember service PIN"
+msgstr "Remember service PIN"
+
+msgid "Reminder, you have chosen to save timeshift file."
+msgstr "Reminder, you have chosen to save timeshift file."
+
+msgid "Remote box"
+msgstr "Remote box"
+
+msgid "Remote control type"
+msgstr "Remote control type"
+
+msgid "Remove"
+msgstr "Remove"
+
+msgid "Remove Confirmation"
+msgstr "Remove Confirmation"
+
+msgid "Remove Service"
+msgstr "Remove Service"
+
+msgid "Remove a mark"
+msgstr "Remove a mark"
+
+msgid "Remove a nameserver entry"
+msgstr "Remove a nameserver entry"
+
+msgid "Remove all alternatives"
+msgstr "Remove all alternatives"
+
+msgid "Remove all new found flags"
+msgstr "Remove all new found flags"
+
+msgid "Remove bookmark"
+msgstr "Remove bookmark"
+
+msgid "Remove bouquet from parental protection"
+msgstr "Remove bouquet from parental protection"
+
+msgid "Remove cable services"
+msgstr "Remove cable services"
+
+msgid "Remove completed timers after (days)"
+msgstr "Remove completed timers after (days)"
+
+msgid "Remove currently selected title"
+msgstr "Remove currently selected title"
+
+msgid "Remove entry"
+msgstr "Remove entry"
+
+msgid "Remove finished."
+msgstr "Remove finished."
+
+msgid "Remove from parental protection"
+msgstr "Remove from parental protection"
+
+msgid "Remove items from trash can after (days)"
+msgstr "Remove items from trash can after (days)"
+
+msgid "Remove new found flag"
+msgstr "Remove new found flag"
+
+msgid "Remove plugins"
+msgstr "Remove plugins"
+
+msgid "Remove selected satellite"
+msgstr "Remove selected satellite"
+
+msgid "Remove terrestrial services"
+msgstr "Remove terrestrial services"
+
+msgid "Remove timer"
+msgstr "Remove timer"
+
+msgid "Remove title"
+msgstr "Remove title"
+
+msgid "Removing"
+msgstr "Removing"
+
+msgid "Removing Service"
+msgstr "Removing Service"
+
+#, python-format
+msgid "Removing directory %s failed. (Maybe not empty.)"
+msgstr "Removing directory %s failed. (Maybe not empty.)"
+
+msgid "Removing partition table"
+msgstr "Removing partition table"
+
+msgid "Removing service"
+msgstr "Removing service"
+
+msgid "Rename"
+msgstr "Rename"
+
+msgid "Rename entry"
+msgstr "Rename entry"
+
+msgid "Rename failed!"
+msgstr "Rename failed!"
+
+msgid "Rename name and description for new events"
+msgstr "Rename name and description for new events"
+
+msgid "Rename to:"
+msgstr "Rename to:"
+
+#, python-format
+msgid "Renamed %s!"
+msgstr "Renamed %s!"
+
+msgid "Repeat"
+msgstr "Repeat"
+
+msgid "Repeat Display Message"
+msgstr "Repeat Display Message"
+
+msgid "Repeat type"
+msgstr "Repeat type"
+
+msgid "Repeating event currently recording... What do you want to do?"
+msgstr "Repeating event currently recording... What do you want to do?"
+
+msgid "Repeating the event currently recording... What do you want to do?"
+msgstr "Repeating the event currently recording... What do you want to do?"
+
+msgid "Repeats"
+msgstr "Repeats"
+
+msgid "Replace `- ` in dialogs with colored text per speaker (like teletext subtitles for the hearing impaired)"
+msgstr "Replace `- ` in dialogs with colored text per speaker (like teletext subtitles for the hearing impaired)"
+
+msgid "Require authentication for http streams"
+msgstr "Require authentication for http streams"
+
+msgid "Required medium type:"
+msgstr "Required medium type:"
+
+msgid "Rereading partition table"
+msgstr "Rereading partition table"
+
+msgid "Reserved"
+msgstr "Reserved"
+
+msgid "Reset"
+msgstr "Reset"
+
+msgid "Reset and renumerate title names"
+msgstr "Reset and renumerate title names"
+
+msgid "Reset playback position"
+msgstr "Reset playback position"
+
+msgid "Reset video enhancement settings to system defaults?"
+msgstr "Reset video enhancement settings to system defaults?"
+
+msgid "Reset video enhancement settings to your last configuration?"
+msgstr "Reset video enhancement settings to your last configuration?"
+
+msgid "Reshare:"
+msgstr "Reshare:"
+
+msgid "Resolution"
+msgstr "Resolution"
+
+msgid "Restart"
+msgstr "Restart"
+
+msgid "Restart GUI"
+msgstr "Restart GUI"
+
+msgid "Restart GUI now?"
+msgstr "Restart GUI now?"
+
+msgid "Restart network"
+msgstr "Restart network"
+
+msgid "Restart test"
+msgstr "Restart test"
+
+msgid "Restart your network connection and interfaces.\n"
+msgstr "Restart your network connection and interfaces.\n"
+
+msgid "Restore"
+msgstr "Restore"
+
+msgid "Restore backups"
+msgstr "Restore backups"
+
+msgid "Restore deleted user bouquets"
+msgstr "Restore deleted user bouquets"
+
+msgid "Restore system settings"
+msgstr "Restore system settings"
+
+msgid "Restoring..."
+msgstr "Restoring..."
+
+msgid "Resume from last position"
+msgstr "Resume from last position"
+
+#, python-format
+msgid "Resume position at %s"
+msgstr "Resume position at %s"
+
+msgid "Resuming playback"
+msgstr "Resuming playback"
+
+msgid "Return to movie list"
+msgstr "Return to movie list"
+
+msgid "Return to previous service"
+msgstr "Return to previous service"
+
+msgid "Reverse bouquet buttons"
+msgstr "Reverse bouquet buttons"
+
+msgid "Reverse list"
+msgstr "Reverse list"
+
+msgid "Rewind"
+msgstr "Rewind"
+
+msgid "Rewind speeds"
+msgstr "Rewind speeds"
+
+msgid "Rewrap subtitles"
+msgstr "Rewrap subtitles"
+
+msgid "Right"
+msgstr "Right"
+
+msgid "Right from servicename"
+msgstr "Right from servicename"
+
+msgid "Roll-off"
+msgstr "Roll-off"
+
+msgid "Romanian"
+msgstr "Romanian"
+
+msgid "Root directory"
+msgstr "Root directory"
+
+msgid "Rotor step position:"
+msgstr "Rotor step position:"
+
+msgid "Rotor turning speed"
+msgstr "Rotor turning speed"
+
+msgid "Rotor: "
+msgstr "Rotor: "
+
+msgid "Run how often ?"
+msgstr "Run how often ?"
+
+msgid "Running"
+msgstr "Running"
+
+msgid "Russian"
+msgstr "Russian"
+
+msgid "S"
+msgstr "S"
+
+msgid "S-Video"
+msgstr "S-Video"
+
+msgid "SABnzbd Setup"
+msgstr "SABnzbd Setup"
+
+msgid "SABnzbd setup"
+msgstr "SABnzbd setup"
+
+msgid "SID"
+msgstr "SID"
+
+msgid "SINGLE LAYER DVD"
+msgstr "SINGLE LAYER DVD"
+
+msgid "SNR:"
+msgstr "SNR:"
+
+msgid "SPDIF"
+msgstr "SPDIF"
+
+msgid "SSID:"
+msgstr "SSID:"
+
+msgid "Samba Setup"
+msgstr "Samba Setup"
+
+msgid "Samba setup"
+msgstr "Samba setup"
+
+msgid "Same resolution as skin"
+msgstr "Same resolution as skin"
+
+msgid "Sat"
+msgstr "Sat"
+
+msgid "Satellite"
+msgstr "Satellite"
+
+msgid "Satellite dish setup"
+msgstr "Satellite dish setup"
+
+msgid "Satellite equipment"
+msgstr "Satellite equipment"
+
+msgid "Satellite equipment setup"
+msgstr "Satellite equipment setup"
+
+msgid "Satellite longitude:"
+msgstr "Satellite longitude:"
+
+msgid "Satellites"
+msgstr "Satellites"
+
+msgid "Sats"
+msgstr "Sats"
+
+msgid "Saturation"
+msgstr "Saturation"
+
+msgid "Saturday"
+msgstr "Saturday"
+
+msgid "Save"
+msgstr "Save"
+
+msgid "Save EPG"
+msgstr "Save EPG"
+
+msgid "Save and record"
+msgstr "Save and record"
+
+msgid "Save and stop"
+msgstr "Save and stop"
+
+msgid "Save every (in hours)"
+msgstr "Save every (in hours)"
+
+msgid "Save playlist"
+msgstr "Save playlist"
+
+msgid "Save timeshift and zap"
+msgstr "Save timeshift and zap"
+
+msgid "Save timeshift as movie and continue recording"
+msgstr "Save timeshift as movie and continue recording"
+
+msgid "Save timeshift as movie and stop recording"
+msgstr "Save timeshift as movie and stop recording"
+
+msgid "Save timeshift in movie dir and zap"
+msgstr "Save timeshift in movie dir and zap"
+
+msgid "Saving EPG Cache..."
+msgstr "Saving EPG Cache..."
+
+msgid "Saving Timeshift files"
+msgstr "Saving Timeshift files"
+
+msgid "Saving timeshift as movie now. This might take a while!"
+msgstr "Saving timeshift as movie now. This might take a while!"
+
+msgid "Scaler sharpness"
+msgstr "Scaler sharpness"
+
+msgid "Scaler vertical dejagging"
+msgstr "Scaler vertical dejagging"
+
+msgid "Scaling mode"
+msgstr "Scaling mode"
+
+msgid "Scan"
+msgstr "Scan"
+
+msgid "Scan "
+msgstr "Scan "
+
+#. TRANSLATORS: option name, indicating which type of (DVB-C) modulation should be scanned. The modulation type is printed in '%s'. E.g.: 'Scan QAM16'
+#, python-format
+msgid "Scan %s"
+msgstr "Scan %s"
+
+#. TRANSLATORS: option name, indicating which type of (DVB-C) band should be scanned. The name of the band is printed in '%s'. E.g.: 'Scan EU MID band'
+#, python-format
+msgid "Scan %s band"
+msgstr "Scan %s band"
+
+msgid "Scan additional SR"
+msgstr "Scan additional SR"
+
+msgid "Scan files..."
+msgstr "Scan files..."
+
+msgid "Scan options"
+msgstr "Scan options"
+
+msgid "Scan wireless networks"
+msgstr "Scan wireless networks"
+
+msgid "Scan your network for wireless access points and connect to them using your selected wireless device.\n"
+msgstr "Scan your network for wireless access points and connect to them using your selected wireless device.\n"
+
+#, python-format
+msgid "Scanning %s..."
+msgstr "Scanning %s..."
+
+#. TRANSLATORS: The stb is performing a channel scan, progress percentage is printed in '%d' (and '%%' will show a single '%' symbol)
+#, python-format
+msgid "Scanning - %d%% completed"
+msgid_plural "Scanning - %d%% completed"
+msgstr[0] "Scanning - %d%% completed"
+msgstr[1] "Scanning - %d%% completed"
+
+#, python-format
+msgid "Scanning completed, %d channel found"
+msgid_plural "Scanning completed, %d channels found"
+msgstr[0] "Scanning completed, %d channel found"
+msgstr[1] "Scanning completed, %d channels found"
+
+msgid "Scanning failed!"
+msgstr "Scanning failed!"
+
+msgid "Scanning..."
+msgstr "Scanning..."
+
+msgid "Scans default lamedbs sorted by satellite with a connected dish positioner"
+msgstr "Scans default lamedbs sorted by satellite with a connected dish positioner"
+
+msgid "Scrolling Speed"
+msgstr "Scrolling Speed"
+
+msgid "Scrolling Speed (software render)"
+msgstr "Scrolling Speed (software render)"
+
+msgid "Scrolling delay (software render)"
+msgstr "Scrolling delay (software render)"
+
+msgid "Search"
+msgstr "Search"
+
+msgid "Search IMDb for information about the current event."
+msgstr "Search IMDb for information about the current event."
+
+msgid "Search east"
+msgstr "Search east"
+
+msgid "Search for similar events"
+msgstr "Search for similar events"
+
+msgid "Search the epg for the current event."
+msgstr "Search the epg for the current event."
+
+msgid "Search west"
+msgstr "Search west"
+
+msgid "Search/WEB"
+msgstr "Search/WEB"
+
+msgid "Searching"
+msgstr "Searching"
+
+msgid "Searching east ..."
+msgstr "Searching east ..."
+
+msgid "Searching for available updates. Please wait..."
+msgstr "Searching for available updates. Please wait..."
+
+msgid "Searching for new installed or removed packages. Please wait..."
+msgstr "Searching for new installed or removed packages. Please wait..."
+
+msgid "Searching west ..."
+msgstr "Searching west ..."
+
+msgid "Second cable of motorized LNB"
+msgstr "Second cable of motorised LNB"
+
+msgid "Secondary DNS"
+msgstr "Secondary DNS"
+
+msgid "Seek"
+msgstr "Seek"
+
+msgid "Seek backward"
+msgstr "Seek backward"
+
+msgid "Seek backward (enter time)"
+msgstr "Seek backward (enter time)"
+
+msgid "Seek forward"
+msgstr "Seek forward"
+
+msgid "Seek forward (enter time)"
+msgstr "Seek forward (enter time)"
+
+msgid "Seekbar activation"
+msgstr "Seekbar activation"
+
+msgid "Seekbar sensibility"
+msgstr "Seekbar sensibility"
+
+msgid "Select"
+msgstr "Select"
+
+msgid "Select CAId"
+msgstr "Select CAId"
+
+msgid "Select a wireless network"
+msgstr "Select a wireless network"
+
+msgid "Select action"
+msgstr "Select action"
+
+#, python-format
+msgid "Select action for timer %s:"
+msgstr "Select action for timer %s:"
+
+msgid "Select all"
+msgstr "Select all"
+
+msgid "Select audio track"
+msgstr "Select audio track"
+
+msgid "Select backup files"
+msgstr "Select backup files"
+
+msgid "Select backup location"
+msgstr "Select backup location"
+
+msgid "Select channel to record from"
+msgstr "Select channel to record from"
+
+msgid "Select copy destination for:"
+msgstr "Select copy destination for:"
+
+msgid "Select destination for:"
+msgstr "Select destination for:"
+
+msgid "Select files for backup."
+msgstr "Select files for backup."
+
+msgid "Select files/folders to backup"
+msgstr "Select files/folders to backup"
+
+msgid "Select folders"
+msgstr "Select folders"
+
+msgid "Select how to activate the Quick EPG mode:"
+msgstr "Select how to activate the Quick EPG mode:"
+
+msgid "Select if timeshift should continue when set to record."
+msgstr "Select if timeshift should continue when set to record."
+
+msgid "Select input device"
+msgstr "Select input device"
+
+msgid "Select input device."
+msgstr "Select input device."
+
+msgid "Select interface"
+msgstr "Select interface"
+
+msgid "Select location"
+msgstr "Select location"
+
+msgid "Select menu entry"
+msgstr "Select menu entry"
+
+msgid "Select movie"
+msgstr "Select movie"
+
+msgid "Select provider to add..."
+msgstr "Select provider to add..."
+
+msgid "Select refresh rate"
+msgstr "Select refresh rate"
+
+msgid "Select satellites"
+msgstr "Select satellites"
+
+msgid "Select seekbar to be activated by arrow L/R (long) or << >> (long)."
+msgstr "Select seekbar to be activated by arrow L/R (long) or << >> (long)."
+
+msgid "Select service to add..."
+msgstr "Select service to add..."
+
+msgid "Select slot"
+msgstr "Select slot"
+
+msgid "Select sort method:"
+msgstr "Select sort method:"
+
+msgid "Select target folder"
+msgstr "Select target folder"
+
+msgid "Select the desired function and click on \"OK\" to assign it. Use \"CH+/-\" to toggle between the lists. Select an assigned function and click on \"OK\" to de-assign it. Use \"Next/Previous\" to change the order of the assigned functions."
+msgstr "Select the desired function and click on \"OK\" to assign it. Use \"CH+/-\" to toggle between the lists. Select an assigned function and click on \"OK\" to de-assign it. Use \"Next/Previous\" to change the order of the assigned functions."
+
+msgid "Select the movie path"
+msgstr "Select the movie path"
+
+msgid "Select upgrade source"
+msgstr "Select upgrade source"
+
+msgid "Select upgrade source to edit."
+msgstr "Select upgrade source to edit."
+
+msgid "Select video input with up/down buttons"
+msgstr "Select video input with up/down buttons"
+
+msgid "Select video mode"
+msgstr "Select video mode"
+
+msgid "Select wireless network"
+msgstr "Select wireless network"
+
+msgid "Select your provider, and press OK to start the scan"
+msgstr "Select your provider, and press OK to start the scan"
+
+msgid "Selecting satellites 1 (USALS)"
+msgstr "Selecting satellites 1 (USALS)"
+
+msgid "Selecting satellites 2 (USALS)"
+msgstr "Selecting satellites 2 (USALS)"
+
+msgid "Send"
+msgstr "Send"
+
+msgid "Send Confirmation"
+msgstr "Send Confirmation"
+
+msgid "Send DiSEqC"
+msgstr "Send DiSEqC"
+
+msgid "Send DiSEqC only on satellite change"
+msgstr "Send DiSEqC only on satellite change"
+
+msgid "Send yourself a copy"
+msgstr "Send yourself a copy"
+
+msgid "Seperate titles with a main menu"
+msgstr "Seperate titles with a main menu"
+
+msgid "Sequence repeat"
+msgstr "Sequence repeat"
+
+msgid "Serbian"
+msgstr "Serbian"
+
+msgid "Serial No"
+msgstr "Serial No"
+
+msgid "Serial no"
+msgstr "Serial no"
+
+msgid "Serv.Name"
+msgstr "Serv.Name"
+
+msgid "Server:"
+msgstr "Server:"
+
+msgid "Servers"
+msgstr "Servers"
+
+msgid "Servers:"
+msgstr "Servers:"
+
+msgid "Service"
+msgstr "Service"
+
+msgid "Service Information"
+msgstr "Service Information"
+
+msgid "Service Name"
+msgstr "Service Name"
+
+msgid "Service Title mode"
+msgstr "Service Title mode"
+
+msgid "Service font size"
+msgstr "Service font size"
+
+msgid "Service info font size"
+msgstr "Service info font size"
+
+msgid ""
+"Service invalid!\n"
+"(Timeout reading PMT)"
+msgstr ""
+"Service invalid!\n"
+"(Timeout reading PMT)"
+
+msgid "Service name font size"
+msgstr "Service name font size"
+
+msgid ""
+"Service not found!\n"
+"(SID not found in PAT)"
+msgstr ""
+"Service not found!\n"
+"(SID not found in PAT)"
+
+msgid "Service number font size"
+msgstr "Service number font size"
+
+msgid "Service reference"
+msgstr "Service reference"
+
+msgid "Service scan"
+msgstr "Service scan"
+
+msgid "Service searching"
+msgstr "Service searching"
+
+msgid ""
+"Service unavailable!\n"
+"Check tuner configuration!"
+msgstr ""
+"Service unavailable!\n"
+"Check tuner configuration!"
+
+msgid "Service width"
+msgstr "Service width"
+
+msgid "Services"
+msgstr "Services"
+
+msgid "Services may be grouped in bouquets. When enabled, you can use more than one bouquet."
+msgstr "Services may be grouped in bouquets. When enabled, you can use more than one bouquet."
+
+msgid "Set Framerate for MiniTV"
+msgstr "Set Framerate for MiniTV"
+
+msgid "Set as startup service"
+msgstr "Set as startup service"
+
+msgid "Set default"
+msgstr "Set default"
+
+msgid "Set end time"
+msgstr "Set end time"
+
+msgid "Set fixed"
+msgstr "Set fixed"
+
+msgid "Set fps for external subtitles"
+msgstr "Set fps for external subtitles"
+
+msgid "Set interface as the default Interface"
+msgstr "Set interface as the default Interface"
+
+msgid "Set limits"
+msgstr "Set limits"
+
+msgid "Set startup service"
+msgstr "Set startup service"
+
+msgid "Set system"
+msgstr "Set system"
+
+#, python-format
+msgid "Set the MAC address of your %s %s.\n"
+msgstr "Set the MAC address of your %s %s.\n"
+
+msgid "Set the channel for this timer."
+msgstr "Set the channel for this timer."
+
+msgid "Set the date the timer must start."
+msgstr "Set the date the timer must start."
+
+msgid "Set the default location for your instant recordings. Press 'OK' to add new locations, select left/right to select an existing location."
+msgstr "Set the default location for your instant recordings. Press 'OK' to add new locations, select left/right to select an existing location."
+
+msgid "Set the default location for your recordings. Press 'OK' to add new locations, select left/right to select an existing location."
+msgstr "Set the default location for your recordings. Press 'OK' to add new locations, select left/right to select an existing location."
+
+msgid "Set the default location for your timers. Press 'OK' to add new locations, select left/right to select an existing location."
+msgstr "Set the default location for your timers. Press 'OK' to add new locations, select left/right to select an existing location."
+
+msgid "Set the default location for your timeshift-files. Press 'OK' to add new locations, select left/right to select an existing location."
+msgstr "Set the default location for your timeshift-files. Press 'OK' to add new locations, select left/right to select an existing location."
+
+msgid "Set the default sorting method."
+msgstr "Set the default sorting method."
+
+msgid "Set the delay time between repeated loops, this uses a software render in some skins."
+msgstr "Set the delay time between repeated loops, this uses a software render in some skins."
+
+msgid "Set the description of the recording."
+msgstr "Set the description of the recording."
+
+msgid "Set the desired primetime (hour)."
+msgstr "Set the desired primetime (hour)."
+
+msgid "Set the desired primetime (minutes)."
+msgstr "Set the desired primetime (minutes)."
+
+msgid "Set the jump-size of the seekbar."
+msgstr "Set the jump-size of the seekbar."
+
+msgid "Set the name the recording will get."
+msgstr "Set the name the recording will get."
+
+msgid "Set the scrolling speed of text on the front display, this uses a software render in some skins."
+msgstr "Set the scrolling speed of text on the front display, this uses a software render in some skins."
+
+msgid "Set the scrolling speed of text on the front display."
+msgstr "Set the scrolling speed of text on the front display."
+
+msgid "Set the time before checking video source for resolution/refresh rate infomation."
+msgstr "Set the time before checking video source for resolution/refresh rate infomation."
+
+msgid "Set the time delay before hiding the infobar."
+msgstr "Set the time delay before hiding the infobar."
+
+msgid "Set the time the timer must start."
+msgstr "Set the time the timer must start."
+
+msgid "Set the time the timer must stop."
+msgstr "Set the time the timer must stop."
+
+msgid "Set the type of the progress indication in the channel selection screen."
+msgstr "Set the type of the progress indication in the channel selection screen."
+
+msgid "Set to the desired primetime (hour)."
+msgstr "Set to the desired primetime (hour)."
+
+msgid "Set to the desired primetime (minutes)."
+msgstr "Set to the desired primetime (minutes)."
+
+msgid "Set to what you want the button to do."
+msgstr "Set to what you want the button to do."
+
+msgid "Set voltage and 22KHz"
+msgstr "Set voltage and 22KHz"
+
+msgid "Sets the root folder of movie list, to remove the '..' from being shown in that folder."
+msgstr "Sets the root folder of movie list, to remove the '..' from being shown in that folder."
+
+msgid "Settings"
+msgstr "Settings"
+
+msgid "Settings..."
+msgstr "Settings..."
+
+msgid "Setup"
+msgstr "Setup"
+
+msgid "Setup how to control the channel changing."
+msgstr "Setup how to control the channel changing."
+
+msgid "Setup menu"
+msgstr "Setup menu"
+
+msgid "Setup mode"
+msgstr "Setup mode"
+
+msgid "Setup network time synchronization interval."
+msgstr "Setup network time synchronisation interval."
+
+msgid "Setup the interval (in hours) to check for online updates."
+msgstr "Setup the interval (in hours) to check for online updates."
+
+msgid "Setup your positioner"
+msgstr "Setup your positioner"
+
+msgid "Setup your satellite equipment"
+msgstr "Setup your satellite equipment"
+
+msgid "Setup your timezone."
+msgstr "Setup your timezone."
+
+msgid "Share Folder's"
+msgstr "Share Folder's"
+
+msgid "Share View"
+msgstr "Share View"
+
+msgid "Shares"
+msgstr "Shares"
+
+msgid "Sharpness"
+msgstr "Sharpness"
+
+msgid "Short filenames"
+msgstr "Short filenames"
+
+msgid "Show /tmp/ecm.info"
+msgstr "Show /tmp/ecm.info"
+
+msgid "Show 1080p 24fps as"
+msgstr "Show 1080p 24fps as"
+
+msgid "Show 1080p 25fps as"
+msgstr "Show 1080p 25fps as"
+
+msgid "Show 1080p 30fps as"
+msgstr "Show 1080p 30fps as"
+
+msgid "Show 2160p 24fps as"
+msgstr "Show 2160p 24fps as"
+
+msgid "Show 2160p 25fps as"
+msgstr "Show 2160p 25fps as"
+
+msgid "Show 2160p 30fps as"
+msgstr "Show 2160p 30fps as"
+
+msgid "Show 480/576p 24fps as"
+msgstr "Show 480/576p 24fps as"
+
+msgid "Show 720p 24fps as"
+msgstr "Show 720p 24fps as"
+
+msgid "Show AutoTimer List"
+msgstr "Show AutoTimer List"
+
+msgid "Show CCcam Info in extensions?"
+msgstr "Show CCcam Info in extensions?"
+
+msgid "Show Clients"
+msgstr "Show Clients"
+
+msgid "Show Display Icons"
+msgstr "Show Display Icons"
+
+msgid "Show E2 Log"
+msgstr "Show E2 Log"
+
+msgid "Show EIT now/next in infobar"
+msgstr "Show EIT now/next in infobar"
+
+msgid "Show EPG for current channel..."
+msgstr "Show EPG for current channel..."
+
+msgid "Show EPG for current service"
+msgstr "Show EPG for current service"
+
+msgid "Show EPG..."
+msgstr "Show EPG..."
+
+msgid "Show Games show"
+msgstr "Show Games show"
+
+msgid "Show Log"
+msgstr "Show Log"
+
+msgid "Show Log Manager in extensions list ?"
+msgstr "Show Log Manager in extensions list ?"
+
+msgid "Show Media playback Remaining/Elapsed as"
+msgstr "Show Media playback Remaining/Elapsed as"
+
+msgid "Show MiniTV in the Front Display"
+msgstr "Show MiniTV in the Front Display"
+
+msgid "Show OE Log"
+msgstr "Show OE Log"
+
+msgid "Show OScam Info in extensions?"
+msgstr "Show OScam Info in extensions?"
+
+msgid "Show PIP"
+msgstr "Show PIP"
+
+msgid "Show PIP in the Front Display"
+msgstr "Show PIP in the Front Display"
+
+msgid "Show PVR status in Movie Player infobar"
+msgstr "Show PVR status in Movie Player infobar"
+
+msgid "Show RFmod setup..."
+msgstr "Show RFmod setup..."
+
+msgid "Show Readers/Proxies"
+msgstr "Show Readers/Proxies"
+
+msgid "Show SD as"
+msgstr "Show SD as"
+
+msgid "Show Time Remaining/Elapsed"
+msgstr "Show Time Remaining/Elapsed"
+
+msgid "Show Timer List"
+msgstr "Show Timer List"
+
+msgid "Show Transponder Remaining/Elapsed as"
+msgstr "Show Transponder Remaining/Elapsed as"
+
+msgid "Show VCR scart on main menu"
+msgstr "Show VCR scart on main menu"
+
+msgid "Show ViX spinning logo when the system is busy."
+msgstr "Show ViX spinning logo when the system is busy."
+
+msgid "Show WLAN status"
+msgstr "Show WLAN status"
+
+msgid "Show alternatives"
+msgstr "Show alternatives"
+
+msgid "Show animation while busy"
+msgstr "Show animation while busy"
+
+msgid "Show background behind subtitles"
+msgstr "Show background behind subtitles"
+
+msgid "Show background in Radio mode"
+msgstr "Show background in Radio mode"
+
+msgid "Show background when tuned to a radio channel."
+msgstr "Show background when tuned to a radio channel."
+
+msgid "Show bouquet on launch"
+msgstr "Show bouquet on launch"
+
+msgid "Show channel number in infobar"
+msgstr "Show channel number in infobar"
+
+msgid "Show channel numbers in channel selection"
+msgstr "Show channel numbers in channel selection"
+
+msgid "Show columns"
+msgstr "Show columns"
+
+msgid "Show crypto icons"
+msgstr "Show crypto icons"
+
+msgid "Show crypto info in infobar"
+msgstr "Show crypto info in infobar"
+
+msgid "Show detailed event info"
+msgstr "Show detailed event info"
+
+msgid "Show encryption info in the infobar (when supported by the skin)."
+msgstr "Show encryption info in the infobar (when supported by the skin)."
+
+msgid "Show epg"
+msgstr "Show epg"
+
+msgid "Show event details"
+msgstr "Show event details"
+
+msgid "Show event info plugins"
+msgstr "Show event info plugins"
+
+msgid "Show event-progress in channel selection"
+msgstr "Show event-progress in channel selection"
+
+msgid "Show extended description"
+msgstr "Show extended description"
+
+msgid "Show extension selection"
+msgstr "Show extension selection"
+
+msgid "Show extensions..."
+msgstr "Show extensions..."
+
+msgid "Show favourites list"
+msgstr "Show favourites list"
+
+msgid "Show full menu path"
+msgstr "Show full menu path"
+
+msgid "Show graphical multi EPG"
+msgstr "Show graphical multi EPG"
+
+msgid "Show help"
+msgstr "Show help"
+
+msgid "Show icon for new/unseen items"
+msgstr "Show icon for new/unseen items"
+
+msgid "Show in extensions list ?"
+msgstr "Show in extensions list ?"
+
+msgid "Show info"
+msgstr "Show info"
+
+msgid "Show info line"
+msgstr "Show info line"
+
+msgid "Show infobar on channel change"
+msgstr "Show infobar on channel change"
+
+msgid "Show infobar on event change"
+msgstr "Show infobar on event change"
+
+msgid "Show infobar on skip forward/backward"
+msgstr "Show infobar on skip forward/backward"
+
+msgid "Show job tasks in extensions"
+msgstr "Show job tasks in extensions"
+
+msgid "Show live tv when movie stopped"
+msgstr "Show live tv when movie stopped"
+
+msgid "Show menu"
+msgstr "Show menu"
+
+msgid "Show message when recording starts"
+msgstr "Show message when recording starts"
+
+msgid "Show movie lengths in movielist"
+msgstr "Show movie lengths in movielist"
+
+msgid "Show movies"
+msgstr "Show movies"
+
+msgid "Show multi EPG"
+msgstr "Show multi EPG"
+
+msgid "Show network mounts ..."
+msgstr "Show network mounts ..."
+
+msgid "Show or hide the extended description, (skin dependant)."
+msgstr "Show or hide the extended description, (skin dependant)."
+
+msgid "Show picon background color"
+msgstr "Show picon background color"
+
+msgid "Show picons in service list"
+msgstr "Show picons in service list"
+
+msgid "Show positioner movement"
+msgstr "Show positioner movement"
+
+msgid "Show positioner position"
+msgstr "Show positioner position"
+
+msgid "Show program information..."
+msgstr "Show program information..."
+
+msgid "Show record indicator"
+msgstr "Show record indicator"
+
+msgid "Show screensaver"
+msgstr "Show screensaver"
+
+msgid "Show second infobar"
+msgstr "Show second infobar"
+
+msgid "Show select audio track"
+msgstr "Show select audio track"
+
+msgid "Show service list"
+msgstr "Show service list"
+
+msgid "Show service list or movies"
+msgstr "Show service list or movies"
+
+msgid "Show service type icons"
+msgstr "Show service type icons"
+
+msgid "Show shutdown menu"
+msgstr "Show shutdown menu"
+
+msgid "Show single epg for current channel"
+msgstr "Show single epg for current channel"
+
+msgid "Show source packages"
+msgstr "Show source packages"
+
+msgid "Show status icons in movie list"
+msgstr "Show status icons in movie list"
+
+msgid "Show subservice selection"
+msgstr "Show subservice selection"
+
+msgid "Show subtitle selection"
+msgstr "Show subtitle selection"
+
+msgid "Show the DreamPlex player..."
+msgstr "Show the DreamPlex player..."
+
+msgid "Show the list of autotimers."
+msgstr "Show the list of autotimers."
+
+msgid "Show the list of timers."
+msgstr "Show the list of timers."
+
+msgid "Show the plugin browser.."
+msgstr "Show the plugin browser.."
+
+msgid "Show the radio player..."
+msgstr "Show the radio player..."
+
+msgid "Show the tv player..."
+msgstr "Show the tv player..."
+
+msgid "Show time elapsed as positive"
+msgstr "Show time elapsed as positive"
+
+msgid "Show time in 24 hour clock format."
+msgstr "Show time in 24 hour clock format."
+
+msgid "Show time remaining/elapsed"
+msgstr "Show time remaining/elapsed"
+
+msgid "Show translation packages"
+msgstr "Show translation packages"
+
+msgid "Show transponder info"
+msgstr "Show transponder info"
+
+msgid "Show transponder remaining/elapsed as"
+msgstr "Show transponder remaining/elapsed as"
+
+msgid "Show warning when in a stream"
+msgstr "Show warning when in a stream"
+
+msgid "Show warning when timeshift is stopped"
+msgstr "Show warning when timeshift is stopped"
+
+msgid "Shows live tv or informations on LCD."
+msgstr "Shows live tv or informations on LCD."
+
+msgid "Shows the icons when new/unseen, otherwise it will not show an icon."
+msgstr "Shows the icons when new/unseen, otherwise it will not show an icon."
+
+msgid "Shows the state of your wireless LAN connection.\n"
+msgstr "Shows the state of your wireless LAN connection.\n"
+
+msgid "Shows the watched status of the movie."
+msgstr "Shows the watched status of the movie."
+
+msgid "Shuffle playlist"
+msgstr "Shuffle playlist"
+
+msgid "Shutdown"
+msgstr "Shutdown"
+
+msgid "Side by Side"
+msgstr "Side by Side"
+
+msgid "Side by side"
+msgstr "Side by side"
+
+msgid "Signal Finder"
+msgstr "Signal Finder"
+
+msgid "Signal OK, proceeding"
+msgstr "Signal OK, proceeding"
+
+msgid "Signal Strength:"
+msgstr "Signal Strength:"
+
+msgid "Signal finder"
+msgstr "Signal finder"
+
+msgid "Signal quality"
+msgstr "Signal quality"
+
+msgid "Signal strength:"
+msgstr "Signal strength:"
+
+msgid "Signal: "
+msgstr "Signal: "
+
+msgid "Similar"
+msgstr "Similar"
+
+msgid "Similar broadcasts:"
+msgstr "Similar broadcasts:"
+
+msgid "Simple"
+msgstr "Simple"
+
+msgid "Simple fade"
+msgstr "Simple fade"
+
+msgid "Simple titleset (compatibility for legacy players)"
+msgstr "Simple titleset (compatibility for legacy players)"
+
+msgid "Simple zoom"
+msgstr "Simple zoom"
+
+msgid "Single"
+msgstr "Single"
+
+msgid "Single EPG"
+msgstr "Single EPG"
+
+msgid "Single satellite"
+msgstr "Single satellite"
+
+msgid "Single step (GOP)"
+msgstr "Single step (GOP)"
+
+msgid "SingleEPG settings"
+msgstr "SingleEPG settings"
+
+msgid "Site latitude"
+msgstr "Site latitude"
+
+msgid "Site longitude"
+msgstr "Site longitude"
+
+msgid "Size: "
+msgstr "Size: "
+
+msgid "Skin Setting"
+msgstr "Skin Setting"
+
+#, python-format
+msgid "Skin name:\t%s\n"
+msgstr "Skin name:\t%s\n"
+
+msgid "Skin setup"
+msgstr "Skin setup"
+
+msgid "Skins"
+msgstr "Skins"
+
+msgid "Skip back"
+msgstr "Skip back"
+
+msgid "Skip empty services"
+msgstr "Skip empty services"
+
+msgid "Skip forward"
+msgstr "Skip forward"
+
+msgid "Skip internet connection check (disables automatic package installation)"
+msgstr "Skip internet connection check (disables automatic package installation)"
+
+msgid "Sleep"
+msgstr "Sleep"
+
+msgid "Sleep delay"
+msgstr "Sleep delay"
+
+msgid "Slide drop"
+msgstr "Slide drop"
+
+msgid "Slide from left"
+msgstr "Slide from left"
+
+msgid "Slide left to right"
+msgstr "Slide left to right"
+
+msgid "Slide picture in loop"
+msgstr "Slide picture in loop"
+
+msgid "Slide right to left"
+msgstr "Slide right to left"
+
+msgid "Slide show interval (sec.)"
+msgstr "Slide show interval (sec.)"
+
+msgid "Slide top to bottom"
+msgstr "Slide top to bottom"
+
+#, python-format
+msgid "Slot %d"
+msgstr "Slot %d"
+
+msgid "Slovak"
+msgstr "Slovak"
+
+msgid "Slovenian"
+msgstr "Slovenian"
+
+msgid "Slow"
+msgstr "Slow"
+
+msgid "Slow motion speeds"
+msgstr "Slow motion speeds"
+
+msgid "Small"
+msgstr "Small"
+
+msgid "Small progress"
+msgstr "Small progress"
+
+msgid "Smooth"
+msgstr "Smooth"
+
+msgid "Social/Political/Economics"
+msgstr "Social/Political/Economics"
+
+msgid "SoftCam and CI"
+msgstr "SoftCam and CI"
+
+msgid "Softcam setings"
+msgstr "Softcam setings"
+
+msgid "Softcam settings"
+msgstr "Softcam settings"
+
+msgid "SoftcamCheck"
+msgstr "SoftcamCheck"
+
+msgid "Software"
+msgstr "Software"
+
+msgid "Software Update"
+msgstr "Software Update"
+
+msgid "Software management"
+msgstr "Software management"
+
+msgid "Software manager setup"
+msgstr "Software manager setup"
+
+msgid "Software restore"
+msgstr "Software restore"
+
+msgid "Software update"
+msgstr "Software update"
+
+msgid "Software update settings"
+msgstr "Software update settings"
+
+msgid "Softwaremanager information"
+msgstr "Softwaremanager information"
+
+msgid "Some plugins are not available:\n"
+msgstr "Some plugins are not available:\n"
+
+msgid "Sorry feeds are down for maintenance, please try again later. If this issue persists please check openvix.co.uk or world-of-satellite.com."
+msgstr "Sorry feeds are down for maintenance, please try again later. If this issue persists please check openvix.co.uk or world-of-satellite.com."
+
+msgid "Sorry feeds seem be in an unstable state, if you wish to use them please enable 'Allow unstable (experimental) updates' in \"Software update settings\"."
+msgstr "Sorry feeds seem be in an unstable state, if you wish to use them please enable 'Allow unstable (experimental) updates' in \"Software update settings\"."
+
+msgid "Sorry the feeds are down for maintenance"
+msgstr "Sorry the feeds are down for maintenance"
+
+msgid "Sorry the feeds seem to be in an unstable state, if you wish to use them please enable 'Allow unstable (experimental) updates' in \"Software update settings\"."
+msgstr "Sorry the feeds seem to be in an unstable state, if you wish to use them please enable 'Allow unstable (experimental) updates' in \"Software update settings\"."
+
+msgid "Sorry your Inadyn config is missing"
+msgstr "Sorry your Inadyn config is missing"
+
+msgid "Sorry your MiniDLNA config is missing"
+msgstr "Sorry your MiniDLNA config is missing"
+
+msgid "Sorry your uShare config is missing"
+msgstr "Sorry your uShare config is missing"
+
+#, python-format
+msgid "Sorry, %s has not been installed!"
+msgstr "Sorry, %s has not been installed!"
+
+msgid "Sorry, no backups found!"
+msgstr "Sorry, no backups found!"
+
+msgid "Sorry, no details available!"
+msgstr "Sorry, no details available!"
+
+msgid "Sorry, this tuner is in use."
+msgstr "Sorry, this tuner is in use."
+
+msgid ""
+"Sorry, your backup destination is not writeable.\n"
+"Please select a different one."
+msgstr ""
+"Sorry, your backup destination is not writeable.\n"
+"Please select a different one."
+
+msgid "Sort"
+msgstr "Sort"
+
+msgid "Sort EPG List"
+msgstr "Sort EPG List"
+
+msgid "Sort Trash by deletion time"
+msgstr "Sort Trash by deletion time"
+
+msgid "Sort by"
+msgstr "Sort by"
+
+msgid "Sort by default"
+msgstr "Sort by default"
+
+msgid "Sort list by"
+msgstr "Sort list by"
+
+msgid "Sort list to default and exit?"
+msgstr "Sort list to default and exit?"
+
+msgid "Sort list:"
+msgstr "Sort list:"
+
+msgid "Sort menu screens alphabetically"
+msgstr "Sort menu screens alphabetically"
+
+msgid "Sort plug-in browser alphabetically"
+msgstr "Sort plug-in browser alphabetically"
+
+msgid "Sort plugins list to default?"
+msgstr "Sort plugins list to default?"
+
+msgid "Sort setting screens alphabetically"
+msgstr "Sort setting screens alphabetically"
+
+msgid "Sound"
+msgstr "Sound"
+
+msgid "Sound carrier"
+msgstr "Sound carrier"
+
+msgid "Source request"
+msgstr "Source request"
+
+msgid "South"
+msgstr "South"
+
+msgid "Space used:"
+msgstr "Space used:"
+
+msgid "Spanish"
+msgstr "Spanish"
+
+msgid "Split preview mode"
+msgstr "Split preview mode"
+
+msgid "Splitscreen"
+msgstr "Splitscreen"
+
+msgid "Sports"
+msgstr "Sports"
+
+msgid "Standard"
+msgstr "Standard"
+
+msgid "Standart list"
+msgstr "Standart list"
+
+msgid "Standby"
+msgstr "Standby"
+
+msgid "Standby / restart"
+msgstr "Standby / restart"
+
+msgid "Standby and Restart"
+msgstr "Standby and Restart"
+
+msgid "StandbyLED"
+msgstr "StandbyLED"
+
+msgid "Start"
+msgstr "Start"
+
+msgid "Start from the beginning"
+msgstr "Start from the beginning"
+
+msgid "Start instant recording"
+msgstr "Start instant recording"
+
+msgid "Start offline decode"
+msgstr "Start offline decode"
+
+msgid "Start recording?"
+msgstr "Start recording?"
+
+msgid "Start teletext"
+msgstr "Start teletext"
+
+msgid "Start test"
+msgstr "Start test"
+
+msgid "Start time"
+msgstr "Start time"
+
+msgid "Start timeshift"
+msgstr "Start timeshift"
+
+msgid "Starting on"
+msgstr "Starting on"
+
+msgid "Status"
+msgstr "Status"
+
+msgid "Step east"
+msgstr "Step east"
+
+msgid "Step west"
+msgstr "Step west"
+
+msgid "Stepped east"
+msgstr "Stepped east"
+
+msgid "Stepped west"
+msgstr "Stepped west"
+
+msgid "Stop"
+msgstr "Stop"
+
+msgid "Stop PiP"
+msgstr "Stop PiP"
+
+msgid "Stop all current recordings"
+msgstr "Stop all current recordings"
+
+msgid "Stop and delete all current recordings"
+msgstr "Stop and delete all current recordings"
+
+msgid "Stop and delete recording"
+msgstr "Stop and delete recording"
+
+msgid "Stop and delete recording:"
+msgstr "Stop and delete recording:"
+
+msgid "Stop and delete recordings:"
+msgstr "Stop and delete recordings:"
+
+msgid "Stop current event and disable future events"
+msgstr "Stop current event and disable future events"
+
+msgid "Stop current event but not future events"
+msgstr "Stop current event but not future events"
+
+msgid "Stop entry"
+msgstr "Stop entry"
+
+msgid "Stop playing this movie?"
+msgstr "Stop playing this movie?"
+
+msgid "Stop previous broadcasted service on return to movie list."
+msgstr "Stop previous broadcasted service on return to movie list."
+
+msgid "Stop recording"
+msgstr "Stop recording"
+
+msgid "Stop recording and delete"
+msgstr "Stop recording and delete"
+
+msgid "Stop recording now"
+msgstr "Stop recording now"
+
+msgid "Stop recording:"
+msgstr "Stop recording:"
+
+msgid "Stop recordings:"
+msgstr "Stop recordings:"
+
+msgid "Stop service on return to movie list"
+msgstr "Stop service on return to movie list"
+
+msgid "Stop test"
+msgstr "Stop test"
+
+msgid "Stop testing plane after # failed transponders"
+msgstr "Stop testing plane after # failed transponders"
+
+msgid "Stop testing plane after # successful transponders"
+msgstr "Stop testing plane after # successful transponders"
+
+msgid "Stop timer recording"
+msgstr "Stop timer recording"
+
+msgid "Stop timeshift"
+msgstr "Stop timeshift"
+
+msgid "Stop timeshift while recording?"
+msgstr "Stop timeshift while recording?"
+
+msgid "Stop using as startup service"
+msgstr "Stop using as startup service"
+
+msgid "Stopped"
+msgstr "Stopped"
+
+msgid "Stops timeshift being used if a recording is in progress. (Advisable for USB sticks)"
+msgstr "Stops timeshift being used if a recording is in progress. (Advisable for USB sticks)"
+
+msgid "Storage devices"
+msgstr "Storage devices"
+
+msgid "Store at index"
+msgstr "Store at index"
+
+msgid "Store position"
+msgstr "Store position"
+
+msgid "Stored position"
+msgstr "Stored position"
+
+msgid "Stream"
+msgstr "Stream"
+
+msgid "Stream request"
+msgstr "Stream request"
+
+msgid "Stream-tv"
+msgstr "Stream-tv"
+
+msgid "Streaming"
+msgstr "Streaming"
+
+msgid "Streaming clients info"
+msgstr "Streaming clients info"
+
+msgid "Streaming port of the fallback remote receiver. By default this is '8001'"
+msgstr "Streaming port of the fallback remote receiver. By default this is '8001'"
+
+msgid "Strict DLNA"
+msgstr "Strict DLNA"
+
+msgid "Stripes"
+msgstr "Stripes"
+
+msgid "Strongest position"
+msgstr "Strongest position"
+
+msgid "Subnet"
+msgstr "Subnet"
+
+msgid "Subservices"
+msgstr "Subservices"
+
+msgid "Subtitle"
+msgstr "Subtitle"
+
+msgid "Subtitle Quickmenu"
+msgstr "Subtitle Quickmenu"
+
+msgid "Subtitle alignment"
+msgstr "Subtitle alignment"
+
+msgid "Subtitle border width"
+msgstr "Subtitle border width"
+
+msgid "Subtitle delay when timing is bad"
+msgstr "Subtitle delay when timing is bad"
+
+msgid "Subtitle delay when timing lacks"
+msgstr "Subtitle delay when timing lacks"
+
+msgid "Subtitle font size"
+msgstr "Subtitle font size"
+
+msgid "Subtitle language selection 1"
+msgstr "Subtitle language selection 1"
+
+msgid "Subtitle language selection 2"
+msgstr "Subtitle language selection 2"
+
+msgid "Subtitle language selection 3"
+msgstr "Subtitle language selection 3"
+
+msgid "Subtitle language selection 4"
+msgstr "Subtitle language selection 4"
+
+msgid "Subtitle position"
+msgstr "Subtitle position"
+
+msgid "Subtitle selection"
+msgstr "Subtitle selection"
+
+msgid "Subtitle selection..."
+msgstr "Subtitle selection..."
+
+msgid "Subtitle settings"
+msgstr "Subtitle settings"
+
+msgid "Subtitles"
+msgstr "Subtitles"
+
+msgid "Subtitles settings"
+msgstr "Subtitles settings"
+
+msgid "Sun"
+msgstr "Sun"
+
+msgid "Sunday"
+msgstr "Sunday"
+
+msgid "Support at"
+msgstr "Support at"
+
+msgid "Swap PIP"
+msgstr "Swap PIP"
+
+msgid "Swap PiP and main picture"
+msgstr "Swap PiP and main picture"
+
+msgid "Swap SNR in '%' with SNR in 'db'"
+msgstr "Swap SNR in '%' with SNR in 'db'"
+
+msgid "Swap services"
+msgstr "Swap services"
+
+msgid "Swedish"
+msgstr "Swedish"
+
+msgid "Switch TV to correct input"
+msgstr "Switch TV to correct input"
+
+msgid "Switch between filelist/playlist"
+msgstr "Switch between filelist/playlist"
+
+msgid "Switch config"
+msgstr "Switch config"
+
+msgid "Switch to HDMI in mode"
+msgstr "Switch to HDMI in mode"
+
+msgid "Switch to TV mode"
+msgstr "Switch to TV mode"
+
+msgid "Switch to filelist"
+msgstr "Switch to filelist"
+
+msgid "Switch to next sub service"
+msgstr "Switch to next sub service"
+
+msgid "Switch to playlist"
+msgstr "Switch to playlist"
+
+msgid "Switch to previous sub service"
+msgstr "Switch to previous sub service"
+
+msgid "Switch to radio mode"
+msgstr "Switch to radio mode"
+
+msgid "Switch to the next channel"
+msgstr "Switch to the next channel"
+
+msgid "Switch to the next channel in history"
+msgstr "Switch to the next channel in history"
+
+msgid "Switch to the previous channel"
+msgstr "Switch to the previous channel"
+
+msgid "Switch to the previous channel in history"
+msgstr "Switch to the previous channel in history"
+
+msgid "Switchable tuner types:"
+msgstr "Switchable tuner types:"
+
+msgid "Symbol rate"
+msgstr "Symbol rate"
+
+msgid "Symbolrate:"
+msgstr "Symbolrate:"
+
+msgid "Sync NTP every (minutes)"
+msgstr "Sync NTP every (minutes)"
+
+msgid "Sync failure moving back to origin !"
+msgstr "Sync failure moving back to origin !"
+
+msgid "Sync time using"
+msgstr "Sync time using"
+
+msgid "Synchronize system time using transponder or internet."
+msgstr "Synchronise system time using transponder or internet."
+
+msgid "System"
+msgstr "System"
+
+#, python-format
+msgid "System temperature: %s"
+msgstr "System temperature: %s"
+
+#, python-format
+msgid ""
+"System temperature: %s%sC\n"
+"\n"
+msgstr ""
+"System temperature: %s%sC\n"
+"\n"
+
+msgid "System: "
+msgstr "System: "
+
+msgid "TB"
+msgstr "TB"
+
+#. TRANSLATORS: Add here whatever should be shown in the "translator" about screen, up to 6 lines (use \n for newline)
+msgid "TRANSLATOR_INFO"
+msgstr "TRANSLATOR_INFO"
+
+msgid "TS file is too large for ISO9660 level 1!"
+msgstr "TS file is too large for ISO9660 level 1!"
+
+msgid "TSID"
+msgstr "TSID"
+
+msgid "TUNING"
+msgstr "TUNING"
+
+msgid "TV"
+msgstr "TV"
+
+msgid "TV physical address report"
+msgstr "TV physical address report"
+
+msgid "TXT PID"
+msgstr "TXT PID"
+
+msgid "Table of contents for collection"
+msgstr "Table of contents for collection"
+
+msgid "Tags"
+msgstr "Tags"
+
+msgid "Teletext"
+msgstr "Teletext"
+
+msgid "Teletext subtitle color"
+msgstr "Teletext subtitle color"
+
+msgid "Telnet Interface"
+msgstr "Telnet Interface"
+
+msgid "Telnet Port"
+msgstr "Telnet Port"
+
+msgid "Telnet Setup"
+msgstr "Telnet Setup"
+
+msgid "Telnet interface"
+msgstr "Telnet interface"
+
+msgid "Telnet port"
+msgstr "Telnet port"
+
+msgid "Telnet setup"
+msgstr "Telnet setup"
+
+msgid "Terrestrial"
+msgstr "Terrestrial"
+
+msgid "Terrestrial provider"
+msgstr "Terrestrial provider"
+
+msgid "Test DiSEqC settings"
+msgstr "Test DiSEqC settings"
+
+msgid "Test mode"
+msgstr "Test mode"
+
+#, python-format
+msgid "Test the network configuration of your %s %s.\n"
+msgstr "Test the network configuration of your %s %s.\n"
+
+msgid "Test type"
+msgstr "Test type"
+
+msgid "Testscreens"
+msgstr "Testscreens"
+
+msgid "Testscreens that are helpfull to fine-tune your display"
+msgstr "Testscreens that are helpfull to fine-tune your display"
+
+msgid "Text"
+msgstr "Text"
+
+msgid "Text color"
+msgstr "Text color"
+
+msgid "Thai"
+msgstr "Thai"
+
+msgid ""
+"Thank you for using the wizard.\n"
+"Please press OK to continue."
+msgstr ""
+"Thank you for using the wizard.\n"
+"Please press OK to continue."
+
+msgid ""
+"Thank you for using the wizard. Your %s %s is now ready to use.\n"
+"Please press OK to start using your %s %s."
+msgstr ""
+"Thank you for using the wizard. Your %s %s is now ready to use.\n"
+"Please press OK to start using your %s %s."
+
+msgid "The %s %s reads the stored EPG data every (hours)."
+msgstr "The %s %s reads the stored EPG data every (hours)."
+
+msgid "The %s %s stores the EPG data every (hours)."
+msgstr "The %s %s stores the EPG data every (hours)."
+
+msgid ""
+"The AutoTimer plugin is not installed!\n"
+"Please install it."
+msgstr ""
+"The AutoTimer plugin is not installed!\n"
+"Please install it."
+
+msgid ""
+"The Cool TV Guide plugin is not installed!\n"
+"Dont bother with it and use the default ViX EPG guide instead."
+msgstr ""
+"The Cool TV Guide plugin is not installed!\n"
+"Dont bother with it and use the default ViX EPG guide instead."
+
+#, python-format
+msgid "The DVD standard doesn't support H.264 (HDTV) video streams. Do you want to create a %s %s format data DVD (which will not play in stand-alone DVD players) instead?"
+msgstr "The DVD standard doesn't support H.264 (HDTV) video streams. Do you want to create a %s %s format data DVD (which will not play in stand-alone DVD players) instead?"
+
+msgid ""
+"The DreamPlex plugin is not installed!\n"
+"Please install it."
+msgstr ""
+"The DreamPlex plugin is not installed!\n"
+"Please install it."
+
+msgid ""
+"The EPGSearch plugin is not installed!\n"
+"Please install it."
+msgstr ""
+"The EPGSearch plugin is not installed!\n"
+"Please install it."
+
+msgid ""
+"The Filesystem on your Timeshift-Device does not support hardlinks.\n"
+"Make sure it is formatted in EXT2 or EXT3!"
+msgstr ""
+"The Filesystem on your Timeshift-Device does not support hardlinks.\n"
+"Make sure it is formatted in EXT2 or EXT3!"
+
+msgid ""
+"The IMDb plugin is not installed!\n"
+"Please install it."
+msgstr ""
+"The IMDb plugin is not installed!\n"
+"Please install it."
+
+msgid "The PIN code has been changed successfully."
+msgstr "The PIN code has been changed successfully."
+
+msgid "The PIN codes you entered are different."
+msgstr "The PIN codes you entered are different."
+
+msgid "The backup failed. Please choose a different backup location."
+msgstr "The backup failed. Please choose a different backup location."
+
+msgid "The current update may be unstable"
+msgstr "The current update may be unstable"
+
+#, python-format
+msgid ""
+"The directory %s is not a EXT2, EXT3, EXT4 or NFS partition.\n"
+"Make sure you select a valid partition type."
+msgstr ""
+"The directory %s is not a EXT2, EXT3, EXT4 or NFS partition.\n"
+"Make sure you select a valid partition type."
+
+#, python-format
+msgid ""
+"The directory %s is not writable.\n"
+"Make sure you select a writable directory instead."
+msgstr ""
+"The directory %s is not writable.\n"
+"Make sure you select a writable directory instead."
+
+msgid "The following files were found..."
+msgstr "The following files were found..."
+
+msgid "The loopthrough setting is wrong."
+msgstr "The loopthrough setting is wrong."
+
+msgid ""
+"The network wizard extension is not installed!\n"
+"Please install it."
+msgstr ""
+"The network wizard extension is not installed!\n"
+"Please install it."
+
+#, python-format
+msgid "The path %s already exists."
+msgstr "The path %s already exists."
+
+msgid "The pin code you entered is wrong."
+msgstr "The pin code you entered is wrong."
+
+#, python-format
+msgid "The results have been written to %s."
+msgstr "The results have been written to %s."
+
+msgid "The service has been added to the favourites."
+msgstr "The service has been added to the favourites."
+
+msgid "The service has been added to the selected bouquet."
+msgstr "The service has been added to the selected bouquet."
+
+msgid ""
+"The software management extension is not installed!\n"
+"Please install it."
+msgstr ""
+"The software management extension is not installed!\n"
+"Please install it."
+
+msgid "The timer file (pm_timers.xml) is corrupt and could not be loaded."
+msgstr "The timer file (pm_timers.xml) is corrupt and could not be loaded."
+
+msgid "The timer file (timers.xml) is corrupt and could not be loaded."
+msgstr "The timer file (timers.xml) is corrupt and could not be loaded."
+
+msgid ""
+"The unicable connection setting is wrong.\n"
+" Maybe recursive connection of tuners."
+msgstr ""
+"The unicable connection setting is wrong.\n"
+" Maybe recursive connection of tuners."
+
+#, python-format
+msgid "The user interface of your %s %s is restarting"
+msgstr "The user interface of your %s %s is restarting"
+
+#, python-format
+msgid ""
+"The user interface of your %s %s is restarting\n"
+"due to an error in mytest.py"
+msgstr ""
+"The user interface of your %s %s is restarting\n"
+"due to an error in mytest.py"
+
+msgid ""
+"The wireless LAN plugin is not installed!\n"
+"Please install it and choose what you want to do next."
+msgstr ""
+"The wireless LAN plugin is not installed!\n"
+"Please install it and choose what you want to do next."
+
+msgid ""
+"The wireless LAN plugin is not installed!\n"
+"Please install it."
+msgstr ""
+"The wireless LAN plugin is not installed!\n"
+"Please install it."
+
+msgid "The wizard can backup your current settings. Do you want to do a backup now?"
+msgstr "The wizard can backup your current settings. Do you want to do a backup now?"
+
+msgid "The wizard is finished now."
+msgstr "The wizard is finished now."
+
+msgid "There are at least "
+msgstr "There are at least "
+
+#, python-format
+msgid "There are at least %s updates available."
+msgstr "There are at least %s updates available."
+
+msgid "There are currently no outstanding actions."
+msgstr "There are currently no outstanding actions."
+
+msgid "There are no updates available."
+msgstr "There are no updates available."
+
+msgid "There has been an error, please try again later. If this issue persists, please check openvix.co.uk or world-of-satellite.com"
+msgstr "There has been an error, please try again later. If this issue persists, please check openvix.co.uk or world-of-satellite.com"
+
+msgid "There is no [webif] section in oscam.conf"
+msgstr "There is no [webif] section in oscam.conf"
+
+msgid "There is no signal to lock on !"
+msgstr "There is no signal to lock on !"
+
+msgid ""
+"There might not be enough space on the selected partition..\n"
+"Do you really want to continue?"
+msgstr ""
+"There might not be enough space on the selected partition..\n"
+"Do you really want to continue?"
+
+#, python-format
+msgid "This %s %s cannot decode %s streams!"
+msgstr "This %s %s cannot decode %s streams!"
+
+msgid "This DVD RW medium is already formatted - reformatting will erase all content on the disc."
+msgstr "This DVD RW medium is already formatted - reformatting will erase all content on the disc."
+
+msgid "This allows you change the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size"
+msgstr "This allows you change the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size"
+
+msgid "This allows you to change the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size"
+msgstr "This allows you to change the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size"
+
+msgid "This allows you to change the number of rows shown."
+msgstr "This allows you to change the number of rows shown."
+
+msgid "This can be either the IP or name of the fallback receiver, not including the scheme or port number (e.g. either 'xxx.xxx.xxx.xxx' or 'name_second_box')."
+msgstr "This can be either the IP or name of the fallback receiver, not including the scheme or port number (e.g. either 'xxx.xxx.xxx.xxx' or 'name_second_box')."
+
+msgid "This option allows to reduce the block-noise in the picture. Obviously this is at the cost of the picture's sharpness."
+msgstr "This option allows to reduce the block-noise in the picture. Obviously this is at the cost of the picture's sharpness."
+
+msgid "This option allows to set the level of dynamic contrast of the picture."
+msgstr "This option allows to set the level of dynamic contrast of the picture."
+
+msgid "This option allows you choose how to display elapsed time as + or -"
+msgstr "This option allows you choose how to display elapsed time as + or -"
+
+msgid "This option allows you choose how to display remaining time, or elapsed time, or both."
+msgstr "This option allows you choose how to display remaining time, or elapsed time, or both."
+
+msgid "This option allows you choose how to display the remaining/elapsed time for live TV."
+msgstr "This option allows you choose how to display the remaining/elapsed time for live TV."
+
+msgid "This option allows you choose the background color of transparent picons."
+msgstr "This option allows you choose the background color of transparent picons."
+
+msgid "This option allows you enable smoothing filter to control the dithering process."
+msgstr "This option allows you enable smoothing filter to control the dithering process."
+
+msgid "This option allows you enable the vertical scaler dejagging."
+msgstr "This option allows you enable the vertical scaler dejagging."
+
+msgid "This option allows you set the layout view (Text or Graphics)."
+msgstr "This option allows you set the layout view (Text or Graphics)."
+
+msgid "This option allows you to boost the blue tones in the picture."
+msgstr "This option allows you to boost the blue tones in the picture."
+
+msgid "This option allows you to boost the green tones in the picture."
+msgstr "This option allows you to boost the green tones in the picture."
+
+msgid "This option allows you to bypass HDMI EDID check"
+msgstr "This option allows you to bypass HDMI EDID check"
+
+msgid "This option allows you to change the Colorspace from Auto to RGB"
+msgstr "This option allows you to change the Colorspace from Auto to RGB"
+
+msgid "This option allows you to change the virtual loudspeaker position."
+msgstr "This option allows you to change the virtual loudspeaker position."
+
+msgid "This option allows you to choose from the two channel lists that are available."
+msgstr "This option allows you to choose from the two channel lists that are available."
+
+msgid "This option allows you to choose how to display 1080p 24Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "This option allows you to choose how to display 1080p 24Hz on your TV. (as not all TV's support these resolutions)"
+
+msgid "This option allows you to choose how to display 1080p 25Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "This option allows you to choose how to display 1080p 25Hz on your TV. (as not all TV's support these resolutions)"
+
+msgid "This option allows you to choose how to display 1080p 30Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "This option allows you to choose how to display 1080p 30Hz on your TV. (as not all TV's support these resolutions)"
+
+msgid "This option allows you to choose how to display 2160p 24Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "This option allows you to choose how to display 2160p 24Hz on your TV. (as not all TV's support these resolutions)"
+
+msgid "This option allows you to choose how to display 2160p 25Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "This option allows you to choose how to display 2160p 25Hz on your TV. (as not all TV's support these resolutions)"
+
+msgid "This option allows you to choose how to display 2160p 30Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "This option allows you to choose how to display 2160p 30Hz on your TV. (as not all TV's support these resolutions)"
+
+msgid "This option allows you to choose how to display 720p 24Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "This option allows you to choose how to display 720p 24Hz on your TV. (as not all TV's support these resolutions)"
+
+msgid "This option allows you to choose how to display SD progressive 24Hz on your TV. (as not all TV's support these resolutions)"
+msgstr "This option allows you to choose how to display SD progressive 24Hz on your TV. (as not all TV's support these resolutions)"
+
+msgid "This option allows you to choose how to display elapsed time. As + or -"
+msgstr "This option allows you to choose how to display elapsed time. As + or -"
+
+msgid "This option allows you to choose how to display standard defintion video on your TV."
+msgstr "This option allows you to choose how to display standard defintion video on your TV."
+
+msgid "This option allows you to choose how to display the remaining/elapsed time for Media playback."
+msgstr "This option allows you to choose how to display the remaining/elapsed time for Media playback."
+
+msgid "This option allows you to choose how to display the remaining/elapsed time for live TV."
+msgstr "This option allows you to choose how to display the remaining/elapsed time for live TV."
+
+msgid "This option allows you to choose how to display the remaining/elapsed time for media playback."
+msgstr "This option allows you to choose how to display the remaining/elapsed time for media playback."
+
+msgid "This option allows you to choose what the first button press jumps to in channel list screen, (so pressing '2' jumps to 'A' or '2' first), when 'Quick Actions' preset actions are perfomed. "
+msgstr "This option allows you to choose what the first button press jumps to in channel list screen, (so pressing '2' jumps to 'A' or '2' first), when 'Quick Actions' preset actions are perfomed. "
+
+msgid "This option allows you to disable sorting of the menus"
+msgstr "This option allows you to disable sorting of the menus"
+
+msgid "This option allows you to disable sorting of the option in setting screens"
+msgstr "This option allows you to disable sorting of the option in setting screens"
+
+msgid "This option allows you to disable sorting of the plugin browser."
+msgstr "This option allows you to disable sorting of the plugin browser."
+
+msgid "This option allows you to enable 3D Surround Sound for an output."
+msgstr "This option allows you to enable 3D Surround Sound for an output."
+
+msgid "This option allows you to power on or off the display."
+msgstr "This option allows you to power on or off the display."
+
+msgid "This option allows you to set the layout view (Text or Graphics)."
+msgstr "This option allows you to set the layout view (Text or Graphics)."
+
+msgid "This option allows you to show the SNR as a percentage (not all receivers support this)."
+msgstr "This option allows you to show the SNR as a percentage (not all receivers support this)."
+
+msgid "This option allows you to show the full menu path"
+msgstr "This option allows you to show the full menu path"
+
+msgid "This option allows you to view the old and new settings side by side."
+msgstr "This option allows you to view the old and new settings side by side."
+
+msgid "This option configures output for Auto Volume Level."
+msgstr "This option configures output for Auto Volume Level."
+
+msgid "This option configures the general audio delay of Dolby Digital sound tracks."
+msgstr "This option configures the general audio delay of Dolby Digital sound tracks."
+
+msgid "This option configures the general audio delay of stereo sound tracks."
+msgstr "This option configures the general audio delay of stereo sound tracks."
+
+msgid "This option configures the screen resolution in PC output mode."
+msgstr "This option configures the screen resolution in PC output mode."
+
+msgid "This option configures the video output mode (or resolution)."
+msgstr "This option configures the video output mode (or resolution)."
+
+msgid "This option lets you adjust the 3D depth"
+msgstr "This option lets you adjust the 3D depth"
+
+msgid "This option lets you adjust the transparency of the user interface"
+msgstr "This option lets you adjust the transparency of the user interface"
+
+msgid "This option lets you choose the 3D mode"
+msgstr "This option lets you choose the 3D mode"
+
+msgid "This option lets you show the option in the extension screen"
+msgstr "This option lets you show the option in the extension screen"
+
+msgid "This option moves the PVR status from the separate window into the Movie Player infobar."
+msgstr "This option moves the PVR status from the separate window into the Movie Player infobar."
+
+msgid "This option set the level of surpression of musquito noise (Musquito Noise is random aliasing as a result of strong compression). Obviously this goes at the cost of picture details."
+msgstr "This option set the level of surpression of musquito noise (Musquito Noise is random aliasing as a result of strong compression). Obviously this goes at the cost of picture details."
+
+msgid "This option sets  the picture contrast."
+msgstr "This option sets  the picture contrast."
+
+msgid "This option sets the picture brightness."
+msgstr "This option sets the picture brightness."
+
+msgid "This option sets the picture color space."
+msgstr "This option sets the picture color space."
+
+msgid "This option sets the picture flesh tones."
+msgstr "This option sets the picture flesh tones."
+
+msgid "This option sets the picture hue."
+msgstr "This option sets the picture hue."
+
+msgid "This option sets the picture saturation."
+msgstr "This option sets the picture saturation."
+
+msgid "This option sets the scaler sharpness, used when stretching picture from 4:3 to 16:9."
+msgstr "This option sets the scaler sharpness, used when stretching picture from 4:3 to 16:9."
+
+msgid "This option sets the surpression of false digital contours, that are the result of a limited number of discrete values."
+msgstr "This option sets the surpression of false digital contours, that are the result of a limited number of discrete values."
+
+msgid "This option sets up the picture sharpness, used when the picture is being upscaled."
+msgstr "This option sets up the picture sharpness, used when the picture is being upscaled."
+
+msgid "This plugin is installed."
+msgstr "This plugin is installed."
+
+msgid "This plugin is not installed."
+msgstr "This plugin is not installed."
+
+msgid "This plugin will be installed."
+msgstr "This plugin will be installed."
+
+msgid "This plugin will be removed."
+msgstr "This plugin will be removed."
+
+msgid ""
+"This test checks for configured nameservers.\n"
+"If you get a \"unconfirmed\" message:\n"
+"- please check your DHCP server, cabling and adapter setup\n"
+"- if you configured your nameservers manually please verify your entries in the \"Nameserver\" configuration"
+msgstr ""
+"This test checks for configured nameservers.\n"
+"If you get a \"unconfirmed\" message:\n"
+"- please check your DHCP server, cabling and adapter setup\n"
+"- if you configured your nameservers manually please verify your entries in the \"Nameserver\" configuration"
+
+msgid ""
+"This test checks whether a network cable is connected to your LAN adapter.\n"
+"If you get a \"disconnected\" message:\n"
+"- verify that a network cable is attached\n"
+"- verify that the cable is not broken"
+msgstr ""
+"This test checks whether a network cable is connected to your LAN adapter.\n"
+"If you get a \"disconnected\" message:\n"
+"- verify that a network cable is attached\n"
+"- verify that the cable is not broken"
+
+msgid ""
+"This test checks whether a valid IP address is found for your LAN adapter.\n"
+"If you get a \"unconfirmed\" message:\n"
+"- no valid IP address was found\n"
+"- please check your DHCP server, cabling and adapter setup"
+msgstr ""
+"This test checks whether a valid IP address is found for your LAN adapter.\n"
+"If you get a \"unconfirmed\" message:\n"
+"- no valid IP address was found\n"
+"- please check your DHCP server, cabling and adapter setup"
+
+msgid ""
+"This test checks whether your LAN adapter is set up for automatic IP address configuration with DHCP.\n"
+"If you get a \"disabled\" message:\n"
+" - then your LAN adapter is configured for manual IP setup\n"
+"- verify thay you have entered correct IP informations in the adapter setup dialog.\n"
+"If you get an \"enabled\" message:\n"
+"-verify that you have a configured and working DHCP server in your network."
+msgstr ""
+"This test checks whether your LAN adapter is set up for automatic IP address configuration with DHCP.\n"
+"If you get a \"disabled\" message:\n"
+" - then your LAN adapter is configured for manual IP setup\n"
+"- verify thay you have entered correct IP informations in the adapter setup dialog.\n"
+"If you get an \"enabled\" message:\n"
+"-verify that you have a configured and working DHCP server in your network."
+
+msgid "This test detects your configured LAN adapter."
+msgstr "This test detects your configured LAN adapter."
+
+msgid ""
+"This will (re-)calculate all positions of your rotor and may remove previously memorised positions and fine-tuning!\n"
+"Are you sure?"
+msgstr ""
+"This will (re-)calculate all positions of your rotor and may remove previously memorised positions and fine-tuning!\n"
+"Are you sure?"
+
+msgid "Three"
+msgstr "Three"
+
+msgid "Threshold"
+msgstr "Threshold"
+
+msgid "Thu"
+msgstr "Thu"
+
+msgid "Thumbnails"
+msgstr "Thumbnails"
+
+msgid "Thursday"
+msgstr "Thursday"
+
+msgid "TiVo support"
+msgstr "TiVo support"
+
+msgid "Time"
+msgstr "Time"
+
+msgid "Time Update in Minutes:"
+msgstr "Time Update in Minutes:"
+
+msgid "Time scale"
+msgstr "Time scale"
+
+msgid "Time settings"
+msgstr "Time settings"
+
+msgid "Time to execute command or script"
+msgstr "Time to execute command or script"
+
+msgid "Time update in minutes"
+msgstr "Time update in minutes"
+
+msgid "Timeline 24 Hour"
+msgstr "Timeline 24 Hour"
+
+msgid "Timeline font size"
+msgstr "Timeline font size"
+
+msgid "Timer"
+msgstr "Timer"
+
+msgid "Timer List"
+msgstr "Timer List"
+
+msgid "Timer entry"
+msgstr "Timer entry"
+
+msgid ""
+"Timer overlap in pm_timers.xml detected!\n"
+"Please recheck it!"
+msgstr ""
+"Timer overlap in pm_timers.xml detected!\n"
+"Please recheck it!"
+
+msgid ""
+"Timer overlap in timers.xml detected!\n"
+"Please recheck it!"
+msgstr ""
+"Timer overlap in timers.xml detected!\n"
+"Please recheck it!"
+
+msgid "Timer record location"
+msgstr "Timer record location"
+
+msgid "Timer recording location"
+msgstr "Timer recording location"
+
+msgid "Timer sanity error"
+msgstr "Timer sanity error"
+
+msgid "Timer selection"
+msgstr "Timer selection"
+
+msgid "Timer selection..."
+msgstr "Timer selection..."
+
+msgid "Timer type"
+msgstr "Timer type"
+
+msgid "Timers"
+msgstr "Timers"
+
+msgid "Timeshift"
+msgstr "Timeshift"
+
+msgid "Timeshift is running. Select an action.\n"
+msgstr "Timeshift is running. Select an action.\n"
+
+msgid "Timeshift location"
+msgstr "Timeshift location"
+
+msgid "Timeshift not possible!"
+msgstr "Timeshift not possible!"
+
+msgid "Timeshift on a stream is not supported!"
+msgstr "Timeshift on a stream is not supported!"
+
+msgid "Timeshift save failed!"
+msgstr "Timeshift save failed!"
+
+msgid "Timeshift save recording (Select event)"
+msgstr "Timeshift save recording (Select event)"
+
+msgid "Timeshift save recording (stop after current event)"
+msgstr "Timeshift save recording (stop after current event)"
+
+msgid "Timeshift saved to your harddisk!"
+msgstr "Timeshift saved to your harddisk!"
+
+msgid "Timeshift settings"
+msgstr "Timeshift settings"
+
+msgid "Timeshift will get saved at the end of an event!"
+msgstr "Timeshift will get saved at the end of an event!"
+
+msgid "Timeshift-save action on zap"
+msgstr "Timeshift-save action on zap"
+
+msgid "Timezone"
+msgstr "Timezone"
+
+msgid "Title"
+msgstr "Title"
+
+msgid "Title properties"
+msgstr "Title properties"
+
+msgid "Titleset mode"
+msgstr "Titleset mode"
+
+msgid "Today"
+msgstr "Today"
+
+msgid "Toggle Digital downmix..."
+msgstr "Toggle Digital downmix..."
+
+msgid "Toggle HDMI-In PiP"
+msgstr "Toggle HDMI-In PiP"
+
+msgid "Toggle HDMI-In full screen"
+msgstr "Toggle HDMI-In full screen"
+
+msgid "Toggle LCD LiveTV"
+msgstr "Toggle LCD LiveTV"
+
+msgid "Toggle PIP-ZAP"
+msgstr "Toggle PIP-ZAP"
+
+msgid "Toggle Picture In Graphics"
+msgstr "Toggle Picture In Graphics"
+
+msgid "Toggle a cut mark at the current position"
+msgstr "Toggle a cut mark at the current position"
+
+msgid "Toggle aspect ratio..."
+msgstr "Toggle aspect ratio..."
+
+msgid "Toggle between bouquet/epg lists"
+msgstr "Toggle between bouquet/epg lists"
+
+msgid "Tone amplitude"
+msgstr "Tone amplitude"
+
+msgid "Tone mode"
+msgstr "Tone mode"
+
+msgid "Toneburst"
+msgstr "Toneburst"
+
+msgid "Toneburst A/B"
+msgstr "Toneburst A/B"
+
+msgid "Top and Bottom"
+msgstr "Top and Bottom"
+
+msgid "Total"
+msgstr "Total"
+
+msgid "Total cards:"
+msgstr "Total cards:"
+
+#, python-format
+msgid "Total clients streaming: %d (%s)"
+msgstr "Total clients streaming: %d (%s)"
+
+msgid "Total handled client ecm's"
+msgstr "Total handled client ecm's"
+
+msgid "Total handled client emm's"
+msgstr "Total handled client emm's"
+
+msgid "Total memory:"
+msgstr "Total memory:"
+
+msgid "Total swap:"
+msgstr "Total swap:"
+
+msgid "Total:"
+msgstr "Total:"
+
+msgid "Track"
+msgstr "Track"
+
+msgid "Transcoding: "
+msgstr "Transcoding: "
+
+msgid "Translations"
+msgstr "Translations"
+
+msgid "Transmission mode"
+msgstr "Transmission mode"
+
+msgid "Transparent"
+msgstr "Transparent"
+
+msgid "Transponder"
+msgstr "Transponder"
+
+msgid "Transponder Information"
+msgstr "Transponder Information"
+
+msgid "Transponder type"
+msgstr "Transponder type"
+
+msgid "Trash can"
+msgstr "Trash can"
+
+msgid "Trashcan:"
+msgstr "Trashcan:"
+
+msgid "Tries left:"
+msgstr "Tries left:"
+
+msgid "Try to find used transponders in cable network.. please wait..."
+msgstr "Try to find used transponders in cable network.. please wait..."
+
+msgid "Try to find used transponders in terrestrial network... please wait..."
+msgstr "Try to find used transponders in terrestrial network... please wait..."
+
+msgid "Trying to download a new packetlist. Please wait..."
+msgstr "Trying to download a new packetlist. Please wait..."
+
+msgid "Tue"
+msgstr "Tue"
+
+msgid "Tuesday"
+msgstr "Tuesday"
+
+msgid "Tune"
+msgstr "Tune"
+
+msgid "Tune and focus"
+msgstr "Tune and focus"
+
+msgid "Tune failed!"
+msgstr "Tune failed!"
+
+msgid "Tuner"
+msgstr "Tuner"
+
+msgid "Tuner :"
+msgstr "Tuner :"
+
+msgid "Tuner configuration"
+msgstr "Tuner configuration"
+
+msgid "Tuner is not supported"
+msgstr "Tuner is not supported"
+
+msgid "Tuner not available."
+msgstr "Tuner not available."
+
+msgid "Tuner settings"
+msgstr "Tuner settings"
+
+msgid "Tuner slot"
+msgstr "Tuner slot"
+
+msgid "Tuner status"
+msgstr "Tuner status"
+
+msgid "Tuner status:"
+msgstr "Tuner status:"
+
+msgid "Tuner type"
+msgstr "Tuner type"
+
+msgid "Tuning algorithm"
+msgstr "Tuning algorithm"
+
+msgid "Turkish"
+msgstr "Turkish"
+
+msgid "Turn off HDMI-IN PiP mode"
+msgstr "Turn off HDMI-IN PiP mode"
+
+msgid "Turn off HDMI-IN full screen mode"
+msgstr "Turn off HDMI-IN full screen mode"
+
+msgid "Turn on HDMI-IN PiP mode"
+msgstr "Turn on HDMI-IN PiP mode"
+
+msgid "Turn on HDMI-IN full screen mode"
+msgstr "Turn on HDMI-IN full screen mode"
+
+msgid "Turn on the power LED during standby."
+msgstr "Turn on the power LED during standby."
+
+msgid "Turning step size"
+msgstr "Turning step size"
+
+msgid "Two"
+msgstr "Two"
+
+msgid "Two lines"
+msgstr "Two lines"
+
+msgid "Type"
+msgstr "Type"
+
+msgid "Type of scan"
+msgstr "Type of scan"
+
+msgid "Type: "
+msgstr "Type: "
+
+msgid "USALS"
+msgstr "USALS"
+
+msgid "USALS Calibration"
+msgstr "USALS Calibration"
+
+msgid "Ukrainian"
+msgstr "Ukrainian"
+
+msgid "Unattended upgrade without GUI and reboot system"
+msgstr "Unattended upgrade without GUI and reboot system"
+
+msgid "Undetermined"
+msgstr "Undetermined"
+
+msgid "Undo install"
+msgstr "Undo install"
+
+msgid "Undo uninstall"
+msgstr "Undo uninstall"
+
+msgid "Unencrypted"
+msgstr "Unencrypted"
+
+msgid "Unhide parental control services"
+msgstr "Unhide parental control services"
+
+msgid "Unicable / JESS"
+msgstr "Unicable / JESS"
+
+msgid "Unicable LNB"
+msgstr "Unicable LNB"
+
+msgid "Unicable Matrix"
+msgstr "Unicable Matrix"
+
+msgid "Uninstall"
+msgstr "Uninstall"
+
+msgid "Universal LNB"
+msgstr "Universal LNB"
+
+msgid "Unknown"
+msgstr "Unknown"
+
+msgid "Unmark service as a dedicated 3D service"
+msgstr "Unmark service as a dedicated 3D service"
+
+msgid "Unmount"
+msgstr "Unmount"
+
+msgid "Unsupported"
+msgstr "Unsupported"
+
+msgid "Up"
+msgstr "Up"
+
+msgid "Update"
+msgstr "Update"
+
+msgid "Update channel list only"
+msgstr "Update channel list only"
+
+#, python-format
+msgid "Update completed, %d package was installed."
+msgid_plural "Update completed, %d packages were installed."
+msgstr[0] "Update completed, %d package was installed."
+msgstr[1] "Update completed, %d packages were installed."
+
+#, python-format
+msgid "Update failed. Your %s %s does not have a working internet connection."
+msgstr "Update failed. Your %s %s does not have a working internet connection."
+
+msgid "Update interval (in seconds)"
+msgstr "Update interval (in seconds)"
+
+msgid "Updatefeed not available."
+msgstr "Updatefeed not available."
+
+msgid "Updating software catalog"
+msgstr "Updating software catalog"
+
+msgid "Upgrade and reboot system"
+msgstr "Upgrade and reboot system"
+
+msgid "Upgrade finished."
+msgstr "Upgrade finished."
+
+#, python-format
+msgid ""
+"Upgrade in progress\n"
+"Please wait until your %s %s reboots\n"
+"This may take a few minutes"
+msgstr ""
+"Upgrade in progress\n"
+"Please wait until your %s %s reboots\n"
+"This may take a few minutes"
+
+msgid "Upgrading"
+msgstr "Upgrading"
+
+msgid "Uphops +"
+msgstr "Uphops +"
+
+msgid "Uphops -"
+msgstr "Uphops -"
+
+msgid "Uphops: "
+msgstr "Uphops: "
+
+msgid "Uptime"
+msgstr "Uptime"
+
+msgid "Usage setup"
+msgstr "Usage setup"
+
+msgid "Use"
+msgstr "Use"
+
+msgid "Use DHCP"
+msgstr "Use DHCP"
+
+msgid "Use EIT EPG information when it is available."
+msgstr "Use EIT EPG information when it is available."
+
+msgid "Use FreeSat EPG information when it is available."
+msgstr "Use FreeSat EPG information when it is available."
+
+msgid "Use MHW EPG information when it is available."
+msgstr "Use MHW EPG information when it is available."
+
+msgid "Use Netmed EPG information when it is available."
+msgstr "Use Netmed EPG information when it is available."
+
+msgid "Use TV remote control"
+msgstr "Use TV remote control"
+
+msgid "Use USALS for this sat"
+msgstr "Use USALS for this sat"
+
+msgid "Use ViaSat EPG information when it is available."
+msgstr "Use ViaSat EPG information when it is available."
+
+msgid "Use Virgin EPG information when it is available."
+msgstr "Use Virgin EPG information when it is available."
+
+msgid "Use a gateway"
+msgstr "Use a gateway"
+
+msgid "Use circular LNB"
+msgstr "Use circular LNB"
+
+msgid "Use fastscan channel names"
+msgstr "Use fastscan channel names"
+
+msgid "Use fastscan channel numbering"
+msgstr "Use fastscan channel numbering"
+
+msgid "Use frequency or channel"
+msgstr "Use frequency or channel"
+
+msgid "Use individual settings for each directory"
+msgstr "Use individual settings for each directory"
+
+msgid "Use interface"
+msgstr "Use interface"
+
+msgid "Use official channel numbering"
+msgstr "Use official channel numbering"
+
+msgid "Use original DVB subtitle position"
+msgstr "Use original DVB subtitle position"
+
+msgid "Use original teletext position"
+msgstr "Use original teletext position"
+
+msgid "Use power measurement"
+msgstr "Use power measurement"
+
+msgid "Use slim screen"
+msgstr "Use slim screen"
+
+msgid "Use the Left/Right buttons on your remote to adjust the size of the user interface. Left button decreases the size, Right increases the size."
+msgstr "Use the Left/Right buttons on your remote to adjust the size of the user interface. Left button decreases the size, Right increases the size."
+
+msgid "Use the Left/Right buttons on your remote to move the user interface left/right"
+msgstr "Use the Left/Right buttons on your remote to move the user interface left/right"
+
+msgid "Use the Left/Right buttons on your remote to move the user interface up/down"
+msgstr "Use the Left/Right buttons on your remote to move the user interface up/down"
+
+msgid "Use the alternative or the conventional radio mode."
+msgstr "Use the alternative or the conventional radio mode."
+
+msgid "Use the alternative screen"
+msgstr "Use the alternative screen"
+
+msgid ""
+"Use the deletion time to sort Trash folders.\n"
+"Most recently deleted at the top."
+msgstr ""
+"Use the deletion time to sort Trash folders.\n"
+"Most recently deleted at the top."
+
+msgid "Use the network wizard to configure selected network adapter"
+msgstr "Use the network wizard to configure selected network adapter"
+
+msgid "Use the network wizard to configure your Network\n"
+msgstr "Use the network wizard to configure your Network\n"
+
+msgid "Use the up/down keys on your remote control to select an option. After that, press OK."
+msgstr "Use the up/down keys on your remote control to select an option. After that, press OK."
+
+msgid "Use the wizard to set up basic features"
+msgstr "Use the wizard to set up basic features"
+
+msgid "Use these input device settings?"
+msgstr "Use these input device settings?"
+
+msgid "Use these settings?"
+msgstr "Use these settings?"
+
+msgid "Use this video enhancement settings?"
+msgstr "Use this video enhancement settings?"
+
+msgid "Use timeshift seekbar while timeshifting?"
+msgstr "Use timeshift seekbar while timeshifting?"
+
+msgid "Use trash can in movie list"
+msgstr "Use trash can in movie list"
+
+msgid "Used service scan type"
+msgstr "Used service scan type"
+
+msgid "Used:"
+msgstr "Used:"
+
+msgid "User - bouquets"
+msgstr "User - bouquets"
+
+msgid "User defined"
+msgstr "User defined"
+
+msgid "User defined transponder"
+msgstr "User defined transponder"
+
+msgid "User interface"
+msgstr "User interface"
+
+msgid "User interface settings"
+msgstr "User interface settings"
+
+msgid "User interface visibility"
+msgstr "User interface visibility"
+
+msgid "Username"
+msgstr "Username"
+
+msgid "Username (httpuser)"
+msgstr "Username (httpuser)"
+
+msgid "Username:"
+msgstr "Username:"
+
+#, python-format
+msgid "Using LNB %d"
+msgstr "Using LNB %d"
+
+msgid "Using fixed address"
+msgstr "Using fixed address"
+
+msgid "Using old profile: "
+msgstr "Using old profile: "
+
+#, python-format
+msgid "Using tuner %s"
+msgstr "Using tuner %s"
+
+msgid "Usually when the subtitle language is the same as the audio language, the subtitles will not be used. Enable this option to allow these subtitles to be used."
+msgstr "Usually when the subtitle language is the same as the audio language, the subtitles will not be used. Enable this option to allow these subtitles to be used."
+
+msgid "VCR scart"
+msgstr "VCR scart"
+
+msgid "VMGM (intro trailer)"
+msgstr "VMGM (intro trailer)"
+
+msgid "VU+"
+msgstr "VU+"
+
+msgid "Version: "
+msgstr "Version: "
+
+#, python-format
+msgid "Version: %s"
+msgstr "Version: %s"
+
+msgid "Vertical"
+msgstr "Vertical"
+
+msgid "Vertical turning speed"
+msgstr "Vertical turning speed"
+
+msgid "ViX EPG"
+msgstr "ViX EPG"
+
+msgid "Video Enhancement Settings"
+msgstr "Video Enhancement Settings"
+
+msgid "Video PID"
+msgstr "Video PID"
+
+#, python-format
+msgid "Video content: %ix%i%s %iHz"
+msgstr "Video content: %ix%i%s %iHz"
+
+msgid "Video enhancement preview"
+msgstr "Video enhancement preview"
+
+msgid "Video enhancement setup"
+msgstr "Video enhancement setup"
+
+msgid ""
+"Video input selection\n"
+"\n"
+"Please press OK if you can see this page on your TV (or select a different input port).\n"
+"\n"
+"The next input port will be automatically probed in 20 seconds."
+msgstr ""
+"Video input selection\n"
+"\n"
+"Please press OK if you can see this page on your TV (or select a different input port).\n"
+"\n"
+"The next input port will be automatically probed in 20 seconds."
+
+msgid "Video mode selection."
+msgstr "Video mode selection."
+
+#, python-format
+msgid "Video mode: %s"
+msgstr "Video mode: %s"
+
+msgid "Video output"
+msgstr "Video output"
+
+#, python-format
+msgid "Video: %s fps"
+msgstr "Video: %s fps"
+
+msgid "Videocodec"
+msgstr "Videocodec"
+
+msgid "Videoformat"
+msgstr "Videoformat"
+
+msgid "Videomode"
+msgstr "Videomode"
+
+msgid "Videosize"
+msgstr "Videosize"
+
+msgid "View"
+msgstr "View"
+
+msgid "View Movies..."
+msgstr "View Movies..."
+
+msgid "View Rass interactive..."
+msgstr "View Rass interactive..."
+
+msgid "View Video CD..."
+msgstr "View Video CD..."
+
+msgid "View details"
+msgstr "View details"
+
+msgid "View extensions..."
+msgstr "View extensions..."
+
+msgid "View list of available "
+msgstr "View list of available "
+
+msgid "View list of available CommonInterface extensions"
+msgstr "View list of available CommonInterface extensions"
+
+msgid "View list of available EPG extensions."
+msgstr "View list of available EPG extensions."
+
+msgid "View list of available Satellite equipment extensions."
+msgstr "View list of available Satellite equipment extensions."
+
+msgid "View list of available communication extensions."
+msgstr "View list of available communication extensions."
+
+msgid "View list of available default settings"
+msgstr "View list of available default settings"
+
+msgid "View list of available display and userinterface extensions."
+msgstr "View list of available display and userinterface extensions."
+
+msgid "View list of available multimedia extensions."
+msgstr "View list of available multimedia extensions."
+
+msgid "View list of available networking extensions"
+msgstr "View list of available networking extensions"
+
+msgid "View list of available recording extensions"
+msgstr "View list of available recording extensions"
+
+msgid "View list of available skins"
+msgstr "View list of available skins"
+
+msgid "View list of available software extensions"
+msgstr "View list of available software extensions"
+
+msgid "View list of available system extensions"
+msgstr "View list of available system extensions"
+
+msgid "View mode"
+msgstr "View mode"
+
+msgid "View photos..."
+msgstr "View photos..."
+
+msgid "View teletext..."
+msgstr "View teletext..."
+
+msgid "View the changes"
+msgstr "View the changes"
+
+msgid "View video CD..."
+msgstr "View video CD..."
+
+msgid "Virtuosso Image Xtreme"
+msgstr "Virtuosso Image Xtreme"
+
+msgid "Visual impaired commentary"
+msgstr "Visual impaired commentary"
+
+msgid "Vix forum user name"
+msgstr "Vix forum user name"
+
+msgid "Voltage mode"
+msgstr "Voltage mode"
+
+msgid "W"
+msgstr "W"
+
+msgid "WARNING: feeds may be unstable."
+msgstr "WARNING: feeds may be unstable."
+
+msgid "WEP"
+msgstr "WEP"
+
+msgid "WLAN connection"
+msgstr "WLAN connection"
+
+msgid "WPA"
+msgstr "WPA"
+
+msgid "WPA or WPA2"
+msgstr "WPA or WPA2"
+
+msgid "WPA2"
+msgstr "WPA2"
+
+msgid "WSS on 4:3"
+msgstr "WSS on 4:3"
+
+msgid "Waiting"
+msgstr "Waiting"
+
+msgid "Waiting for mount"
+msgstr "Waiting for mount"
+
+msgid "Waiting for partition"
+msgstr "Waiting for partition"
+
+msgid "Wake Up"
+msgstr "Wake Up"
+
+msgid "Wake Up To Standby"
+msgstr "Wake Up To Standby"
+
+msgid "Wakeup"
+msgstr "Wakeup"
+
+msgid "Wakeup TV from standby"
+msgstr "Wakeup TV from standby"
+
+msgid "Wakeup signal from TV"
+msgstr "Wakeup signal from TV"
+
+#, python-format
+msgid "Wakeup your %s %s from standby"
+msgstr "Wakeup your %s %s from standby"
+
+msgid "Warning"
+msgstr "Warning"
+
+msgid "Warning: no LNB; using factory defaults."
+msgstr "Warning: no LNB; using factory defaults."
+
+msgid "Watch movies..."
+msgstr "Watch movies..."
+
+msgid "Watch recordings..."
+msgstr "Watch recordings..."
+
+msgid "Web Interface"
+msgstr "Web Interface"
+
+msgid "Web interface"
+msgstr "Web interface"
+
+msgid "Wed"
+msgstr "Wed"
+
+msgid "Wednesday"
+msgstr "Wednesday"
+
+msgid "Weekday"
+msgstr "Weekday"
+
+msgid "Weekend"
+msgstr "Weekend"
+
+msgid "Weekly"
+msgstr "Weekly"
+
+msgid "Weighted position"
+msgstr "Weighted position"
+
+msgid ""
+"Welcome to the cutlist editor.\n"
+"\n"
+"Seek to the start of the stuff you want to cut away. Press OK, select 'start cut'.\n"
+"\n"
+"Then seek to the end, press OK, select 'end cut'. That's it."
+msgstr ""
+"Welcome to the cutlist editor.\n"
+"\n"
+"Seek to the start of the stuff you want to cut away. Press OK, select 'start cut'.\n"
+"\n"
+"Then seek to the end, press OK, select 'end cut'. That's it."
+
+msgid "Welcome to the image upgrade wizard. The wizard will assist you in upgrading the firmware of your %s %s by providing a backup facility for your current settings and a short explanation of how to upgrade your firmware."
+msgstr "Welcome to the image upgrade wizard. The wizard will assist you in upgrading the firmware of your %s %s by providing a backup facility for your current settings and a short explanation of how to upgrade your firmware."
+
+msgid ""
+"Welcome.\n"
+"\n"
+"If you want to connect your %s %s to the Internet, this wizard will guide you through the basic network setup of your %s %s.\n"
+"\n"
+"Press OK to start configuring your network"
+msgstr ""
+"Welcome.\n"
+"\n"
+"If you want to connect your %s %s to the Internet, this wizard will guide you through the basic network setup of your %s %s.\n"
+"\n"
+"Press OK to start configuring your network"
+
+msgid ""
+"Welcome.\n"
+"\n"
+"This start wizard will guide you through the basic setup of your %s %s.\n"
+"Press the OK button on your remote control to move to the next step."
+msgstr ""
+"Welcome.\n"
+"\n"
+"This start wizard will guide you through the basic setup of your %s %s.\n"
+"Press the OK button on your remote control to move to the next step."
+
+msgid "West"
+msgstr "West"
+
+msgid "West limit set"
+msgstr "West limit set"
+
+msgid "What Day of week ?"
+msgstr "What Day of week ?"
+
+msgid "What action is required on completion of the timer? 'Auto' lets the box return to the state it had when the timer started. 'Do nothing', 'Go to standby' and 'Go to deep standby' do exactly that."
+msgstr "What action is required on completion of the timer? 'Auto' lets the box return to the state it had when the timer started. 'Do nothing', 'Go to standby' and 'Go to deep standby' do exactly that."
+
+msgid "What date of month ?"
+msgstr "What date of month ?"
+
+msgid "What do you want to scan?"
+msgstr "What do you want to scan?"
+
+msgid "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+msgstr "When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded"
+
+msgid "When enabled the LNB power will not be switched off in standby"
+msgstr "When enabled the LNB power will not be switched off in standby"
+
+msgid "When enabled the LNB toneburst will be forced"
+msgstr "When enabled the LNB toneburst will be forced"
+
+msgid "When enabled the online checker will also check for experimental versions"
+msgstr "When enabled the online checker will also check for experimental versions"
+
+msgid "When enabled, AIT data will be included in http streams. This allows a client receiver to use HbbTV."
+msgstr "When enabled, AIT data will be included in http streams. This allows a client receiver to use HbbTV."
+
+msgid "When enabled, EIT data will be included in http streams. This allows a client receiver to show EPG."
+msgstr "When enabled, EIT data will be included in http streams. This allows a client receiver to show EPG."
+
+msgid "When enabled, a popup message will be shown when a movie has finished and the next one will start."
+msgstr "When enabled, a popup message will be shown when a movie has finished and the next one will start."
+
+msgid "When enabled, a popup message will be shown when a recording starts."
+msgstr "When enabled, a popup message will be shown when a recording starts."
+
+msgid "When enabled, a recording is allowed to interrupt live TV, when there are no free tuners."
+msgstr "When enabled, a recording is allowed to interrupt live TV, when there are no free tuners."
+
+msgid "When enabled, a warning will be displayed and the user will get an option to stop or to continue the timeshift."
+msgstr "When enabled, a warning will be displayed and the user will get an option to stop or to continue the timeshift."
+
+msgid "When enabled, a warning will be displayed that timeshift is not supported in an IP stream.."
+msgstr "When enabled, a warning will be displayed that timeshift is not supported in an IP stream.."
+
+msgid "When enabled, always descramble receiving http streams. This takes up more resources (descrambling demuxers), only enable if necessary. Individual streams are always descrambled if 0x100 is added to the service type, regardless of this setting. Default off."
+msgstr "When enabled, always descramble receiving http streams. This takes up more resources (descrambling demuxers), only enable if necessary. Individual streams are always descrambled if 0x100 is added to the service type, regardless of this setting. Default off."
+
+msgid "When enabled, authentication is required to watch http streams."
+msgstr "When enabled, authentication is required to watch http streams."
+
+msgid "When enabled, channel numbering will start at '1' for every bouquet."
+msgstr "When enabled, channel numbering will start at '1' for every bouquet."
+
+msgid "When enabled, content with an aspect ratio of 4:3 will be stretched to fit the screen."
+msgstr "When enabled, content with an aspect ratio of 4:3 will be stretched to fit the screen."
+
+msgid "When enabled, continue to the next bouquet when the last channel of the current bouquet is reached."
+msgstr "When enabled, continue to the next bouquet when the last channel of the current bouquet is reached."
+
+msgid "When enabled, deleted recordings are moved to the trash can, instead of being deleted immediately."
+msgstr "When enabled, deleted recordings are moved to the trash can, instead of being deleted immediately."
+
+msgid "When enabled, external subtitles will always be turned on for movie playback."
+msgstr "When enabled, external subtitles will always be turned on for movie playback."
+
+msgid "When enabled, graphical DVB subtitles are preferred over teletext subtitles, when both types are available."
+msgstr "When enabled, graphical DVB subtitles are preferred over teletext subtitles, when both types are available."
+
+msgid "When enabled, graphical DVB subtitles will be centered horizontally."
+msgstr "When enabled, graphical DVB subtitles will be centered horizontally."
+
+msgid "When enabled, graphical DVB subtitles will be displayed at their original position."
+msgstr "When enabled, graphical DVB subtitles will be displayed at their original position."
+
+msgid "When enabled, graphical DVB subtitles will be displayed in yellow, instead of the original color."
+msgstr "When enabled, graphical DVB subtitles will be displayed in yellow, instead of the original color."
+
+msgid "When enabled, http streams are descrambled on the server side. The (remote) client receiver does not have to do descrambling. Default on."
+msgstr "When enabled, http streams are descrambled on the server side. The (remote) client receiver does not have to do descrambling. Default on."
+
+msgid "When enabled, it is possible to leave the Movie Player with exit."
+msgstr "When enabled, it is possible to leave the Movie Player with exit."
+
+msgid "When enabled, measure power consumption to detect when the rotor stops turning (when supported by the tuner)."
+msgstr "When enabled, measure power consumption to detect when the rotor stops turning (when supported by the tuner)."
+
+msgid "When enabled, network trash cans are probed for cleaning."
+msgstr "When enabled, network trash cans are probed for cleaning."
+
+msgid "When enabled, pressing '0' will zap you to the first channel in your first bouquet and delete your zap-history."
+msgstr "When enabled, pressing '0' will zap you to the first channel in your first bouquet and delete your zap-history."
+
+msgid "When enabled, reformat subtitles to match the width of the screen."
+msgstr "When enabled, reformat subtitles to match the width of the screen."
+
+msgid "When enabled, show channel numbers in the channel selection screen."
+msgstr "When enabled, show channel numbers in the channel selection screen."
+
+msgid "When enabled, subtitles for the hearing impaired can be used."
+msgstr "When enabled, subtitles for the hearing impaired can be used."
+
+msgid "When enabled, subtitles for the hearing impaired will be preferred over normal subtitles, when both types are available."
+msgstr "When enabled, subtitles for the hearing impaired will be preferred over normal subtitles, when both types are available."
+
+msgid "When enabled, teletext pages will be cached, allowing faster access."
+msgstr "When enabled, teletext pages will be cached, allowing faster access."
+
+msgid "When enabled, teletext subtitles will be displayed at their original position."
+msgstr "When enabled, teletext subtitles will be displayed at their original position."
+
+msgid "When enabled, the PiP can be closed by the EXIT button."
+msgstr "When enabled, the PiP can be closed by the EXIT button."
+
+msgid "When enabled, the VCR scart option will be shown in the main menu"
+msgstr "When enabled, the VCR scart option will be shown in the main menu"
+
+msgid "When enabled, the length of each recording will be shown in the movielist (this might cause some additional loading time)."
+msgstr "When enabled, the length of each recording will be shown in the movielist (this might cause some additional loading time)."
+
+msgid "When enabled, the receiver will automatically use the audio track which you selected before."
+msgstr "When enabled, the receiver will automatically use the audio track which you selected before."
+
+msgid "When enabled, the receiver will automatically use the subtitles which you selected before."
+msgstr "When enabled, the receiver will automatically use the subtitles which you selected before."
+
+msgid "When enabled, the receiver will select an AC3 track (when available)."
+msgstr "When enabled, the receiver will select an AC3 track (when available)."
+
+msgid "When enabled, the receiver will select an AC3+ track (when available)."
+msgstr "When enabled, the receiver will select an AC3+ track (when available)."
+
+msgid "When enabled, this setting has more weight than 'Preferred tuner for recordings'."
+msgstr "When enabled, this setting has more weight than 'Preferred tuner for recordings'."
+
+msgid "When enabled, this setting has more weight than 'Preferred tuner'."
+msgstr "When enabled, this setting has more weight than 'Preferred tuner'."
+
+msgid "When enabled, timeshift starts automatically in background after the specified time."
+msgstr "When enabled, timeshift starts automatically in background after the specified time."
+
+msgid "When enabled, use DHCP for the IP configuration."
+msgstr "When enabled, use DHCP for the IP configuration."
+
+msgid "When enabled, your receiver will detect activity on the VCR SCART input."
+msgstr "When enabled, your receiver will detect activity on the VCR SCART input."
+
+msgid "When maximum space for all logs is reached, the oldest logs will be deleted."
+msgstr "When maximum space for all logs is reached, the oldest logs will be deleted."
+
+msgid "When nonzero, a recording will start earlier than the starting time indicated by the EPG."
+msgstr "When nonzero, a recording will start earlier than the starting time indicated by the EPG."
+
+msgid "When nonzero, a recording will stop later than the ending time indicated by the EPG."
+msgstr "When nonzero, a recording will stop later than the ending time indicated by the EPG."
+
+msgid "When set the PIG will return to live after a movie has stopped playing."
+msgstr "When set the PIG will return to live after a movie has stopped playing."
+
+msgid "When set, each folder will show the previous state used. When off, the default values will be shown."
+msgstr "When set, each folder will show the previous state used. When off, the default values will be shown."
+
+msgid "When the content has an aspect ratio of 16:9, choose whether to scale/stretch the picture."
+msgstr "When the content has an aspect ratio of 16:9, choose whether to scale/stretch the picture."
+
+msgid "When the content has an aspect ratio of 4:3, choose whether to scale/stretch the picture."
+msgstr "When the content has an aspect ratio of 4:3, choose whether to scale/stretch the picture."
+
+msgid "When tuned to a service the system will normally scan the transponder for any changes and save them. Only set to 'yes' if you're absolutely sure of what you're doing."
+msgstr "When tuned to a service the system will normally scan the transponder for any changes and save them. Only set to 'yes' if you're absolutely sure of what you're doing."
+
+#, python-format
+msgid ""
+"When you perform a factory reset, you will lose ALL of your configuration data\n"
+"(including bouquets, services, satellite data ...)\n"
+"After completion of the factory reset, your %s %s will restart automatically!\n"
+"\n"
+"Do you really want to do a factory reset?"
+msgstr ""
+"When you perform a factory reset, you will lose ALL of your configuration data\n"
+"(including bouquets, services, satellite data ...)\n"
+"After completion of the factory reset, your %s %s will restart automatically!\n"
+"\n"
+"Do you really want to do a factory reset?"
+
+msgid "When you use the remote fallback tuner for recording, the timer conflict detection can't properly detect conflicts. This option allows you to turn off the timer confict detection. This setting is only for advanced users; the default is 'yes'."
+msgstr "When you use the remote fallback tuner for recording, the timer conflict detection can't properly detect conflicts. This option allows you to turn off the timer confict detection. This setting is only for advanced users; the default is 'yes'."
+
+msgid "Where do you want to backup your settings?"
+msgstr "Where do you want to backup your settings?"
+
+msgid "Where should the recording be saved?"
+msgstr "Where should the recording be saved?"
+
+msgid "Where to save temporary timeshift recordings?"
+msgstr "Where to save temporary timeshift recordings?"
+
+msgid "Which event do you want to save permanently?"
+msgstr "Which event do you want to save permanently?"
+
+msgid "White"
+msgstr "White"
+
+msgid "Width"
+msgstr "Width"
+
+msgid "Wireless LAN"
+msgstr "Wireless LAN"
+
+msgid "Wireless network"
+msgstr "Wireless network"
+
+msgid "Wireless network configuration..."
+msgstr "Wireless network configuration..."
+
+msgid "Wireless network connection setup"
+msgstr "Wireless network connection setup"
+
+msgid "Wireless network connection setup."
+msgstr "Wireless network connection setup."
+
+msgid "Wireless network state"
+msgstr "Wireless network state"
+
+msgid "With popup"
+msgstr "With popup"
+
+msgid "With this option set to 'yes' the channel list will always show you the list of bouquets. If set to 'no' the current bouquet will be opened."
+msgstr "With this option set to 'yes' the channel list will always show you the list of bouquets. If set to 'no' the current bouquet will be opened."
+
+msgid "With this option you can hide Job Tasks from the extension screen (short blue button press)."
+msgstr "With this option you can hide Job Tasks from the extension screen (short blue button press)."
+
+msgid "Without popup"
+msgstr "Without popup"
+
+msgid "Write error while recording. Disk full?\n"
+msgstr "Write error while recording. Disk full?\n"
+
+#, python-format
+msgid ""
+"Write error while recording. Disk full?\n"
+"%s"
+msgstr ""
+"Write error while recording. Disk full?\n"
+"%s"
+
+msgid "Write failed!"
+msgstr "Write failed!"
+
+msgid "Write to /tmp/positionersetup.log"
+msgstr "Write to /tmp/positionersetup.log"
+
+msgid "XBox 360 support"
+msgstr "XBox 360 support"
+
+msgid "XP1000"
+msgstr "XP1000"
+
+msgid "YES"
+msgstr "YES"
+
+msgid "YPbPr"
+msgstr "YPbPr"
+
+msgid "Year"
+msgstr "Year"
+
+msgid "Yellow"
+msgstr "Yellow"
+
+msgid "Yellow DVB subtitles"
+msgstr "Yellow DVB subtitles"
+
+msgid "Yellow long"
+msgstr "Yellow long"
+
+msgid "Yes"
+msgstr "Yes"
+
+msgid "Yes (save index in setup tuner)"
+msgstr "Yes (save index in setup tuner)"
+
+msgid "Yes to all"
+msgstr "Yes to all"
+
+msgid "Yes, always"
+msgstr "Yes, always"
+
+msgid "Yes, and delete this movie"
+msgstr "Yes, and delete this movie"
+
+msgid "Yes, and return to the movie list"
+msgstr "Yes, and return to the movie list"
+
+msgid "Yes, backup my settings!"
+msgstr "Yes, backup my settings!"
+
+msgid "Yes, but don't save timeshift as movie"
+msgstr "Yes, but don't save timeshift as movie"
+
+msgid "Yes, but save timeshift as movie and continue recording"
+msgstr "Yes, but save timeshift as movie and continue recording"
+
+msgid "Yes, but save timeshift as movie and stop recording"
+msgstr "Yes, but save timeshift as movie and stop recording"
+
+msgid "Yes, delete this movie and return to the movie list"
+msgstr "Yes, delete this movie and return to the movie list"
+
+msgid "Yes, do a manual scan now"
+msgstr "Yes, do a manual scan now"
+
+msgid "Yes, do an automatic scan now"
+msgstr "Yes, do an automatic scan now"
+
+msgid "Yes, do another manual scan now"
+msgstr "Yes, do another manual scan now"
+
+msgid "Yes, restore the settings now"
+msgstr "Yes, restore the settings now"
+
+msgid "Yes, show delete time"
+msgstr "Yes, show delete time"
+
+msgid "Yes, show record time"
+msgstr "Yes, show record time"
+
+msgid "Yes, shut down now."
+msgstr "Yes, shut down now."
+
+msgid "Yesterday"
+msgstr "Yesterday"
+
+#, python-format
+msgid ""
+"You already have a bootlogo installed,\n"
+"would you like to remove\n"
+"\"%s\"?"
+msgstr ""
+"You already have a bootlogo installed,\n"
+"would you like to remove\n"
+"\"%s\"?"
+
+#, python-format
+msgid ""
+"You already have a channel list installed,\n"
+"would you like to remove\n"
+"\"%s\"?"
+msgstr ""
+"You already have a channel list installed,\n"
+"would you like to remove\n"
+"\"%s\"?"
+
+msgid "You can Display MiniTV with or without OSD Menu"
+msgstr "You can Display MiniTV with or without OSD Menu"
+
+msgid "You can Display PIP with or without OSD Menu"
+msgstr "You can Display PIP with or without OSD Menu"
+
+msgid "You can cancel the installation."
+msgstr "You can cancel the installation."
+
+msgid "You can cancel the removal."
+msgstr "You can cancel the removal."
+
+msgid "You can continue watching TV while this is running."
+msgstr "You can continue watching TV while this is running."
+
+msgid "You can have the list sorted by time or alphanumerical."
+msgstr "You can have the list sorted by time or alphanumerical."
+
+msgid "You can install this plugin."
+msgstr "You can install this plugin."
+
+#, python-format
+msgid "You can only burn %s %s recordings!"
+msgstr "You can only burn %s %s recordings!"
+
+msgid "You can remove this plugin."
+msgstr "You can remove this plugin."
+
+msgid "You cannot delete this!"
+msgstr "You cannot delete this!"
+
+msgid "You didn't select a channel to record from."
+msgstr "You didn't select a channel to record from."
+
+msgid "You have already sent this log, are you sure you want to resend it?\n"
+msgstr "You have already sent this log, are you sure you want to resend it?\n"
+
+msgid "You have chosen to backup your settings. Please press OK to start the backup now."
+msgstr "You have chosen to backup your settings. Please press OK to start the backup now."
+
+msgid "You have chosen to restore your settings. Enigma2 will restart after restore. Please press OK to start the restore now."
+msgstr "You have chosen to restore your settings. Enigma2 will restart after restore. Please press OK to start the restore now."
+
+msgid ""
+"You have chosen to save the current timeshift event, but the event has not yet finished\n"
+"What do you want to do ?"
+msgstr ""
+"You have chosen to save the current timeshift event, but the event has not yet finished\n"
+"What do you want to do ?"
+
+msgid "You have not selected any logs to delete."
+msgstr "You have not selected any logs to delete."
+
+msgid "You have not selected any logs to send"
+msgstr "You have not selected any logs to send"
+
+msgid ""
+"You have not setup your user info in the setup screen\n"
+"Press MENU, enter your info, and then try again"
+msgstr ""
+"You have not setup your user info in the setup screen\n"
+"Press MENU, enter your info, and then try again"
+
+#, python-format
+msgid "You have to wait %s!"
+msgstr "You have to wait %s!"
+
+#, python-format
+msgid "You must switch to the service %s (%s - '%s')!\n"
+msgstr "You must switch to the service %s (%s - '%s')!\n"
+
+msgid ""
+"You need a PC connected to your %s %s. If you need further instructions, please visit the website http://www.dm7025.de.\n"
+"Your %s %s will now be halted. After you have performed the update instructions from the website, your new firmware will ask you to restore your settings."
+msgstr ""
+"You need a PC connected to your %s %s. If you need further instructions, please visit the website http://www.dm7025.de.\n"
+"Your %s %s will now be halted. After you have performed the update instructions from the website, your new firmware will ask you to restore your settings."
+
+msgid "You seem to be in timeshft, the service will briefly stop as timeshift stops."
+msgstr "You seem to be in timeshft, the service will briefly stop as timeshift stops."
+
+msgid "You seem to be in timeshift!"
+msgstr "You seem to be in timeshift!"
+
+msgid "You seem to be in timeshift, Do you want to leave timeshift ?"
+msgstr "You seem to be in timeshift, Do you want to leave timeshift ?"
+
+msgid "You system does not support ext4"
+msgstr "You system does not support ext4"
+
+#, python-format
+msgid "Your %s %s does not support PiP HD"
+msgstr "Your %s %s does not support PiP HD"
+
+#, python-format
+msgid "Your %s %s has no network access, please check your network settings and make sure you have network cable connected and try again."
+msgstr "Your %s %s has no network access, please check your network settings and make sure you have network cable connected and try again."
+
+#, python-format
+msgid "Your %s %s is not connected to the internet, please check your network settings and try again."
+msgstr "Your %s %s is not connected to the internet, please check your network settings and try again."
+
+#, python-format
+msgid ""
+"Your %s %s is now ready to be used.\n"
+"\n"
+"Your internet connection is working now.\n"
+"\n"
+msgstr ""
+"Your %s %s is now ready to be used.\n"
+"\n"
+"Your internet connection is working now.\n"
+"\n"
+
+msgid ""
+"Your %s %s is now ready to use.\n"
+"\n"
+"Your internet connection is working now.\n"
+"\n"
+"Please press OK to continue."
+msgstr ""
+"Your %s %s is now ready to use.\n"
+"\n"
+"Your internet connection is working now.\n"
+"\n"
+"Please press OK to continue."
+
+#, python-format
+msgid "Your %s %s is rebooting"
+msgstr "Your %s %s is rebooting"
+
+#, python-format
+msgid "Your %s %s is shutting down"
+msgstr "Your %s %s is shutting down"
+
+msgid "Your %s %s is shutting down. Please wait..."
+msgstr "Your %s %s is shutting down. Please wait..."
+
+#, python-format
+msgid "Your %s %s might be unusable now. Please consult the manual for further assistance before rebooting your %s %s."
+msgstr "Your %s %s might be unusable now. Please consult the manual for further assistance before rebooting your %s %s."
+
+#, python-format
+msgid ""
+"Your %s %s will be restarted after the installation of service.\n"
+"\n"
+"Do you want to install now ?"
+msgstr ""
+"Your %s %s will be restarted after the installation of service.\n"
+"\n"
+"Do you want to install now ?"
+
+#, python-format
+msgid ""
+"Your %s %s will be restarted after the installation of the service\n"
+"Are you ready to install \"%s\" ?"
+msgstr ""
+"Your %s %s will be restarted after the installation of the service\n"
+"Are you ready to install \"%s\" ?"
+
+#, python-format
+msgid ""
+"Your %s %s will be restarted after the removal of service\n"
+"Do you want to remove now ?"
+msgstr ""
+"Your %s %s will be restarted after the removal of service\n"
+"Do you want to remove now ?"
+
+#, python-format
+msgid ""
+"Your %s %s will be restarted after the removal of the service\n"
+"Do you want to remove the service now ?"
+msgstr ""
+"Your %s %s will be restarted after the removal of the service\n"
+"Do you want to remove the service now ?"
+
+msgid "Your STB will restart after pressing OK on your remote control."
+msgstr "Your STB will restart after pressing OK on your remote control."
+
+msgid "Your backup succeeded. We will now continue to explain the further upgrade process."
+msgstr "Your backup succeeded. We will now continue to explain the further upgrade process."
+
+msgid "Your collection exceeds the size of a single layer medium, you will need a blank dual layer DVD!"
+msgstr "Your collection exceeds the size of a single layer medium, you will need a blank dual layer DVD!"
+
+#, python-format
+msgid ""
+"Your config file is not well formed:\n"
+"%s"
+msgstr ""
+"Your config file is not well formed:\n"
+"%s"
+
+msgid "Your current collection will get lost!"
+msgstr "Your current collection will get lost!"
+
+msgid ""
+"Your frontprocessor firmware must be upgraded.\n"
+"Press OK to start upgrade."
+msgstr ""
+"Your frontprocessor firmware must be upgraded.\n"
+"Press OK to start upgrade."
+
+#, python-format
+msgid ""
+"Your frontprocessor will be upgraded\n"
+"Please wait until your %s %s reboots\n"
+"This may take a few minutes"
+msgstr ""
+"Your frontprocessor will be upgraded\n"
+"Please wait until your %s %s reboots\n"
+"This may take a few minutes"
+
+msgid ""
+"Your internet connection is not working!\n"
+"Please choose what you want to do next."
+msgstr ""
+"Your internet connection is not working!\n"
+"Please choose what you want to do next."
+
+#, python-format
+msgid "Your internet connection is working (ip: %s)"
+msgstr "Your internet connection is working (ip: %s)"
+
+msgid "Your network configuration has been activated."
+msgstr "Your network configuration has been activated."
+
+msgid "Your network has finished restarting"
+msgstr "Your network has finished restarting"
+
+msgid "Your network is restarting, Please wait..."
+msgstr "Your network is restarting, Please wait..."
+
+msgid "Your receiver does not have an internet connection"
+msgstr "Your receiver does not have an internet connection"
+
+msgid "Your receiver is not connected to the internet"
+msgstr "Your receiver is not connected to the internet"
+
+msgid ""
+"Your wireless LAN internet connection could not be started!\n"
+"Have you attached your USB WLAN Stick?\n"
+"\n"
+"Please choose what you want to do next."
+msgstr ""
+"Your wireless LAN internet connection could not be started!\n"
+"Have you attached your USB WLAN Stick?\n"
+"\n"
+"Please choose what you want to do next."
+
+msgid "Zap"
+msgstr "Zap"
+
+msgid "Zap + Exit"
+msgstr "Zap + Exit"
+
+msgid "Zap back to previously tuned service?"
+msgstr "Zap back to previously tuned service?"
+
+msgid "Zap back to service before positioner setup?"
+msgstr "Zap back to service before positioner setup?"
+
+msgid "Zap back to service before tuner setup?"
+msgstr "Zap back to service before tuner setup?"
+
+msgid "Zap down"
+msgstr "Zap down"
+
+msgid "Zap focus to Picture in Picture"
+msgstr "Zap focus to Picture in Picture"
+
+msgid "Zap focus to main screen"
+msgstr "Zap focus to main screen"
+
+msgid "Zap mode"
+msgstr "Zap mode"
+
+msgid "Zap to"
+msgstr "Zap to"
+
+msgid "Zap to channel (setup in menu)"
+msgstr "Zap to channel (setup in menu)"
+
+msgid "Zap to channel and close (setup in menu)"
+msgstr "Zap to channel and close (setup in menu)"
+
+msgid "Zap up"
+msgstr "Zap up"
+
+msgid "Zoom In/Out TV..."
+msgstr "Zoom In/Out TV..."
+
+msgid "Zoom Off..."
+msgstr "Zoom Off..."
+
+msgid "Zoom from left"
+msgstr "Zoom from left"
+
+msgid "Zoom from right"
+msgstr "Zoom from right"
+
+msgid "[TimeShift] Restarting Timeshift!"
+msgstr "[TimeShift] Restarting Timeshift!"
+
+msgid "[Timeshift] Merging records failed!"
+msgstr "[Timeshift] Merging records failed!"
+
+msgid "[alternative edit]"
+msgstr "[alternative edit]"
+
+msgid "[bouquet edit]"
+msgstr "[bouquet edit]"
+
+msgid "[favourite edit]"
+msgstr "[favourite edit]"
+
+msgid "[move mode]"
+msgstr "[move mode]"
+
+msgid "a gui to assign services/providers to common interface modules"
+msgstr "a gui to assign services/providers to common interface modules"
+
+msgid "a gui to assign services/providers/caids to common interface modules"
+msgstr "a gui to assign services/providers/caids to common interface modules"
+
+msgid "about to start"
+msgstr "about to start"
+
+msgid "activatePiP"
+msgstr "activatePiP"
+
+msgid "add bookmark"
+msgstr "add bookmark"
+
+msgid "address:"
+msgstr "address:"
+
+msgid "adult movie/drama"
+msgstr "adult movie/drama"
+
+msgid "advanced"
+msgstr "advanced"
+
+msgid "adventure/western/war"
+msgstr "adventure/western/war"
+
+msgid "advertisement/shopping"
+msgstr "advertisement/shopping"
+
+msgid "alpha then oldest"
+msgstr "alpha then oldest"
+
+msgid "alphabetic"
+msgstr "alphabetic"
+
+msgid "alphabetic reverse"
+msgstr "alphabetic reverse"
+
+msgid "alpharev then newest"
+msgstr "alpharev then newest"
+
+msgid "alternative"
+msgstr "alternative"
+
+msgid "am"
+msgstr "am"
+
+msgid "and never ask again this session"
+msgstr "and never ask again this session"
+
+msgid "are you sure you want to cancel all the changes"
+msgstr "are you sure you want to cancel all the changes"
+
+msgid "arts/culture (without music, general)"
+msgstr "arts/culture (without music, general)"
+
+msgid "arts/culture magazine"
+msgstr "arts/culture magazine"
+
+msgid "as plugin in extended bar"
+msgstr "as plugin in extended bar"
+
+msgid "at beginning"
+msgstr "at beginning"
+
+msgid "at end"
+msgstr "at end"
+
+msgid "athletics"
+msgstr "athletics"
+
+msgid "audio tracks"
+msgstr "audio tracks"
+
+msgid "auto"
+msgstr "auto"
+
+msgid "auto deepstandby"
+msgstr "auto deepstandby"
+
+msgid "auto standby"
+msgstr "auto standby"
+
+msgid "automatic"
+msgstr "automatic"
+
+msgid "back"
+msgstr "back"
+
+msgid "background image"
+msgstr "background image"
+
+msgid "ballet"
+msgstr "ballet"
+
+#, python-format
+msgid "bc%s"
+msgstr "bc%s"
+
+msgid "better"
+msgstr "better"
+
+msgid "black"
+msgstr "black"
+
+msgid "black & white"
+msgstr "black & white"
+
+msgid "blacklist"
+msgstr "blacklist"
+
+msgid "blue"
+msgstr "blue"
+
+msgid "broadcasting/press"
+msgstr "broadcasting/press"
+
+msgid "by date"
+msgstr "by date"
+
+msgid "caid:"
+msgstr "caid:"
+
+msgid "card"
+msgstr "card"
+
+msgid "card reader"
+msgstr "card reader"
+
+msgid "cartoon/puppets"
+msgstr "cartoon/puppets"
+
+msgid "center"
+msgstr "center"
+
+msgid "chapters"
+msgstr "chapters"
+
+msgid "childrens's/youth program (general)"
+msgstr "childrens's/youth program (general)"
+
+msgid "circular left"
+msgstr "circular left"
+
+msgid "circular right"
+msgstr "circular right"
+
+msgid "close share view"
+msgstr "close share view"
+
+msgid "comedy"
+msgstr "comedy"
+
+msgid "confirmed"
+msgstr "confirmed"
+
+msgid "connected"
+msgstr "connected"
+
+msgid "cooking"
+msgstr "cooking"
+
+msgid "copy"
+msgstr "copy"
+
+msgid "create directory"
+msgstr "create directory"
+
+msgid "daily"
+msgstr "daily"
+
+msgid "day"
+msgstr "day"
+
+msgid "decrease uphop by 1"
+msgstr "decrease uphop by 1"
+
+msgid "delete"
+msgstr "delete"
+
+msgid "delete cut"
+msgstr "delete cut"
+
+msgid "delete time - show delete time (Trash ONLY)"
+msgstr "delete time - show delete time (Trash ONLY)"
+
+msgid "delete time - show record time (Trash ONLY)"
+msgstr "delete time - show record time (Trash ONLY)"
+
+msgid "descramble and record ecm"
+msgstr "descramble and record ecm"
+
+msgid "detective/thriller"
+msgstr "detective/thriller"
+
+msgid "disable"
+msgstr "disable"
+
+msgid "disabled"
+msgstr "disabled"
+
+msgid "disconnected"
+msgstr "disconnected"
+
+msgid "discussion/interview/debate"
+msgstr "discussion/interview/debate"
+
+msgid "do nothing"
+msgstr "do nothing"
+
+msgid "documentary"
+msgstr "documentary"
+
+msgid "don't descramble, record ecm"
+msgstr "don't descramble, record ecm"
+
+msgid "done!"
+msgstr "done!"
+
+msgid "e-mail address"
+msgstr "e-mail address"
+
+msgid "east"
+msgstr "east"
+
+msgid "ecm time:"
+msgstr "ecm time:"
+
+msgid "ecm.info"
+msgstr "ecm.info"
+
+msgid "economics/social advisory"
+msgstr "economics/social advisory"
+
+msgid "education/science/factual topics (general)"
+msgstr "education/science/factual topics (general)"
+
+msgid "empty"
+msgstr "empty"
+
+msgid "enable"
+msgstr "enable"
+
+msgid "enabled"
+msgstr "enabled"
+
+msgid "end cut here"
+msgstr "end cut here"
+
+msgid "ene"
+msgstr "ene"
+
+msgid "enter number to jump to channel."
+msgstr "enter number to jump to channel."
+
+msgid "entertainment (10-16 year old)"
+msgstr "entertainment (10-16 year old)"
+
+msgid "entertainment (6-14 year old)"
+msgstr "entertainment (6-14 year old)"
+
+msgid "epg cache backup"
+msgstr "epg cache backup"
+
+msgid "equal to"
+msgstr "equal to"
+
+msgid "equestrian"
+msgstr "equestrian"
+
+msgid "error starting scanning"
+msgstr "error starting scanning"
+
+msgid "error while scanning"
+msgstr "error while scanning"
+
+msgid "ese"
+msgstr "ese"
+
+msgid "et4000"
+msgstr "et4000"
+
+msgid "et5000/6000"
+msgstr "et5000/6000"
+
+msgid "et8000/et10000"
+msgstr "et8000/et10000"
+
+msgid "et9000/et9100"
+msgstr "et9000/et9100"
+
+msgid "et9200/9500/6500"
+msgstr "et9200/9500/6500"
+
+msgid "exit DVD player or return to file browser"
+msgstr "exit DVD player or return to file browser"
+
+msgid "experimental film/video"
+msgstr "experimental film/video"
+
+msgid "extensions."
+msgstr "extensions."
+
+msgid "extra wide"
+msgstr "extra wide"
+
+msgid "failed"
+msgstr "failed"
+
+msgid "false"
+msgstr "false"
+
+msgid "fashion"
+msgstr "fashion"
+
+msgid "fast"
+msgstr "fast"
+
+msgid "fileformats (BMP, PNG, JPG, GIF)"
+msgstr "fileformats (BMP, PNG, JPG, GIF)"
+
+msgid "filename"
+msgstr "filename"
+
+msgid "film/cinema"
+msgstr "film/cinema"
+
+msgid "fine arts"
+msgstr "fine arts"
+
+msgid "fitness & health"
+msgstr "fitness & health"
+
+msgid "flat alphabetic"
+msgstr "flat alphabetic"
+
+msgid "flat alphabetic reverse"
+msgstr "flat alphabetic reverse"
+
+msgid "folk/traditional music"
+msgstr "folk/traditional music"
+
+msgid "football/soccer"
+msgstr "football/soccer"
+
+msgid "foreign countries/expeditions"
+msgstr "foreign countries/expeditions"
+
+msgid "forward to the next chapter"
+msgstr "forward to the next chapter"
+
+msgid "free"
+msgstr "free"
+
+msgid "free diskspace"
+msgstr "free diskspace"
+
+msgid "from"
+msgstr "from"
+
+msgid "full"
+msgstr "full"
+
+msgid "further education"
+msgstr "further education"
+
+msgid "game show/quiz/contest"
+msgstr "game show/quiz/contest"
+
+msgid "gardening"
+msgstr "gardening"
+
+msgid "get the cards' server"
+msgstr "get the cards' server"
+
+msgid "go to deep standby"
+msgstr "go to deep standby"
+
+msgid "go to standby"
+msgstr "go to standby"
+
+msgid "grab this frame as bitmap"
+msgstr "grab this frame as bitmap"
+
+msgid "green"
+msgstr "green"
+
+msgid "handicraft"
+msgstr "handicraft"
+
+msgid "handled"
+msgstr "handled"
+
+msgid ""
+"has been sent to the ViX team.\n"
+"please quote"
+msgstr ""
+"has been sent to the ViX team.\n"
+"please quote"
+
+msgid "height"
+msgstr "height"
+
+msgid "hops:"
+msgstr "hops:"
+
+msgid "horizontal"
+msgstr "horizontal"
+
+msgid "increase uphop by 1"
+msgstr "increase uphop by 1"
+
+msgid "information/education/school program"
+msgstr "information/education/school program"
+
+msgid "init module"
+msgstr "init module"
+
+msgid "init modules"
+msgstr "init modules"
+
+msgid "insert mark here"
+msgstr "insert mark here"
+
+msgid "invalid type"
+msgstr "invalid type"
+
+msgid "is strongly advised."
+msgstr "is strongly advised."
+
+msgid "jazz"
+msgstr "jazz"
+
+msgid "jump back to the previous title"
+msgstr "jump back to the previous title"
+
+msgid "jump forward to the next title"
+msgstr "jump forward to the next title"
+
+msgid "languages"
+msgstr "languages"
+
+msgid "left"
+msgstr "left"
+
+msgid "leisure hobbies (general)"
+msgstr "leisure hobbies (general)"
+
+msgid "length"
+msgstr "length"
+
+msgid "limit ..., aborting !"
+msgstr "limit ..., aborting !"
+
+msgid "literature"
+msgstr "literature"
+
+msgid "live broadcast"
+msgstr "live broadcast"
+
+msgid "locked"
+msgstr "locked"
+
+msgid "long"
+msgstr "long"
+
+msgid "loopthrough to"
+msgstr "loopthrough to"
+
+msgid "magazines/reports/documentary"
+msgstr "magazines/reports/documentary"
+
+msgid "making a backup before updating"
+msgstr "making a backup before updating"
+
+msgid "manual"
+msgstr "manual"
+
+msgid "martial sports"
+msgstr "martial sports"
+
+msgid "medicine/physiology/psychology"
+msgstr "medicine/physiology/psychology"
+
+msgid "menu"
+msgstr "menu"
+
+msgid "mins"
+msgstr "mins"
+
+msgid "minute"
+msgstr "minute"
+
+msgid "minutes"
+msgstr "minutes"
+
+msgid "month"
+msgstr "month"
+
+msgid "motor sport"
+msgstr "motor sport"
+
+msgid "motoring"
+msgstr "motoring"
+
+msgid "move"
+msgstr "move"
+
+msgid "movie/drama (general)"
+msgstr "movie/drama (general)"
+
+msgid "ms"
+msgstr "ms"
+
+msgid "multinorm"
+msgstr "multinorm"
+
+msgid "music/ballet/dance (general)"
+msgstr "music/ballet/dance (general)"
+
+msgid "musical/opera"
+msgstr "musical/opera"
+
+msgid "nature/animals/environment"
+msgstr "nature/animals/environment"
+
+msgid "ne"
+msgstr "ne"
+
+msgid "never"
+msgstr "never"
+
+msgid "new media"
+msgstr "new media"
+
+msgid "news magazine"
+msgstr "news magazine"
+
+msgid "news/current affairs (general)"
+msgstr "news/current affairs (general)"
+
+msgid "news/weather report"
+msgstr "news/weather report"
+
+msgid "nne"
+msgstr "nne"
+
+msgid "nnw"
+msgstr "nnw"
+
+msgid "no"
+msgstr "no"
+
+msgid "no CAId selected"
+msgstr "no CAId selected"
+
+msgid "no CI slots found"
+msgstr "no CI slots found"
+
+msgid "no channel list"
+msgstr "no channel list"
+
+msgid "no delay"
+msgstr "no delay"
+
+msgid "no module found"
+msgstr "no module found"
+
+msgid "no or unknown card inserted"
+msgstr "no or unknown card inserted"
+
+msgid "no resource manager"
+msgstr "no resource manager"
+
+msgid "no storage devices found"
+msgstr "no storage devices found"
+
+msgid "none"
+msgstr "none"
+
+msgid "normal"
+msgstr "normal"
+
+msgid "not configured"
+msgstr "not configured"
+
+msgid "not locked"
+msgstr "not locked"
+
+msgid "not supported"
+msgstr "not supported"
+
+msgid "not used"
+msgstr "not used"
+
+msgid "nothing connected"
+msgstr "nothing connected"
+
+msgid "nw"
+msgstr "nw"
+
+msgid "of a DUAL layer medium used."
+msgstr "of a DUAL layer medium used."
+
+msgid "of a SINGLE layer medium used."
+msgstr "of a SINGLE layer medium used."
+
+msgid "off"
+msgstr "off"
+
+msgid "offset is"
+msgstr "offset is"
+
+msgid "on"
+msgstr "on"
+
+msgid "on READ ONLY medium."
+msgstr "on READ ONLY medium."
+
+msgid "once"
+msgstr "once"
+
+msgid "only 4K"
+msgstr "only 4K"
+
+msgid "only HD"
+msgstr "only HD"
+
+msgid "original"
+msgstr "original"
+
+msgid "original language"
+msgstr "original language"
+
+msgid "oscam.conf could not be found"
+msgstr "oscam.conf could not be found"
+
+msgid ""
+"oscam.conf not found.\n"
+"Please enter username/password manually."
+msgstr ""
+"oscam.conf not found.\n"
+"Please enter username/password manually."
+
+msgid "packages selected."
+msgstr "packages selected."
+
+msgid "page left"
+msgstr "page left"
+
+msgid "pass"
+msgstr "pass"
+
+msgid "performing arts"
+msgstr "performing arts"
+
+msgid "pid:"
+msgstr "pid:"
+
+msgid "please press OK when ready"
+msgstr "please press OK when ready"
+
+msgid "please wait, loading picture..."
+msgstr "please wait, loading picture..."
+
+msgid "please wait..."
+msgstr "please wait..."
+
+msgid "pm"
+msgstr "pm"
+
+msgid "popular culture/traditional arts"
+msgstr "popular culture/traditional arts"
+
+msgid "pre-school children's program"
+msgstr "pre-school children's program"
+
+msgid "provid:"
+msgstr "provid:"
+
+msgid "provider:"
+msgstr "provider:"
+
+msgid "reboot system"
+msgstr "reboot system"
+
+msgid "record"
+msgstr "record"
+
+msgid "recording..."
+msgstr "recording..."
+
+msgid "red"
+msgstr "red"
+
+msgid "reliable"
+msgstr "reliable"
+
+msgid "religion"
+msgstr "religion"
+
+msgid "remarkable people"
+msgstr "remarkable people"
+
+msgid "remove after this position"
+msgstr "remove after this position"
+
+msgid "remove before this position"
+msgstr "remove before this position"
+
+msgid "remove bookmark"
+msgstr "remove bookmark"
+
+msgid "remove directory"
+msgstr "remove directory"
+
+msgid "remove this mark"
+msgstr "remove this mark"
+
+msgid "rename"
+msgstr "rename"
+
+msgid "repeat playlist"
+msgstr "repeat playlist"
+
+msgid "repeated"
+msgstr "repeated"
+
+msgid "restart GUI"
+msgstr "restart GUI"
+
+msgid "reverse by date"
+msgstr "reverse by date"
+
+msgid "rewind to the previous chapter"
+msgstr "rewind to the previous chapter"
+
+msgid "right"
+msgstr "right"
+
+msgid "rock/pop"
+msgstr "rock/pop"
+
+msgid "romance"
+msgstr "romance"
+
+msgid "running..."
+msgstr "running..."
+
+msgid "save last directory on exit"
+msgstr "save last directory on exit"
+
+msgid "save playlist on exit"
+msgstr "save playlist on exit"
+
+msgid "scan state"
+msgstr "scan state"
+
+msgid "science fiction/fantasy/horror"
+msgstr "science fiction/fantasy/horror"
+
+msgid "se"
+msgstr "se"
+
+msgid "second cable of motorized LNB"
+msgstr "second cable of motorised LNB"
+
+msgid "seconds"
+msgstr "seconds"
+
+msgid "select"
+msgstr "select"
+
+msgid "select CAId's"
+msgstr "select CAId's"
+
+msgid "serious music/classic music"
+msgstr "serious music/classic music"
+
+msgid "serious/classical/religious/historical movie/drama"
+msgstr "serious/classical/religious/historical movie/drama"
+
+msgid "share:"
+msgstr "share:"
+
+msgid "show DVD main menu"
+msgstr "show DVD main menu"
+
+msgid "show all cards"
+msgstr "show all cards"
+
+msgid "show all tags"
+msgstr "show all tags"
+
+msgid "show cards with uphop 0"
+msgstr "show cards with uphop 0"
+
+msgid "show cards with uphop 1"
+msgstr "show cards with uphop 1"
+
+msgid "show cards with uphop 2"
+msgstr "show cards with uphop 2"
+
+msgid "show cards with uphop 3"
+msgstr "show cards with uphop 3"
+
+msgid "show cards with uphop 4"
+msgstr "show cards with uphop 4"
+
+msgid "show cards with uphop 5"
+msgstr "show cards with uphop 5"
+
+msgid "show cards with uphop 6"
+msgstr "show cards with uphop 6"
+
+msgid "show cards with uphop 7"
+msgstr "show cards with uphop 7"
+
+msgid "show cards with uphop 8"
+msgstr "show cards with uphop 8"
+
+msgid "show cards with uphop 9"
+msgstr "show cards with uphop 9"
+
+msgid "show event details"
+msgstr "show event details"
+
+msgid "show mediaplayer on mainmenu"
+msgstr "show mediaplayer on mainmenu"
+
+msgid "show softwaremanager in plugin menu"
+msgstr "show softwaremanager in plugin menu"
+
+msgid "show softwaremanager on blue button"
+msgstr "show softwaremanager on blue button"
+
+msgid "show/game show (general)"
+msgstr "show/game show (general)"
+
+msgid "shuffle"
+msgstr "shuffle"
+
+msgid "shut down"
+msgstr "shut down"
+
+msgid "simple"
+msgstr "simple"
+
+msgid "skip backward"
+msgstr "skip backward"
+
+msgid "skip backward (enter time)"
+msgstr "skip backward (enter time)"
+
+msgid "skip forward"
+msgstr "skip forward"
+
+msgid "skip forward (enter time)"
+msgstr "skip forward (enter time)"
+
+msgid "slow"
+msgstr "slow"
+
+msgid "soap/melodram/folkloric"
+msgstr "soap/melodram/folkloric"
+
+msgid "social/political issues/economics (general)"
+msgstr "social/political issues/economics (general)"
+
+msgid "social/spiritual science"
+msgstr "social/spiritual science"
+
+msgid "sorting of playlists"
+msgstr "sorting of playlists"
+
+msgid "special events"
+msgstr "special events"
+
+msgid "sports (general)"
+msgstr "sports (general)"
+
+msgid "sports magazine"
+msgstr "sports magazine"
+
+msgid "sse"
+msgstr "sse"
+
+msgid "ssw"
+msgstr "ssw"
+
+msgid "standard"
+msgstr "standard"
+
+msgid "start cut here"
+msgstr "start cut here"
+
+msgid "start directory"
+msgstr "start directory"
+
+msgid "stepsize"
+msgstr "stepsize"
+
+msgid "stereo"
+msgstr "stereo"
+
+msgid "sw"
+msgstr "sw"
+
+msgid "switch to bookmarks"
+msgstr "switch to bookmarks"
+
+msgid "switch to filelist"
+msgstr "switch to filelist"
+
+msgid "switch to the next angle"
+msgstr "switch to the next angle"
+
+msgid "switch to the next audio track"
+msgstr "switch to the next audio track"
+
+msgid "switch to the next subtitle language"
+msgstr "switch to the next subtitle language"
+
+msgid "system:"
+msgstr "system:"
+
+msgid "talk show"
+msgstr "talk show"
+
+msgid "team sports"
+msgstr "team sports"
+
+msgid "technology/natural science"
+msgstr "technology/natural science"
+
+msgid "template file"
+msgstr "template file"
+
+msgid "tennis/squash"
+msgstr "tennis/squash"
+
+msgid "this bouquet is protected by a parental control pin"
+msgstr "this bouquet is protected by a parental control pin"
+
+msgid "this recording"
+msgstr "this recording"
+
+msgid "this service is protected by a parental control pin"
+msgstr "this service is protected by a parental control pin"
+
+msgid "toggle time, chapter, audio, subtitle info"
+msgstr "toggle time, chapter, audio, subtitle info"
+
+msgid "top"
+msgstr "top"
+
+msgid "tourism/travel"
+msgstr "tourism/travel"
+
+msgid "traditional (fast)"
+msgstr "traditional (fast)"
+
+msgid "true"
+msgstr "true"
+
+msgid "uShare Name"
+msgstr "uShare Name"
+
+msgid "uShare Port"
+msgstr "uShare Port"
+
+msgid "uShare Setup"
+msgstr "uShare Setup"
+
+msgid "uShare name"
+msgstr "uShare name"
+
+msgid "uShare port"
+msgstr "uShare port"
+
+msgid "uShare setup"
+msgstr "uShare setup"
+
+msgid "unavailable"
+msgstr "unavailable"
+
+msgid "unconfirmed"
+msgstr "unconfirmed"
+
+msgid "unknown"
+msgstr "unknown"
+
+msgid "unknown service"
+msgstr "unknown service"
+
+msgid "unpublished"
+msgstr "unpublished"
+
+msgid "until standby/restart"
+msgstr "until standby/restart"
+
+msgid "updates available."
+msgstr "updates available."
+
+msgid "user defined"
+msgstr "user defined"
+
+msgid "using:"
+msgstr "using:"
+
+msgid "variety show"
+msgstr "variety show"
+
+msgid "vertical"
+msgstr "vertical"
+
+msgid "wait for ci..."
+msgstr "wait for ci..."
+
+msgid "wait for mmi..."
+msgstr "wait for mmi..."
+
+msgid "waiting"
+msgstr "waiting"
+
+msgid "wakeup"
+msgstr "wakeup"
+
+msgid "wakeup to standby"
+msgstr "wakeup to standby"
+
+msgid "water sport"
+msgstr "water sport"
+
+msgid "weekly"
+msgstr "weekly"
+
+msgid "west"
+msgstr "west"
+
+msgid "when asking questions about this log"
+msgstr "when asking questions about this log"
+
+msgid ""
+"when asking questions about this log\n"
+"\n"
+"A copy has been sent to yourself."
+msgstr ""
+"when asking questions about this log\n"
+"\n"
+"A copy has been sent to yourself."
+
+msgid "white"
+msgstr "white"
+
+msgid "wide"
+msgstr "wide"
+
+msgid "width"
+msgstr "width"
+
+msgid "winter sport"
+msgstr "winter sport"
+
+msgid "wireless network interface"
+msgstr "wireless network interface"
+
+#, python-format
+msgid "with %d error"
+msgid_plural "with %d errors"
+msgstr[0] "with %d error"
+msgstr[1] "with %d errors"
+
+msgid "with exit button"
+msgstr "with exit button"
+
+msgid "with left/right buttons"
+msgstr "with left/right buttons"
+
+msgid "with long OK press"
+msgstr "with long OK press"
+
+msgid "with text"
+msgstr "with text"
+
+msgid "with tuner name"
+msgstr "with tuner name"
+
+msgid "wnw"
+msgstr "wnw"
+
+msgid "working"
+msgstr "working"
+
+msgid "wsw"
+msgstr "wsw"
+
+msgid "yellow"
+msgstr "yellow"
+
+msgid "yes"
+msgstr "yes"
+
+msgid "yes (keep feeds)"
+msgstr "yes (keep feeds)"
+
+msgid "zap"
+msgstr "zap"
+
+msgid "zap and record"
+msgstr "zap and record"
+
+msgid "zapped"
+msgstr "zapped"
+
+#~ msgid "3d mode"
+#~ msgstr "3d mode"
+
+#~ msgid "A recording is currently running. Please stop the recording before trying to start the satfinder."
+#~ msgstr "A recording is currently running. Please stop the recording before trying to start the sat finder."
+
+#~ msgid "AA"
+#~ msgstr "AA"
+
+#~ msgid "AB"
+#~ msgstr "AB"
+
+#~ msgid "Action on long power button press"
+#~ msgstr "Action on long power button press"
+
+#~ msgid "Action on short power button press"
+#~ msgstr "Action on short power button press"
+
+#~ msgid "Adjust 3D settings"
+#~ msgstr "Adjust 3D settings"
+
+#~ msgid "Advanced video setup"
+#~ msgstr "Advanced video setup"
+
+#~ msgid "Allows more detailed information to be in the crash log"
+#~ msgstr "Allows more detailed information to be in the crash log"
+
+#~ msgid "BA"
+#~ msgstr "BA"
+
+#~ msgid "BB"
+#~ msgstr "BB"
+
+#~ msgid "Change pin code"
+#~ msgstr "Change pin code"
+
+#~ msgid "Change service PIN"
+#~ msgstr "Change service PIN"
+
+#~ msgid "Change service PINs"
+#~ msgstr "Change service PINs"
+
+#~ msgid "Changelog"
+#~ msgstr "Changelog"
+
+#~ msgid "Channel +/- button mode"
+#~ msgstr "Channel +/- button mode"
+
+#~ msgid "Checking Feeds"
+#~ msgstr "Checking Feeds"
+
+#~ msgid "Configure the function of a long press of the power button."
+#~ msgstr "Configure the function of a long press of the power button."
+
+#~ msgid "Configure the function of a short press of the power button."
+#~ msgstr "Configure the function of a short press of the power button."
+
+#~ msgid "Configure the refresh rate of the screen."
+#~ msgstr "Configure the refresh rate of the screen."
+
+#~ msgid "Connected!"
+#~ msgstr "Connected!"
+
+#~ msgid "Could not connect to %s %s .NFI image feed server:"
+#~ msgstr "Could not connect to %s %s .NFI image feed server:"
+
+#~ msgid "Create more detailed crash log"
+#~ msgstr "Create more detailed crash log"
+
+#~ msgid "Currently installed image"
+#~ msgstr "Currently installed image"
+
+#~ msgid "Delete..."
+#~ msgstr "Delete..."
+
+#~ msgid "Device Information"
+#~ msgstr "Device Information"
+
+#~ msgid "Dialing:"
+#~ msgstr "Dialling:"
+
+#~ msgid "Disconnect"
+#~ msgstr "Disconnect"
+
+#~ msgid "Display"
+#~ msgstr "Display"
+
+#~ msgid "Do you want to download the image to %s ?"
+#~ msgstr "Do you want to download the image to %s ?"
+
+#~ msgid "Download %s from server"
+#~ msgstr "Download %s from server"
+
+#~ msgid "Download .NFI-files for USB-flasher"
+#~ msgstr "Download .NFI-files for USB-flasher"
+
+#~ msgid "Edit bouquets list"
+#~ msgstr "Edit bouquets list"
+
+#~ msgid "Edit services list"
+#~ msgstr "Edit services list"
+
+#~ msgid "Enables a feature so that the receiver can decrypt streams (if the ECM data is included in the stream and a valid card is available)."
+#~ msgstr "Enables a feature so that the receiver can decrypt streams (if the ECM data is included in the stream and a valid card is available)."
+
+#~ msgid "External (CF)"
+#~ msgstr "External (CF)"
+
+#~ msgid "Finished restarting your network"
+#~ msgstr "Finished restarting your network"
+
+#~ msgid "Flash"
+#~ msgstr "Flash"
+
+#~ msgid "Flashing failed"
+#~ msgstr "Flashing failed"
+
+#~ msgid "Free Memory:"
+#~ msgstr "Free Memory:"
+
+#~ msgid "Ftpd service type: Vsftpd server"
+#~ msgstr "Ftpd service type: Vsftpd server"
+
+#~ msgid "Get latest experimental image"
+#~ msgstr "Get latest experimental image"
+
+#~ msgid "Get latest release image"
+#~ msgstr "Get latest release image"
+
+#~ msgid "Image Information"
+#~ msgstr "Image Information"
+
+#~ msgid "Inadyn Log"
+#~ msgstr "Inadyn Log"
+
+#~ msgid "Memory Information"
+#~ msgstr "Memory Information"
+
+#~ msgid "MiniDLNA Log"
+#~ msgstr "MiniDLNA Log"
+
+#~ msgid "Move to other directory"
+#~ msgstr "Move to other directory"
+
+#~ msgid "NFI image flashing"
+#~ msgstr "NFI image flashing"
+
+#~ msgid "NFI image flashing completed. Press Yellow to Reboot!"
+#~ msgstr "NFI image flashing completed. Press Yellow to Reboot!"
+
+#~ msgid "Network Information"
+#~ msgstr "Network Information"
+
+#~ msgid "New PIN"
+#~ msgstr "New PIN"
+
+#~ msgid "No details for this image file"
+#~ msgstr "No details for this image file"
+
+#~ msgid "No updates available. Please try again later."
+#~ msgstr "No updates available. Please try again later."
+
+#~ msgid ""
+#~ "No valid service PIN found!\n"
+#~ "Do you like to change the service PIN now?\n"
+#~ "When you say 'No' here the service protection stay disabled!"
+#~ msgstr ""
+#~ "No valid service PIN found!\n"
+#~ "Do you like to change the service PIN now?\n"
+#~ "When you say 'No' here the service protection stay disabled!"
+
+#~ msgid ""
+#~ "No valid setup PIN found!\n"
+#~ "Do you like to change the setup PIN now?\n"
+#~ "When you say 'No' here the setup protection stay disabled!"
+#~ msgstr ""
+#~ "No valid setup PIN found!\n"
+#~ "Do you like to change the setup PIN now?\n"
+#~ "When you say 'No' here the setup protection stay disabled!"
+
+#~ msgid "OpenVpn Log"
+#~ msgstr "OpenVpn Log"
+
+#~ msgid "Parental control editor"
+#~ msgstr "Parental control editor"
+
+#~ msgid "Parental control setup"
+#~ msgstr "Parental control setup"
+
+#~ msgid "Parental control type"
+#~ msgstr "Parental control type"
+
+#~ msgid "Phone number"
+#~ msgstr "Phone number"
+
+#~ msgid "Please check your network settings!"
+#~ msgstr "Please check your network settings!"
+
+#~ msgid "Please select an NFI file and press green key to flash!"
+#~ msgstr "Please select an NFI file and press green key to flash!"
+
+#~ msgid "Please wait for activation of your network configuration..."
+#~ msgstr "Please wait for activation of your network configuration..."
+
+#~ msgid "Please wait whilst feeds state is checked."
+#~ msgstr "Please wait whilst feeds state is checked."
+
+#~ msgid "PowerTimer Overview"
+#~ msgstr "PowerTimer Overview"
+
+#~ msgid "Prepare another USB stick for image flashing"
+#~ msgstr "Prepare another USB stick for image flashing"
+
+#~ msgid "Reenter new PIN"
+#~ msgstr "Reenter new PIN"
+
+#~ msgid "Restart enigma"
+#~ msgstr "Restart enigma"
+
+#~ msgid "Restore is running..."
+#~ msgstr "Restore is running..."
+
+#~ msgid "Samba Log"
+#~ msgstr "Samba Log"
+
+#~ msgid "Select an image to be downloaded"
+#~ msgstr "Select an image to be downloaded"
+
+#~ msgid "Select default EPG type..."
+#~ msgstr "Select default EPG type…"
+
+#~ msgid "Select desired image from feed list"
+#~ msgstr "Select desired image from feed list"
+
+#~ msgid "Select if you want the Subservice mode to be activated."
+#~ msgstr "Select if you want the Subservice mode to be activated."
+
+#~ msgid "Select if you want to use the ViX colored buttons (set to 'no' if you want to use (Multi Quick Button)."
+#~ msgstr "Select if you want to use the ViX coloured buttons. Set to 'no' if you want to use (Multi Quick Button)."
+
+#~ msgid "Select what you want the Channel +/- buttons to activate."
+#~ msgstr "Select what you want the Channel +/- buttons to activate."
+
+#~ msgid "Select what you want the TV button to activate."
+#~ msgstr "Select what you want the TV button to activate."
+
+#~ msgid "Shall the USB stick wizard proceed and program the image file %s into flash memory?"
+#~ msgstr "Should the USB stick wizard proceed and program the image file %s into flash memory?"
+
+#~ msgid "Show services beginning with"
+#~ msgstr "Show services beginning with"
+
+#~ msgid "Show status icons in movielist"
+#~ msgstr "Show status icons in movielist"
+
+#~ msgid "Show tag menu"
+#~ msgstr "Show tag menu"
+
+#~ msgid "Single transponder"
+#~ msgstr "Single transponder"
+
+#~ msgid "Subservice mode"
+#~ msgstr "Subservice mode"
+
+#~ msgid "TV button mode"
+#~ msgstr "TV button mode"
+
+#~ msgid ""
+#~ "The USB stick was prepared to be bootable.\n"
+#~ "Now you can download an NFI image file!"
+#~ msgstr ""
+#~ "The USB stick was prepared to be bootable.\n"
+#~ "Now you can download an NFI image file!"
+
+#~ msgid ""
+#~ "The following device was found:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Do you want to write the USB flasher to this stick?"
+#~ msgstr ""
+#~ "The following device was found:\n"
+#~ "\n"
+#~ "%s\n"
+#~ "\n"
+#~ "Do you want to write the USB flasher to this stick?"
+
+#~ msgid "The md5sum validation failed, the file may be corrupted!"
+#~ msgstr "The md5sum validation failed, the file may be corrupted!"
+
+#~ msgid "The wizard found a configuration backup. Do you want to restore your old settings from %s?"
+#~ msgstr "The wizard found a configuration backup. Do you want to restore your old settings from %s?"
+
+#~ msgid ""
+#~ "This plugin creates a USB stick which can be used to update the firmware of your %s %s without the need for a network or WLAN connection.\n"
+#~ "First, a USB stick needs to be prepared so that it becomes bootable.\n"
+#~ "In the next step, an NFI image file can be downloaded from the update server and saved on the USB stick.\n"
+#~ "If you already have a prepared bootable USB stick, please insert it now. Otherwise plug in a USB stick with a minimum size of 64 MB!"
+#~ msgstr ""
+#~ "This plugin creates a USB stick which can be used to update the firmware of your %s %s without the need for a network or WLAN connection.\n"
+#~ "First, a USB stick needs to be prepared so that it becomes bootable.\n"
+#~ "In the next step, an NFI image file can be downloaded from the update server and saved on the USB stick.\n"
+#~ "If you already have a prepared bootable USB stick, please insert it now. Otherwise plug in a USB stick with a minimum size of 64 MB!"
+
+#~ msgid "Timer log"
+#~ msgstr "Timer log"
+
+#~ msgid ""
+#~ "To update your %s %s firmware, please follow these steps:\n"
+#~ "1) Turn off your box with the rear power switch and make sure the bootable USB stick is plugged in.\n"
+#~ "2) Turn mains back on and hold the DOWN button on the front panel pressed for 10 seconds.\n"
+#~ "3) Wait for bootup and follow instructions of the wizard."
+#~ msgstr ""
+#~ "To update your %s %s firmware, please follow these steps:\n"
+#~ "1) Turn off your box with the rear power switch and make sure the bootable USB stick is plugged in.\n"
+#~ "2) Turn mains back on and hold the DOWN button on the front panel pressed for 10 seconds.\n"
+#~ "3) Wait for bootup and follow instructions of the wizard."
+
+#~ msgid "USB stick wizard"
+#~ msgstr "USB stick wizard"
+
+#~ msgid "Uncommitted DiSEqC command"
+#~ msgstr "Uncommitted DiSEqC command"
+
+#~ msgid "Use ViX colored Buttons*"
+#~ msgstr "Use ViX coloured Buttons*"
+
+#~ msgid "Use WOL"
+#~ msgstr "Use WOL"
+
+#~ msgid "Version:\t%s"
+#~ msgstr "Version:\t%s"
+
+#~ msgid "Video fine tuning"
+#~ msgstr "Video fine tuning"
+
+#~ msgid "Video fine-tuning"
+#~ msgstr "Video fine-tuning"
+
+#~ msgid "Video setup"
+#~ msgstr "Video setup"
+
+#~ msgid "Video wizard"
+#~ msgstr "Video wizard"
+
+#~ msgid "When enabled, the original line breaks will be removed from the teletext subtitles."
+#~ msgstr "When enabled, the original line breaks will be removed from the teletext subtitles."
+
+#~ msgid "You can disable Telnet Server and use ssh to login."
+#~ msgstr "You can disable Telnet Server and use ssh to login."
+
+#~ msgid "You have chosen to create a new .NFI flasher bootable USB stick. This will repartition the USB stick and therefore all data on it will be erased."
+#~ msgstr "You have chosen to create a new .NFI flasher bootable USB stick. This will repartition the USB stick and therefore all data on it will be erased."
+
+#~ msgid "complex"
+#~ msgstr "complex"
+
+#~ msgid "continue"
+#~ msgstr "continue"
+
+#~ msgid "currently installed image: %s"
+#~ msgstr "currently installed image: %s"
+
+#~ msgid "fine-tune your display"
+#~ msgstr "fine-tune your display"
+
+#~ msgid "leave movie player..."
+#~ msgstr "leave movie player..."
+
+#~ msgid "service PIN"
+#~ msgstr "service PIN"
+
+#~ msgid "setup PIN"
+#~ msgstr "setup PIN"
+
+#~ msgid "special characters"
+#~ msgstr "special characters"
+
+#~ msgid "uShare Log"
+#~ msgstr "uShare Log"
+
+#~ msgid "whitelist"
+#~ msgstr "whitelist"


### PR DESCRIPTION
This change is intended to add the Australian English language option to OpenViX.

The en_AU.po file is simply a copy of the current en_GB with the header information updated.  In general en_AU should closely track en_GB.

The Australian flag icon for "skin_default/countries" was posted in the developer area of the forum.  I was unable to find the source location to commit the file myself.
