### PR TITLE
[ValueRange.py] Correct data type matching

### DIFF
--- a/lib/python/Components/Converter/ValueRange.py
+++ b/lib/python/Components/Converter/ValueRange.py
@@ -8,9 +8,10 @@ class ValueRange(Converter, object):
 
 	@cached
 	def getBoolean(self):
+		val = int(self.source.value)
 		if self.lower <= self.upper:
-			return self.lower <= self.source.value <= self.upper
+			return self.lower <= val <= self.upper
 		else:
-			return not (self.upper < self.source.value < self.lower)
+			return not (self.upper < val < self.lower)
 
 	boolean = property(getBoolean)


### PR DESCRIPTION
This change ensures the the incoming data to the converter is cast as an integer to match the range limits.  Some sources provide the data as a string.

This change is based the Beyonwiz firmware change made by PeterU.
