### PR TITLE
Use new date and time formatting options

### DIFF
--- a/lib/python/Components/EpgList.py
+++ b/lib/python/Components/EpgList.py
@@ -1,3 +1,4 @@
+import skin
 from time import localtime, time, strftime
 
 from enigma import eEPGCache, eListbox, eListboxPythonMultiContent, loadPNG, gFont, getDesktop, eRect, eSize, RT_HALIGN_LEFT, RT_HALIGN_RIGHT, RT_HALIGN_CENTER, RT_VALIGN_CENTER, RT_VALIGN_TOP, RT_WRAP, BT_SCALE, BT_KEEP_ASPECT_RATIO
@@ -559,16 +560,17 @@ class EPGList(HTMLComponent, GUIComponent):
 		height = esize.height()
 		if self.type == EPG_TYPE_MULTI:
 			fontSize = self.eventFontSizeMulti + config.epgselection.multi_eventfs.value
-			xpos = 0
-			w = int((fontSize + 4) * 7.0)  # Service font is 4 px larger
-			self.service_rect = Rect(xpos, 0, w-10, height)
-			xpos += w
-			w = int(fontSize * 5.4)
-			self.start_end_rect = Rect(xpos, 0, w-10, height)
-			self.progress_rect = Rect(xpos, 4, w-10, height-8)
-			xpos += w
-			w = width - xpos
-			self.descr_rect = Rect(xpos, 0, w, height)
+			servW = int((fontSize + 4) * 6.5)  # Service font is 4 px larger
+			if config.usage.time.wide.value:
+				progW = int(fontSize * 6.8)
+			else:
+				progW = int(fontSize * 6.8)
+			servLeft, servWidth, progLeft, progWidth, progHeight, descLeft = skin.parameters.get("MultiEPGColumnFormats", (0, servW - 10, servW, progW, height - 8, servW + progW + 10))
+			progTop = int((height - progHeight) / 2)
+			self.service_rect = Rect(servLeft, 0, servWidth, height)
+			self.progress_rect = Rect(progLeft, progTop, progWidth, progHeight)
+			self.start_end_rect = Rect(progLeft, 0, progWidth, height)
+			self.descr_rect = Rect(descLeft, 0, width - descLeft, height)
 		elif self.type == EPG_TYPE_GRAPH or self.type == EPG_TYPE_INFOBARGRAPH:
 			servicew = 0
 			piconw = 0
@@ -589,7 +591,7 @@ class EPGList(HTMLComponent, GUIComponent):
 				if self.showServiceNumber:
 					font = gFont(self.serviceFontNameGraph, self.serviceFontSizeGraph + config.epgselection.infobar_servfs.value)
 					channelw = getTextBoundarySize(self.instance, font, self.instance.size(), "0000" ).width()
-			
+
 			w = (channelw + piconw + servicew)
 			self.service_rect = Rect(0, 0, w, height)
 			self.event_rect = Rect(w, 0, width - w, height)
@@ -600,9 +602,13 @@ class EPGList(HTMLComponent, GUIComponent):
 			self.picon_size = eSize(piconWidth, piconHeight)
 		else:
 			fontSize = self.eventFontSizeSingle + config.epgselection.enhanced_eventfs.value
-			self.weekday_rect = Rect(0, 0, int(fontSize * 2.3), height)
-			self.datetime_rect = Rect(self.weekday_rect.width(), 0, int(fontSize * 6.5), height)
-			self.descr_rect = Rect(self.datetime_rect.left() + self.datetime_rect.width(), 0, width - self.datetime_rect.left() - self.datetime_rect.width(), height)
+			self.weekday_rect = Rect(0, 0, int(fontSize * 1.9), height)
+			if config.usage.time.wide.value:
+				scale = 7.4
+			else:
+				scale = 6.3
+			self.datetime_rect = Rect(self.weekday_rect.width() + 20, 0, int(fontSize * scale), height)
+			self.descr_rect = Rect(self.datetime_rect.left() + self.datetime_rect.width() + 20, 0, width - self.datetime_rect.left() - self.datetime_rect.width() - 20, height)
 
 	def calcEntryPosAndWidthHelper(self, stime, duration, start, end, width):
 		xpos = (stime - start) * width / (end - start)
@@ -638,8 +644,8 @@ class EPGList(HTMLComponent, GUIComponent):
 		t = localtime(beginTime)
 		res = [
 			None, # no private data needed
-			(eListboxPythonMultiContent.TYPE_TEXT, r1.x, r1.y, r1.w, r1.h, 0, RT_HALIGN_LEFT|RT_VALIGN_CENTER, _(strftime("%a", t))),
-			(eListboxPythonMultiContent.TYPE_TEXT, r2.x, r2.y, r2.w, r1.h, 0, RT_HALIGN_LEFT|RT_VALIGN_CENTER, strftime("%e/%m, %-H:%M", t))
+			(eListboxPythonMultiContent.TYPE_TEXT, r1.x, r1.y, r1.w, r1.h, 0, RT_HALIGN_LEFT | RT_VALIGN_CENTER, strftime("%a", t)),
+			(eListboxPythonMultiContent.TYPE_TEXT, r2.x, r2.y, r2.w, r2.h, 0, RT_HALIGN_LEFT | RT_VALIGN_CENTER, strftime("%s, %s" % (config.usage.date.short.value, config.usage.time.short.value), t))
 		]
 		if clock_types:
 			if self.wasEntryAutoTimer and clock_types in (2,7,12):
@@ -678,8 +684,8 @@ class EPGList(HTMLComponent, GUIComponent):
 		t = localtime(beginTime)
 		res = [
 			None,  # no private data needed
-			(eListboxPythonMultiContent.TYPE_TEXT, r1.x, r1.y, r1.w, r1.h, 0, RT_HALIGN_LEFT|RT_VALIGN_CENTER, _(strftime("%a", t))),
-			(eListboxPythonMultiContent.TYPE_TEXT, r2.x, r2.y, r2.w, r1.h, 0, RT_HALIGN_LEFT|RT_VALIGN_CENTER, strftime("%e/%m, %-H:%M", t))
+			(eListboxPythonMultiContent.TYPE_TEXT, r1.x, r1.y, r1.w, r1.h, 0, RT_HALIGN_LEFT | RT_VALIGN_CENTER, strftime("%a", t)),
+			(eListboxPythonMultiContent.TYPE_TEXT, r2.x, r2.y, r2.w, r2.h, 0, RT_HALIGN_LEFT | RT_VALIGN_CENTER, strftime("%s, %s" % (config.usage.date.short.value, config.usage.time.short.value), t))
 		]
 		if clock_types:
 			if self.wasEntryAutoTimer and clock_types in (2,7,12):
@@ -723,8 +729,12 @@ class EPGList(HTMLComponent, GUIComponent):
 			if nowTime < beginTime:
 				begin = localtime(beginTime)
 				end = localtime(beginTime+duration)
+				if config.usage.time.wide.value:
+					format = "%s-%s"
+				else:
+					format = "%s - %s"
 				res.extend((
-					(eListboxPythonMultiContent.TYPE_TEXT, r4.x, r4.y, r4.w, r4.h, 1, RT_HALIGN_CENTER|RT_VALIGN_CENTER, "%02d.%02d - %02d.%02d"%(begin[3],begin[4],end[3],end[4])),
+					(eListboxPythonMultiContent.TYPE_TEXT, r4.x, r4.y, r4.w, r4.h, 1, RT_HALIGN_CENTER | RT_VALIGN_CENTER, format % (strftime(config.usage.time.short.value, begin), strftime(config.usage.time.short.value, end))),
 					(eListboxPythonMultiContent.TYPE_TEXT, r3.x, r3.y, duration_wid - 10, r3.h, 1, RT_HALIGN_RIGHT|RT_VALIGN_CENTER, _("%d min") % (duration / 60))
 				))
 			else:
@@ -1462,22 +1472,18 @@ class TimelineText(HTMLComponent, GUIComponent):
 
 			nowTime = localtime(time())
 			begTime = localtime(time_base)
-			ServiceWidth = service_rect.width()
-			if nowTime[2] != begTime[2]:
-				if ServiceWidth > 179:
-					datestr = strftime("%A %d %B", localtime(time_base))
-				elif ServiceWidth > 139:
-					datestr = strftime("%a %d %B", localtime(time_base))
-				elif ServiceWidth > 129:
-					datestr = strftime("%a %d %b", localtime(time_base))
-				elif ServiceWidth > 119:
-					datestr = strftime("%a %d", localtime(time_base))
-				elif ServiceWidth > 109:
-					datestr = strftime("%A", localtime(time_base))
-				else:
-					datestr = strftime("%a", localtime(time_base))
+			serviceWidth = service_rect.width()
+			if nowTime.tm_year == begTime.tm_year and nowTime.tm_yday == begTime.tm_yday:
+				datestr = _("Today")
 			else:
-				datestr = '%s'%(_("Today"))
+				if serviceWidth > 179:
+					datestr = strftime(config.usage.date.daylong.value, begTime)
+				elif serviceWidth > 129:
+					datestr = strftime(config.usage.date.dayshort.value, begTime)
+				elif serviceWidth > 79:
+					datestr = strftime(config.usage.date.daysmall.value, begTime)
+				else:
+					datestr = strftime("%a", begTime)
 
 			foreColor = self.foreColor
 			backColor = self.backColor
@@ -1525,14 +1531,7 @@ class TimelineText(HTMLComponent, GUIComponent):
 					border_width = self.borderWidth, border_color = self.borderColor))
 
 			for x in range(0, num_lines):
-				ttime = localtime(time_base + (x*timeStepsCalc))
-				if (self.type == EPG_TYPE_GRAPH and config.epgselection.graph_timeline24h.value) or (self.type == EPG_TYPE_INFOBARGRAPH and config.epgselection.infobar_timeline24h.value):
-					timetext = strftime("%H:%M", localtime(time_base + x*timeStepsCalc))
-				else:
-					if int(strftime("%H",ttime)) > 12:
-						timetext = strftime("%-I:%M",ttime) + _('pm')
-					else:
-						timetext = strftime("%-I:%M",ttime) + _('am')
+				timetext = strftime(config.usage.time.short.value, localtime(time_base + (x * timeStepsCalc)))
 				res.append(MultiContentEntryText(
 					pos = (service_rect.width() + xpos, 0),
 					size = (incWidth, self.listHeight),

--- a/lib/python/Components/MovieList.py
+++ b/lib/python/Components/MovieList.py
@@ -182,6 +182,8 @@ class MovieList(GUIComponent):
 		self.trashShift = 1
 		self.dirShift = 1
 		self.dateWidth = 160
+		if config.usage.time.wide.value:
+			self.dateWidth = int(self.dateWidth * 1.15)
 		self.reloadDelayTimer = None
 		self.l = eListboxPythonMultiContent()
 		self.tags = set()
@@ -307,6 +309,8 @@ class MovieList(GUIComponent):
 			self.spaceRight = int(value)
 		def dateWidth(value):
 			self.dateWidth = int(value)
+			if config.usage.time.wide.value:
+				self.dateWidth = int(self.dateWidth * 1.15)
 		for (attrib, value) in self.skinAttributes[:]:
 			try:
 				locals().get(attrib)(value)
@@ -438,7 +442,7 @@ class MovieList(GUIComponent):
 			if config.movielist.use_fuzzy_dates.value:
 				begin_string = ', '.join(FuzzyTime(begin, inPast = True))
 			else:
-				begin_string = strftime("%a %-e.%b.%Y, %R", localtime(begin))
+				begin_string = strftime("%s, %s" % (config.usage.date.daylong.value, config.usage.time.short.value), localtime(begin))
 
 		ih = self.itemHeight
 		res.append(MultiContentEntryText(pos=(iconSize+space, 0), size=(width-iconSize-space-dateWidth-r, ih), font = 0, flags = RT_HALIGN_LEFT|RT_VALIGN_CENTER, text = data.txt))

--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -13,7 +13,7 @@ from enigma import eDVBSatelliteEquipmentControl as secClass, \
 from Tools.HardwareInfo import HardwareInfo
 from Tools.BoundFunction import boundFunction
 from Components.About import about
-from config import config, ConfigSubsection, ConfigSelection, ConfigFloat, ConfigSatlist, ConfigYesNo, ConfigInteger, ConfigSubList, ConfigNothing, ConfigSubDict, ConfigOnOff, ConfigDateTime, ConfigText
+from Components.config import config, ConfigSubsection, ConfigSelection, ConfigFloat, ConfigSatlist, ConfigYesNo, ConfigInteger, ConfigSubList, ConfigNothing, ConfigSubDict, ConfigOnOff, ConfigDateTime, ConfigText
 
 config.unicable = ConfigSubsection()
 
@@ -1300,8 +1300,8 @@ def InitNimManager(nimmgr, update_slots = []):
 			section.powerMeasurement = ConfigYesNo(default=True)
 			section.powerThreshold = ConfigInteger(default=15, limits=(0, 100))
 			section.turningSpeed = ConfigSelection(turning_speed_choices, "fast")
-			section.fastTurningBegin = ConfigDateTime(default=advanced_lnb_fast_turning_btime, formatstring = _("%H:%M"), increment = 600)
-			section.fastTurningEnd = ConfigDateTime(default=advanced_lnb_fast_turning_etime, formatstring = _("%H:%M"), increment = 600)
+			section.fastTurningBegin = ConfigDateTime(default=advanced_lnb_fast_turning_btime, formatstring=config.usage.time.short.value, increment=600)
+			section.fastTurningEnd = ConfigDateTime(default=advanced_lnb_fast_turning_etime, formatstring=config.usage.time.short.value, increment=600)
 
 	def configLNBChanged(configElement):
 		x = configElement.slot_id
@@ -1432,9 +1432,9 @@ def InitNimManager(nimmgr, update_slots = []):
 			nim.powerThreshold = ConfigInteger(default=hw.get_device_name() == "dm8000" and 15 or 50, limits=(0, 100))
 			nim.turningSpeed = ConfigSelection(turning_speed_choices, "fast")
 			btime = datetime(1970, 1, 1, 7, 0)
-			nim.fastTurningBegin = ConfigDateTime(default = mktime(btime.timetuple()), formatstring = _("%H:%M"), increment = 900)
+			nim.fastTurningBegin = ConfigDateTime(default=mktime(btime.timetuple()), formatstring=config.usage.time.short.value, increment=900)
 			etime = datetime(1970, 1, 1, 19, 0)
-			nim.fastTurningEnd = ConfigDateTime(default = mktime(etime.timetuple()), formatstring = _("%H:%M"), increment = 900)
+			nim.fastTurningEnd = ConfigDateTime(default=mktime(etime.timetuple()), formatstring=config.usage.time.short.value, increment=900)
 
 	def createCableConfig(nim, x):
 		try:

--- a/lib/python/Components/Renderer/NextEpgInfo.py
+++ b/lib/python/Components/Renderer/NextEpgInfo.py
@@ -1,3 +1,4 @@
+from Components.config import config
 from Components.VariableText import VariableText
 from Renderer import Renderer
 from enigma import eLabel, eEPGCache, eServiceReference
@@ -27,7 +28,7 @@ class NextEpgInfo(Renderer, VariableText):
 						for x in range(self.numberOfItems):
 							event = self.epgcache.getNextTimeEntry()
 							if event:
-								self.text = "%s\n%s %s" % (self.text, strftime("%H:%M", localtime(event.getBeginTime())), event.getEventName())
+								self.text = "%s\n%s %s" % (self.text, strftime(config.usage.time.short.value, localtime(event.getBeginTime())), event.getEventName())
 						self.text = self.text and "%s%s" % (pgettext("now/next: 'next' event label", "Next"), self.text) or ""
 
 	def applySkin(self, desktop, parent):

--- a/lib/python/Components/Timeshift.py
+++ b/lib/python/Components/Timeshift.py
@@ -573,7 +573,7 @@ class InfoBarTimeshift:
 
 						# Add Event to list
 						filecount += 1
-						entrylist.append((_("Record") + " #%s (%s): %s" % (filecount,strftime("%H:%M",localtime(int(begintime))),eventname), "%s" % filename))
+						entrylist.append((_("Record") + " #%s (%s): %s" % (filecount, strftime(config.usage.time.short.value, localtime(int(begintime))), eventname), "%s" % filename))
 
 			self.session.openWithCallback(self.recordQuestionCallback, ChoiceBox, title=_("Which event do you want to save permanently?"), list=entrylist)
 

--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -49,7 +49,7 @@ from Tools.Alternatives import GetWithAlternative
 from Plugins.Plugin import PluginDescriptor
 from Components.PluginComponent import plugins
 from Screens.ChoiceBox import ChoiceBox
-from time import localtime, time
+from time import localtime, time, strftime
 try:
 	from Plugins.SystemPlugins.PiPServiceRelation.plugin import getRelationDict
 	plugin_PiPServiceRelation_installed = True
@@ -2884,7 +2884,7 @@ class HistoryZapSelector(Screen):
 							prefix = "+"
 						local_begin = localtime(begin)
 						local_end = localtime(end)
-						durationTime = _("%02d.%02d - %02d.%02d (%s%d min)") % (local_begin[3],local_begin[4],local_end[3],local_end[4],prefix, remaining)
+						durationTime = _("%s - %s (%s%d min)") % (strftime(config.usage.time.short.value, local_begin), strftime(config.usage.time.short.value, local_end), prefix, remaining)
 
 			png = ""
 			picon = getPiconName(str(ServiceReference(x[1])))

--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -1217,7 +1217,7 @@ class EPGSelection(Screen, HelpableScreen):
 				nowTime = localtime(now)
 				begTime = localtime(beg)
 				if nowTime[2] != begTime[2]:
-					datestr = strftime(_('%A %e %b'), begTime)
+					datestr = strftime(config.usage.date.dayshort.value, begTime)
 				else:
 					datestr = '%s' % _('Today')
 			self['date'].setText(datestr)

--- a/lib/python/Screens/EventView.py
+++ b/lib/python/Screens/EventView.py
@@ -225,14 +225,10 @@ class EventViewBase:
 
 		self["summary_description"].setText(extended)
 
-		begintime = event.getBeginTimeString().split(', ')[1].split(':')
-		begindate = event.getBeginTimeString().split(', ')[0].split('.')
-		nowt = time()
-		now = localtime(nowt)
-		test = int(mktime((now.tm_year, int(begindate[1]), int(begindate[0]), int(begintime[0]), int(begintime[1]), 0, now.tm_wday, now.tm_yday, now.tm_isdst)))
-		endtime = int(mktime((now.tm_year, int(begindate[1]), int(begindate[0]), int(begintime[0]), int(begintime[1]), 0, now.tm_wday, now.tm_yday, now.tm_isdst))) + event.getDuration()
-		endtime = localtime(endtime)
-		self["datetime"].setText(event.getBeginTimeString() + ' - ' + strftime(_("%-H:%M"), endtime))
+		begint = event.getBeginTime()
+		begintime = localtime(begint)
+		endtime = localtime(begint + event.getDuration())
+		self["datetime"].setText("%s - %s" % (strftime("%s, %s" % (config.usage.date.short.value, config.usage.time.short.value), begintime), strftime(config.usage.time.short.value, endtime)))
 		self["duration"].setText(_("%d min")%(event.getDuration()/60))
 		if self.SimilarBroadcastTimer is not None:
 			self.SimilarBroadcastTimer.start(400, True)
@@ -273,8 +269,7 @@ class EventViewBase:
 			text = '\n\n' + _('Similar broadcasts:')
 			ret.sort(self.sort_func)
 			for x in ret:
-				t = localtime(x[1])
-				text += _('\n%d.%d.%d, %2d:%02d  -  %s')%(t[2], t[1], t[0], t[3], t[4], x[0])
+				text += "\n%s  -  %s" % (strftime(config.usage.date.long.value + ", " + config.usage.time.short.value, localtime(x[1])), x[0])
 			descr = self["epg_description"]
 			descr.setText(descr.getText()+text)
 			descr = self["FullDescription"]

--- a/lib/python/Screens/OScamInfo.py
+++ b/lib/python/Screens/OScamInfo.py
@@ -1152,7 +1152,7 @@ class oscReaderStats(Screen, OscamInfo):
 								try:
 									last_req = lastreq.split("T")[1][:-5]
 								except IndexError:
-									last_req = time.strftime("%H:%M:%S",time.localtime(float(lastreq)))
+									last_req = time.strftime(config.usage.time.long.value, time.localtime(float(lastreq)))
 							else:
 								last_req = ""
 						else:

--- a/lib/python/Screens/PowerTimerEntry.py
+++ b/lib/python/Screens/PowerTimerEntry.py
@@ -132,12 +132,12 @@ class TimerEntry(Screen, ConfigListScreen):
 		self.timerentry_autosleeprepeat = ConfigSelection(choices = [("once",_("once")), ("repeated", _("repeated"))], default = autosleeprepeat)
 		self.timerrntry_autosleepinstandbyonly = ConfigSelection(choices = [("yes",_("Yes")), ("no", _("No"))],default=autosleepinstandbyonly)
 
-		self.timerentry_date = ConfigDateTime(default = self.timer.begin, formatstring = _("%d.%B %Y"), increment = 86400)
+		self.timerentry_date = ConfigDateTime(default = self.timer.begin, formatstring = config.usage.date.full.value, increment = 86400)
 		self.timerentry_starttime = ConfigClock(default = self.timer.begin)
 		self.timerentry_endtime = ConfigClock(default = self.timer.end)
 		self.timerentry_showendtime = ConfigSelection(default = (((self.timer.end - self.timer.begin) /60 ) > 1), choices = [(True, _("yes")), (False, _("no"))])
 
-		self.timerentry_repeatedbegindate = ConfigDateTime(default = self.timer.repeatedbegindate, formatstring = _("%d.%B %Y"), increment = 86400)
+		self.timerentry_repeatedbegindate = ConfigDateTime(default = self.timer.repeatedbegindate, formatstring = config.usage.date.full.value, increment = 86400)
 
 		self.timerentry_weekday = ConfigSelection(default = weekday_table[weekday], choices = [("mon",_("Monday")), ("tue", _("Tuesday")), ("wed",_("Wednesday")), ("thu", _("Thursday")), ("fri", _("Friday")), ("sat", _("Saturday")), ("sun", _("Sunday"))])
 

--- a/lib/python/Screens/TimeDateInput.py
+++ b/lib/python/Screens/TimeDateInput.py
@@ -1,5 +1,5 @@
 from Screen import Screen
-from Components.config import ConfigClock, ConfigDateTime, getConfigListEntry
+from Components.config import config, ConfigClock, ConfigDateTime, getConfigListEntry
 from Components.ActionMap import NumberActionMap
 from Components.ConfigList import ConfigListScreen
 from Components.Label import Label
@@ -37,7 +37,7 @@ class TimeDateInput(Screen, ConfigListScreen):
 		if conf_date:
 			self.save_mask |= 2
 		else:
-			conf_date = ConfigDateTime(default = time.time(), formatstring = _("%d.%B %Y"), increment = 86400)
+			conf_date = ConfigDateTime(default=time.time(), formatstring=config.usage.date.full.value, increment=86400)
 		self.timeinput_date = conf_date
 		self.timeinput_time = conf_time
 

--- a/lib/python/Screens/TimerEntry.py
+++ b/lib/python/Screens/TimerEntry.py
@@ -167,7 +167,7 @@ class TimerEntry(Screen, ConfigListScreen):
 		self.timerentry_repeated = ConfigSelection(default = repeated, choices = [("weekly", _("weekly")), ("daily", _("daily")), ("weekdays", _("Mon-Fri")), ("user", _("user defined"))])
 		self.timerentry_renamerepeat = ConfigYesNo(default = rename_repeat)
 
-		self.timerentry_date = ConfigDateTime(default = self.timer.begin, formatstring = _("%d %B %Y"), increment = 86400)
+		self.timerentry_date = ConfigDateTime(default = self.timer.begin, formatstring = config.usage.date.full.value, increment = 86400)
 		self.timerentry_starttime = ConfigClock(default = self.timer.begin)
 		self.timerentry_endtime = ConfigClock(default = self.timer.end)
 		self.timerentry_showendtime = ConfigSelection(default = False, choices = [(True, _("yes")), (False, _("no"))])
@@ -178,7 +178,7 @@ class TimerEntry(Screen, ConfigListScreen):
 			tmp.append(default)
 		self.timerentry_dirname = ConfigSelection(default = default, choices = tmp)
 
-		self.timerentry_repeatedbegindate = ConfigDateTime(default = self.timer.repeatedbegindate, formatstring = _("%d.%B %Y"), increment = 86400)
+		self.timerentry_repeatedbegindate = ConfigDateTime(default = self.timer.repeatedbegindate, formatstring = config.usage.date.full.value, increment = 86400)
 
 		self.timerentry_weekday = ConfigSelection(default = weekday_table[weekday], choices = [("mon",_("Monday")), ("tue", _("Tuesday")), ("wed",_("Wednesday")), ("thu", _("Thursday")), ("fri", _("Friday")), ("sat", _("Saturday")), ("sun", _("Sunday"))])
 
@@ -614,7 +614,7 @@ class TimerLog(Screen):
 		self.updateText()
 
 	def fillLogList(self):
-		self.list = [(str(strftime("%Y-%m-%d %H-%M", localtime(x[0])) + " - " + x[2]), x) for x in self.log_entries]
+		self.list = [(str(strftime(config.usage.date.longfulldate.value, localtime(x[0])) + " - " + x[2]), x) for x in self.log_entries]
 
 	def clearLog(self):
 		self.log_entries = []
@@ -672,4 +672,3 @@ class InstantRecordTimerEntry(TimerEntry):
 
 	def saveTimer(self):
 		self.session.nav.RecordTimer.saveTimer()
-

--- a/lib/python/Tools/FuzzyDate.py
+++ b/lib/python/Tools/FuzzyDate.py
@@ -1,10 +1,10 @@
-from time import localtime, time
+from Components.config import config
+from time import localtime, time, strftime
 
-def FuzzyTime(t, inPast = False):
+def FuzzyTime(t, inPast=False):
 	d = localtime(t)
 	nt = time()
-	n = localtime()
-	dayOfWeek = (_("Mon"), _("Tue"), _("Wed"), _("Thu"), _("Fri"), _("Sat"), _("Sun"))
+	n = localtime(nt)
 
 	if d[:3] == n[:3]:
 		# same day
@@ -12,20 +12,20 @@ def FuzzyTime(t, inPast = False):
 	elif d[0] == n[0] and d[7] == n[7] - 1 and inPast:
 		# won't work on New Year's day
 		date = _("Yesterday")
-	elif ((t - nt) < 7*86400) and (nt < t) and not inPast:
+	elif ((t - nt) < 7 * 86400) and (nt < t) and not inPast:
 		# same week (must be future)
-		date = dayOfWeek[d[6]]
+		date = strftime("%a", d)
 	elif d[0] == n[0]:
 		# same year
 		if inPast:
 			# I want the day in the movielist
-			date = "%s %d.%d" % (dayOfWeek[d[6]], d[2], d[1])
+			date = strftime(config.usage.date.dayshort.value, d)
 		else:
-			date = "%d.%d" % (d[2], d[1])
+			date = strftime(config.usage.date.short.value, d)
 	else:
-		date = "%d.%d.%d" % (d[2], d[1], d[0])
+		date = strftime(config.usage.date.long.value, d)
 
-	timeres = "%d:%02d" % (d[3], d[4])
+	timeres = strftime(config.usage.time.short.value, d)
 
 	return date, timeres
 

--- a/lib/python/Tools/StbHardware.py
+++ b/lib/python/Tools/StbHardware.py
@@ -1,6 +1,7 @@
 from fcntl import ioctl
 from struct import pack, unpack
 from boxbranding import getBrandOEM
+from Components.config import config
 
 def getFPVersion():
 	ret = None
@@ -37,7 +38,7 @@ def setRTCoffset():
 
 	t_local = time.localtime(int(time.time()))
 
-	print "set RTC to %s (rtc_offset = %s sec.)" % (time.strftime("%Y/%m/%d %H:%M", t_local), forsleep)
+	print "set RTC to %s (rtc_offset = %s sec.)" % (time.strftime(config.usage.date.daylong.value + "  " + config.usage.time.short.value, t_local), forsleep)
 
 	# Set RTC OFFSET (diff. between UTC and Local Time)
 	try:


### PR DESCRIPTION
The changes to the various modules in this pull request are to remove the hard coded date and time formats and use the new user selectable date / time formats.

Please note that as a result of the new global configuration options for date and time the specific time settings for the EPG timeline are no longer required.  The timeline format is now synchronised to global time format. This change eliminates the need for the config.epgselection.graph_timeline24h and config.epgselection.infobar_timeline24h configuration settings.

[setup.xml] Remove deprecated EPG timeline 24hour configurations

[UsageConfig.py] Remove deprecated EPG timeline 24hour configurations
