### PR TITLE
Allow specification of colours and pixmaps by name

### DIFF
--- a/lib/python/Components/MultiContent.py
+++ b/lib/python/Components/MultiContent.py
@@ -1,21 +1,42 @@
 from enigma import eListboxPythonMultiContent, RT_HALIGN_LEFT, RT_VALIGN_TOP
+from skin import parseColor
+from Tools.LoadPixmap import LoadPixmap
+from Tools.Directories import resolveFilename, SCOPE_ACTIVE_SKIN
+
+def __resolveColor(color):
+	if isinstance(color, str):
+		try:
+			return parseColor(color).argb()
+		except Exception, e:
+			print "[MultiContent]", e
+		return None
+	return color
+
+def __resolvePixmap(pixmap):
+	if isinstance(pixmap, str):
+		try:
+			return LoadPixmap(resolveFilename(SCOPE_ACTIVE_SKIN, pixmap))
+		except Exception, e:
+			print "[MultiContent]", e
+		return None
+	return pixmap
 
 def MultiContentTemplateColor(n): return 0xff000000 | n
 
 def MultiContentEntryText(pos = (0, 0), size = (0, 0), font = 0, flags = RT_HALIGN_LEFT | RT_VALIGN_TOP, text = "", color = None, color_sel = None, backcolor = None, backcolor_sel = None, border_width = None, border_color = None):
-	return eListboxPythonMultiContent.TYPE_TEXT, pos[0], pos[1], size[0], size[1], font, flags, text, color, color_sel, backcolor, backcolor_sel, border_width, border_color
+	return eListboxPythonMultiContent.TYPE_TEXT, pos[0], pos[1], size[0], size[1], font, flags, text, __resolveColor(color), __resolveColor(color_sel), __resolveColor(backcolor), __resolveColor(backcolor_sel), border_width, __resolveColor(border_color)
 
 def MultiContentEntryPixmap(pos = (0, 0), size = (0, 0), png = None, backcolor = None, backcolor_sel = None, flags = 0):
-	return eListboxPythonMultiContent.TYPE_PIXMAP, pos[0], pos[1], size[0], size[1], png, backcolor, backcolor_sel, flags
+	return eListboxPythonMultiContent.TYPE_PIXMAP, pos[0], pos[1], size[0], size[1], __resolvePixmap(png), __resolveColor(backcolor), __resolveColor(backcolor_sel), flags
 
 def MultiContentEntryPixmapAlphaTest(pos = (0, 0), size = (0, 0), png = None, backcolor = None, backcolor_sel = None, flags = 0):
-	return eListboxPythonMultiContent.TYPE_PIXMAP_ALPHATEST, pos[0], pos[1], size[0], size[1], png, backcolor, backcolor_sel, flags
+	return eListboxPythonMultiContent.TYPE_PIXMAP_ALPHATEST, pos[0], pos[1], size[0], size[1], __resolvePixmap(png), __resolveColor(backcolor), __resolveColor(backcolor_sel), flags
 
 def MultiContentEntryPixmapAlphaBlend(pos = (0, 0), size = (0, 0), png = None, backcolor = None, backcolor_sel = None, flags = 0):
-	return eListboxPythonMultiContent.TYPE_PIXMAP_ALPHABLEND, pos[0], pos[1], size[0], size[1], png, backcolor, backcolor_sel, flags
+	return eListboxPythonMultiContent.TYPE_PIXMAP_ALPHABLEND, pos[0], pos[1], size[0], size[1], __resolvePixmap(png), __resolveColor(backcolor), __resolveColor(backcolor_sel), flags
 
 def MultiContentEntryProgress(pos = (0, 0), size = (0, 0), percent = None, borderWidth = None, foreColor = None, foreColorSelected = None, backColor = None, backColorSelected = None):
-	return eListboxPythonMultiContent.TYPE_PROGRESS, pos[0], pos[1], size[0], size[1], percent, borderWidth, foreColor, foreColorSelected, backColor, backColorSelected
+	return eListboxPythonMultiContent.TYPE_PROGRESS, pos[0], pos[1], size[0], size[1], percent, borderWidth,  __resolveColor(foreColor),  __resolveColor(foreColorSelected),  __resolveColor(backColor),  __resolveColor(backColorSelected)
 
 def MultiContentEntryProgressPixmap(pos = (0, 0), size = (0, 0), percent = None, pixmap = None, borderWidth = None, foreColor = None, foreColorSelected = None, backColor = None, backColorSelected = None):
-	return eListboxPythonMultiContent.TYPE_PROGRESS_PIXMAP, pos[0], pos[1], size[0], size[1], percent, pixmap, borderWidth, foreColor, foreColorSelected, backColor, backColorSelected
+	return eListboxPythonMultiContent.TYPE_PROGRESS_PIXMAP, pos[0], pos[1], size[0], size[1], percent, __resolvePixmap(pixmap), borderWidth,  __resolveColor(foreColor),  __resolveColor(foreColorSelected),  __resolveColor(backColor),  __resolveColor(backColorSelected)


### PR DESCRIPTION
This change allows skin developers to specify colours in skin based TemplatedMultiContent converter structures by name as well as number.  The change also allows pixmaps to be referenced by skin relative locations.

In the past users could only specify colours in a TemplatedMultiContent converter structure by using the ARGB hex colour number in the 0xAARRGGBB hex number format.  For example, " color = 0x00FF0000 ".  With this change users can now also specify colours defined in the < colors > section of the skin.  For example, " color = "red" ".  This change should make maintaining skin colour management a much easier process.

Similarly pixmaps in a TemplatedMultiContent converter structure can now access the normal skin path resolution process to make the pixmaps skin relative.  For example, " png = "buttons/button_red.png" ".
