### PR TITLE
Enhance EventName and genre

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -116,6 +116,8 @@
 		<item level="2" text="Maintain old EPG data for" description="Configure for how many minutes finished events should remain visible in the EPG. Useful when you need information about an event which has just finished, or has been delayed.">config.epg.histminutes</item>
 		<item level="2" text="Include EIT in http streams" description="When enabled, EIT data will be included in http streams. This allows a client receiver to show EPG.">config.streaming.stream_eit</item>
 		<item level="2" text="Include AIT in http streams" description="When enabled, AIT data will be included in http streams. This allows a client receiver to use HbbTV.">config.streaming.stream_ait</item>
+		<item level="2" text="Country for EPG event rating information" description="Choose a country scheme for decoding rating information in EPG events.">config.misc.epgratingcountry</item>
+		<item level="2" text="Country for EPG event genre information" description="Choose a country scheme for decoding genre information in EPG events.">config.misc.epggenrecountry</item>
 	</setup>
 	<setup key="subtitlesetup" title="Subtitle settings">
 		<item level="2" text="Teletext subtitle color" description="Configure the color of the teletext subtitles.">config.subtitles.ttx_subtitle_colors</item>

--- a/lib/python/Components/Converter/EventName.py
+++ b/lib/python/Components/Converter/EventName.py
@@ -3,6 +3,7 @@ from enigma import eEPGCache
 from Components.Converter.Converter import Converter
 from Components.Element import cached
 from Components.Converter.genre import getGenreStringSub
+from Components.config import config
 
 
 class ETSIClassifications(dict):
@@ -182,6 +183,8 @@ class EventName(Converter, object):
 					c = countries[country]
 				else:
 					c = countries["ETSI"]
+				if config.misc.epgratingcountry.value:
+					c = countries[config.misc.epgratingcountry.value]
 				rating = c[self.RATNORMAL].get(age, c[self.RATDEFAULT](age))
 				if rating:
 					if self.type == self.RATING:
@@ -196,6 +199,8 @@ class EventName(Converter, object):
 					country = rating.getCountryCode().upper()
 				else:
 					country = "ETSI"
+				if config.misc.epggenrecountry.value:
+					country = config.misc.epggenrecountry.value
 				return self.trimText(getGenreStringSub(genre.getLevel1(), genre.getLevel2(), country=country))
 		elif self.type == self.NAME_NOW:
 			return pgettext("now/next: 'now' event label", "Now") + ": " + self.trimText(event.getEventName())

--- a/lib/python/Components/Converter/EventName.py
+++ b/lib/python/Components/Converter/EventName.py
@@ -5,6 +5,59 @@ from Components.Element import cached
 from Components.Converter.genre import getGenreStringSub
 
 
+class ETSIClassifications(dict):
+	def shortRating(self, age):
+		if age == 0:
+			return _("All ages")
+		elif age <= 15:
+			age += 3
+			return " %d+" % age
+
+	def longRating(self, age):
+		if age == 0:
+			return _("Rating undefined")
+		elif age <= 15:
+			age += 3
+			return _("Minimum age %d years") % age
+
+	def __init__(self):
+		self.update([(i, (self.shortRating(c), self.longRating(c))) for i, c in enumerate(range(0, 15))])
+
+
+class AusClassifications(dict):
+	# In Australia "Not Classified" (NC) is to be displayed as an empty string.
+	#            0   1   2    3    4    5    6    7    8     9     10   11   12    13    14    15
+	SHORTTEXT = ("", "", "P", "P", "C", "C", "G", "G", "PG", "PG", "M", "M", "MA", "MA", "AV", "R")
+	LONGTEXT = {
+		"": _("Not Classified"),
+		"P": _("Preschool"),
+		"C": _("Children"),
+		"G": _("General"),
+		"PG": _("Parental Guidance Recommended"),
+		"M": _("Mature Audience 15+"),
+		"MA": _("Mature Adult Audience 15+"),
+		"AV": _("Adult Audience, Strong Violence 15+"),
+		"R": _("Restricted 18+")
+	}
+
+	def __init__(self):
+		self.update([(i, (c, self.LONGTEXT[c])) for i, c in enumerate(self.SHORTTEXT)])
+
+
+# Each country classification object in the map tuple must be an object that
+# supports obj.get(key[, default]). It need not actually be a dict object.
+#
+# The other element is how the rating number should be formatted if there
+# is no match in the classification object.
+#
+# If there is no matching country then the default ETSI should be selected.
+
+countries = {
+	"ETSI": (ETSIClassifications(), lambda age: (_("bc%d") % age, _("Rating defined by broadcaster - %d") % age)),
+	"AUS": (AusClassifications(), lambda age: (_("BC%d") % age, _("Rating defined by broadcaster - %d") % age))
+}
+
+
 class EventName(Converter, object):
 	NAME = 0
 	SHORT_DESCRIPTION = 1
@@ -27,55 +80,86 @@ class EventName(Converter, object):
 	THIRD_NAME2 = 23
 	THIRD_DESCRIPTION = 24
 
+	RAWRATING = 31
+	RATINGCOUNTRY = 32
+
+	KEYWORDS = {
+		# Arguments...
+		"Name": ("type", NAME),
+		"Description": ("type", SHORT_DESCRIPTION),
+		"ExtendedDescription": ("type", EXTENDED_DESCRIPTION),
+		"FullDescription": ("type", FULL_DESCRIPTION),
+		"ID": ("type", ID),
+		"NowName": ("type", NAME_NOW),
+		"NameNow": ("type", NAME_NOW),
+		"NextName": ("type", NAME_NEXT),
+		"NameNext": ("type", NAME_NEXT),
+		"NextNameOnly": ("type", NAME_NEXT2),
+		"NameNextOnly": ("type", NAME_NEXT2),
+		"Genre": ("type", GENRE),
+		"Rating": ("type", RATING),
+		"SmallRating": ("type", SRATING),
+		"Pdc": ("type", PDC),
+		"PdcTime": ("type", PDCTIME),
+		"PdcTimeShort": ("type", PDCTIMESHORT),
+		"IsRunningStatus": ("type", ISRUNNINGSTATUS),
+		"NextDescription": ("type", NEXT_DESCRIPTION),
+		"ThirdName": ("type", THIRD_NAME),
+		"ThirdNameOnly": ("type", THIRD_NAME2),
+		"ThirdDescription": ("type", THIRD_DESCRIPTION),
+		"RawRating": ("type", RAWRATING),
+		"RatingCountry": ("type", RATINGCOUNTRY),
+		# Options...
+		"Separated": ("separator", "\n\n"),
+		"NotSeparated": ("separator", "\n"),
+		"Trimmed": ("trim", True),
+		"NotTrimmed": ("trim", False)
+	}
+
+	RATSHORT = 0
+	RATLONG = 1
+
+	RATNORMAL = 0
+	RATDEFAULT = 1
+
 	def __init__(self, type):
 		Converter.__init__(self, type)
 		self.epgcache = eEPGCache.getInstance()
-		if type == "Description":
-			self.type = self.SHORT_DESCRIPTION
-		elif type == "ExtendedDescription":
-			self.type = self.EXTENDED_DESCRIPTION
-		elif type == "FullDescription":
-			self.type = self.FULL_DESCRIPTION
-		elif type == "ID":
-			self.type = self.ID
-		elif type == "NameNow" or type == "NowName":
-			self.type = self.NAME_NOW
-		elif type == "NameNext" or type == "NextName":
-			self.type = self.NAME_NEXT
-		elif type == "NameNextOnly" or type == "NextNameOnly":
-			self.type = self.NAME_NEXT2
-		elif type == "Genre":
-			self.type = self.GENRE
-		elif type == "Rating":
-			self.type = self.RATING
-		elif type == "SmallRating":
-			self.type = self.SRATING
-		elif type == "Pdc":
-			self.type = self.PDC
-		elif type == "PdcTime":
-			self.type = self.PDCTIME
-		elif type == "PdcTimeShort":
-			self.type = self.PDCTIMESHORT
-		elif type == "IsRunningStatus":
-			self.type = self.ISRUNNINGSTATUS
-		elif type == "NextDescription":
-			self.type = self.NEXT_DESCRIPTION
-		elif type == "ThirdName":
-			self.type = self.THIRD_NAME
-		elif type == "ThirdNameOnly":
-			self.type = self.THIRD_NAME2
-		elif type == "ThirdDescription":
-			self.type = self.THIRD_DESCRIPTION
+
+		self.type = self.NAME
+		self.separator = "\n"
+		self.trim = False
+
+		parse = ","
+		type.replace(";", parse)  # Some builds use ";" as a separator, most use ",".
+		args = [arg.strip() for arg in type.split(parse)]
+		for arg in args:
+			name, value = self.KEYWORDS.get(arg, ("Error", None))
+			if name == "Error":
+				print "[EventName] ERROR: Unexpected / Invalid argument token '%s'!" % arg
+			else:
+				setattr(self, name, value)
+
+	def trimText(self, text):
+		if self.trim:
+			return str(text).strip()
 		else:
-			self.type = self.NAME
+			return str(text)
+
+	def formatDescription(self, description, extended):
+		description = self.trimText(description)
+		extended = self.trimText(extended)
+		if description[0:20] == extended[0:20]:
+			return extended
+		if description and extended:
+			description += self.separator
+		return description + extended
 
 	@cached
 	def getBoolean(self):
 		event = self.source.event
-		if event is None:
-			return False
-		if self.type == self.PDC:
-			if event.getPdcPil():
+		if event:
+			if self.type == self.PDC and event.getPdcPil():
 				return True
 		return False
 
@@ -88,120 +172,98 @@ class EventName(Converter, object):
 			return ""
 
 		if self.type == self.NAME:
-			return event.getEventName()
-		elif self.type == self.SRATING:
+			return self.trimText(event.getEventName())
+		elif self.type in (self.RATING, self.SRATING):
 			rating = event.getParentalData()
-			if rating is None:
-				return ""
-			else:
-				country = rating.getCountryCode()
+			if rating:
 				age = rating.getRating()
-				if age == 0:
-					return _("All ages")
-				elif age > 15:
-					return _("bc%s") % age
+				country = rating.getCountryCode().upper()
+				if country in countries:
+					c = countries[country]
 				else:
-					age += 3
-					return " %d+" % age
-		elif self.type == self.RATING:
-			rating = event.getParentalData()
-			if rating is None:
-				return ""
-			else:
-				country = rating.getCountryCode()
-				age = rating.getRating()
-				if age == 0:
-					return _("Rating undefined")
-				elif age > 15:
-					return _("Rating defined by broadcaster - %d") % age
-				else:
-					age += 3
-					return _("Minimum age %d years") % age
+					c = countries["ETSI"]
+				rating = c[self.RATNORMAL].get(age, c[self.RATDEFAULT](age))
+				if rating:
+					if self.type == self.RATING:
+						return self.trimText(rating[self.RATLONG])
+					else:
+						return self.trimText(rating[self.RATSHORT])
 		elif self.type == self.GENRE:
 			genre = event.getGenreData()
-			if genre is None:
-				return ""
-			else:
-				return getGenreStringSub(genre.getLevel1(), genre.getLevel2())
+			if genre:
+				rating = event.getParentalData()
+				if rating:
+					country = rating.getCountryCode().upper()
+				else:
+					country = "ETSI"
+				return self.trimText(getGenreStringSub(genre.getLevel1(), genre.getLevel2(), country=country))
 		elif self.type == self.NAME_NOW:
-			return pgettext("now/next: 'now' event label", "Now") + ": " + event.getEventName()
+			return pgettext("now/next: 'now' event label", "Now") + ": " + self.trimText(event.getEventName())
 		elif self.type == self.SHORT_DESCRIPTION:
-			return event.getShortDescription()
+			return self.trimText(event.getShortDescription())
 		elif self.type == self.EXTENDED_DESCRIPTION:
-			return event.getExtendedDescription() or event.getShortDescription()
+			return self.trimText(event.getExtendedDescription() or event.getShortDescription())
 		elif self.type == self.FULL_DESCRIPTION:
-			description = event.getShortDescription()
-			extended = event.getExtendedDescription()
-			if description and extended:
-				description += '\n'
-			return description + extended
+			return self.formatDescription(event.getShortDescription(), event.getExtendedDescription())
 		elif self.type == self.ID:
-			return str(event.getEventId())
+			return self.trimText(event.getEventId())
 		elif self.type == self.PDC:
 			if event.getPdcPil():
 				return _("PDC")
-			return ""
 		elif self.type in (self.PDCTIME, self.PDCTIMESHORT):
 			pil = event.getPdcPil()
 			if pil:
 				if self.type == self.PDCTIMESHORT:
 					return _("%02d:%02d") % ((pil & 0x7C0) >> 6, (pil & 0x3F))
 				return _("%d.%02d. %02d:%02d") % ((pil & 0xF8000) >> 15, (pil & 0x7800) >> 11, (pil & 0x7C0) >> 6, (pil & 0x3F))
-			return ""
 		elif self.type == self.ISRUNNINGSTATUS:
 			if event.getPdcPil():
 				running_status = event.getRunningStatus()
 				if running_status == 1:
-					return "not running"
+					return _("Not running")
 				if running_status == 2:
-					return "starts in a few seconds"
+					return _("Starts in a few seconds")
 				if running_status == 3:
-					return "pausing"
+					return _("Pausing")
 				if running_status == 4:
-					return "running"
+					return _("Running")
 				if running_status == 5:
-					return "service off-air"
-				if running_status in (6,7):
-					return "reserved for future use"
-				return "undefined"
-			return ""
-
-		elif int(self.type) in (6,7) or int(self.type) >= 21:
+					return _("Service off-air")
+				if running_status in (6, 7):
+					return _("Reserved for future use")
+				return _("Undefined")
+		elif self.type in (self.NAME_NEXT, self.NAME_NEXT2) or self.type >= self.NEXT_DESCRIPTION:
 			try:
 				reference = self.source.service
 				info = reference and self.source.info
-				if info is None:
-					return
-				test = [ 'ITSECX', (reference.toString(), 1, -1, 1440) ] # search next 24 hours
-				self.list = [] if self.epgcache is None else self.epgcache.lookupEvent(test)
-				if self.list:
+				if info:
+					test = ["ITSECX", (reference.toString(), 1, -1, 1440)]  # Search next 24 hours
+					self.list = [] if self.epgcache is None else self.epgcache.lookupEvent(test)
+					if self.list:
 						if self.type == self.NAME_NEXT and self.list[1][1]:
-							return pgettext("now/next: 'next' event label", "Next") + ": " + self.list[1][1]
+							return pgettext("now/next: 'next' event label", "Next") + ": " + self.trimText(self.list[1][1])
 						elif self.type == self.NAME_NEXT2 and self.list[1][1]:
-							return self.list[1][1]
+							return self.trimText(self.list[1][1])
 						elif self.type == self.NEXT_DESCRIPTION and (self.list[1][2] or self.list[1][3]):
-							description = self.list[1][2]
-							extended = self.list[1][3]
-							if (description and extended) and (description[0:20] != extended[0:20]):
-								description += '\n'
-							return description + extended
+							return self.formatDescription(self.list[1][2], self.list[1][3])
 						if self.type == self.THIRD_NAME and self.list[2][1]:
-							return pgettext("third event: 'third' event label", "Later") + ": " + self.list[2][1]
+							return pgettext("third event: 'third' event label", "Later") + ": " + self.trimText(self.list[2][1])
 						elif self.type == self.THIRD_NAME2 and self.list[2][1]:
-							return self.list[2][1]
+							return self.trimText(self.list[2][1])
 						elif self.type == self.THIRD_DESCRIPTION and (self.list[2][2] or self.list[2][3]):
-							description = self.list[2][2]
-							extended = self.list[2][3]
-							if (description and extended) and (description[0:20] != extended[0:20]):
-								description += '\n'
-							return description + extended
-						else:
-							# failed to return any epg data.
-							return ""
+							return self.formatDescription(self.list[2][2], self.list[2][3])
 			except:
-				# failed to return any epg data.
+				# Failed to return any EPG data.
 				if self.type == self.NAME_NEXT:
-					return pgettext("now/next: 'next' event label", "Next") + ": " + event.getEventName()
-				return ""
+					return pgettext("now/next: 'next' event label", "Next") + ": " + self.trimText(event.getEventName())
+		elif self.type == self.RAWRATING:
+			rating = event.getParentalData()
+			if rating:
+				return "%d" % rating.getRating()
+		elif self.type == self.RATINGCOUNTRY:
+			rating = event.getParentalData()
+			if rating:
+				return rating.getCountryCode().upper()
+		return ""
 
 	text = property(getText)

--- a/lib/python/Components/Converter/genre.py
+++ b/lib/python/Components/Converter/genre.py
@@ -4,166 +4,273 @@
 # some broadcaster do define other types so this list
 # may grow or be replaced..
 #
-maintype = [	_("Reserved"),
+class GenresETSI:
+	maintype = (
+		_("Reserved"),
 		_("Movie/Drama"),
-		_("News Current Affairs"),
-		_("Show Games show"),
+		_("News/Current Affairs"),
+		_("Show/Games show"),
 		_("Sports"),
 		_("Children/Youth"),
 		_("Music/Ballet/Dance"),
 		_("Arts/Culture"),
 		_("Social/Political/Economics"),
-		_("Education/Science/..."),
+		_("Education/Science/Factual"),
 		_("Leisure hobbies"),
-		_("Other")]
+		_("Other")
+	)
 
+	subtype = {
+		# Movie/Drama
+		1: (
+			_("movie/drama (general)"),
+			_("detective/thriller"),
+			_("adventure/western/war"),
+			_("science fiction/fantasy/horror"),
+			_("comedy"),
+			_("soap/melodrama/folkloric"),
+			_("romance"),
+			_("serious/classical/religious/historical movie/drama"),
+			_("adult movie/drama")
+		),
+		# News/Current Affairs
+		2: (
+			_("news/current affairs (general)"),
+			_("news/weather report"),
+			_("news magazine"),
+			_("documentary"),
+			_("discussion/interview/debate")
+		),
+		# Show/Game show
+		3: (
+			_("show/game show (general)"),
+			_("game show/quiz/contest"),
+			_("variety show"),
+			_("talk show")
+		),
+		# Sports
+		4: (
+			_("sports (general)"),
+			_("special events"),
+			_("sports magazine"),
+			_("football/soccer"),
+			_("tennis/squash"),
+			_("team sports"),
+			_("athletics"),
+			_("motor sport"),
+			_("water sport"),
+			_("winter sport"),
+			_("equestrian"),
+			_("martial sports")
+		),
+		# Children/Youth
+		5: (
+			_("children's/youth program (general)"),
+			_("pre-school children's program"),
+			_("entertainment (6-14 year old)"),
+			_("entertainment (10-16 year old)"),
+			_("information/education/school program"),
+			_("cartoon/puppets")
+		),
+		# Music/Ballet/Dance
+		6: (
+			_("music/ballet/dance (general)"),
+			_("rock/pop"),
+			_("serious music/classic music"),
+			_("folk/traditional music"),
+			_("jazz"),
+			_("musical/opera"),
+			_("ballet")
+		),
+		# Arts/Culture
+		7: (
+			_("arts/culture (without music, general)"),
+			_("performing arts"),
+			_("fine arts"),
+			_("religion"),
+			_("popular culture/traditional arts"),
+			_("literature"),
+			_("film/cinema"),
+			_("experimental film/video"),
+			_("broadcasting/press"),
+			_("new media"),
+			_("arts/culture magazine"),
+			_("fashion")
+		),
+		# Social/Political/Economics
+		8: (
+			_("social/political issues/economics (general)"),
+			_("magazines/reports/documentary"),
+			_("economics/social advisory"),
+			_("remarkable people")
+		),
+		# Education/Science/...
+		9: (
+			_("education/science/factual topics (general)"),
+			_("nature/animals/environment"),
+			_("technology/natural science"),
+			_("medicine/physiology/psychology"),
+			_("foreign countries/expeditions"),
+			_("social/spiritual science"),
+			_("further education"),
+			_("languages")
+		),
 
-subtype = {}
-# Movie/Drama
-subtype[1] = [
-					_("movie/drama (general)"),
-					_("detective/thriller"),
-					_("adventure/western/war"),
-					_("science fiction/fantasy/horror"),
-					_("comedy"),
-					_("soap/melodram/folkloric"),
-					_("romance"),
-					_("serious/classical/religious/historical movie/drama"),
-					_("adult movie/drama")]
+		# Leisure hobies
+		10: (
+			_("leisure hobbies (general)"),
+			_("tourism/travel"),
+			_("handicraft"),
+			_("motoring"),
+			_("fitness & health"),
+			_("cooking"),
+			_("advertisement/shopping"),
+			_("gardening")
+		),
+		# Other
+		11: (
+			_("original language"),
+			_("black & white"),
+			_("unpublished"),
+			_("live broadcast")
+		),
+	}
 
-# News Current Affairs
-subtype[2] = [
-					_("news/current affairs (general)"),
-					_("news/weather report"),
-					_("news magazine"),
-					_("documentary"),
-					_("discussion/interview/debate")]
+class GenresAUS:
+	maintype = (
+		_("Undefined"),
+		_("Movie"),
+		_("News"),
+		_("Entertainment"),
+		_("Sport"),
+		_("Childrens"),
+		_("Music"),
+		_("Arts/Culture"),
+		_("Current Affairs"),
+		_("Education/Information"),
+		_("Infotainment"),
+		_("Special"),
+		_("Comedy"),
+		_("Drama"),
+		_("Documentary"),
+	)
 
-# Show Games show
-subtype[3] = [
-					_("show/game show (general)"),
-					_("game show/quiz/contest"),
-					_("variety show"),
-					_("talk show")]
+	subtype = {
+		# Movie/Drama
+		1: (
+			_("movie (general)"),
+		),
+		# News
+		2: (
+			_("news (general)"),
+		),
+		# Entertainment
+		3: (
+			_("entertainment (general)"),
+		),
+		# Sport
+		4: (
+			_("sport (general)"),
+		),
+		# Childrens
+		5: (
+			_("childrens (general)"),
+		),
+		# Music
+		6: (
+			_("music (general)"),
+		),
+		# Arts/Culture
+		7: (
+			_("arts/culture (general)"),
+		),
+		# Current Affairs
+		8: (
+			_("current affairs (general)"),
+		),
+		# Education/Information
+		9: (
+			_("education/information (general)"),
+		),
+		# Infotainment
+		10: (
+			_("infotainment (general)"),
+		),
+		# Special
+		11: (
+			_("special (general)"),
+		),
+		# Comedy
+		12: (
+			_("comedy (general)"),
+		),
+		# Drama
+		13: (
+			_("drama (general)"),
+		),
+		# Documentary
+		14: (
+			_("documentary (general)"),
+		),
+	}
 
-# Sports
-subtype[4] = [
-					_("sports (general)"),
-					_("special events"),
-					_("sports magazine"),
-					_("football/soccer"),
-					_("tennis/squash"),
-					_("team sports"),
-					_("athletics"),
-					_("motor sport"),
-					_("water sport"),
-					_("winter sport"),
-					_("equestrian"),
-					_("martial sports")]
-
-# Children/Youth
-subtype[5] = [
-					_("childrens's/youth program (general)"),
-					_("pre-school children's program"),
-					_("entertainment (6-14 year old)"),
-					_("entertainment (10-16 year old)"),
-					_("information/education/school program"),
-					_("cartoon/puppets")]
-
-# Music/Ballet/Dance
-subtype[6] = [
-					_("music/ballet/dance (general)"),
-					_("rock/pop"),
-					_("serious music/classic music"),
-					_("folk/traditional music"),
-					_("jazz"),
-					_("musical/opera"),
-					_("ballet")]
-
-# Arts/Culture
-subtype[7] = [
-					_("arts/culture (without music, general)"),
-					_("performing arts"),
-					_("fine arts"),
-					_("religion"),
-					_("popular culture/traditional arts"),
-					_("literature"),
-					_("film/cinema"),
-					_("experimental film/video"),
-					_("broadcasting/press"),
-					_("new media"),
-					_("arts/culture magazine"),
-					_("fashion")]
-
-# Social/Political/Economics
-subtype[8] = [
-					_("social/political issues/economics (general)"),
-					_("magazines/reports/documentary"),
-					_("economics/social advisory"),
-					_("remarkable people")]
-
-# Education/Science/...
-subtype[9] = [
-					_("education/science/factual topics (general)"),
-					_("nature/animals/environment"),
-					_("technology/natural science"),
-					_("medicine/physiology/psychology"),
-					_("foreign countries/expeditions"),
-					_("social/spiritual science"),
-					_("further education"),
-					_("languages")]
-
-# Leisure hobies
-subtype[10] = [
-					_("leisure hobbies (general)"),
-					_("tourism/travel"),
-					_("handicraft"),
-					_("motoring"),
-					_("fitness & health"),
-					_("cooking"),
-					_("advertisement/shopping"),
-					_("gardening")]
-
-# Other
-subtype[11] = [
-					_("original language"),
-					_("black & white"),
-					_("unpublished"),
-					_("live broadcast")]
-
-def getGenreStringMain(hn, ln):
-#	if hn == 0:
-#		return _("Undefined content")
+def __getGenreStringMain(hn, ln, genres):
+	# if hn == 0:
+	# 	return _("Undefined content")
 	if hn == 15:
 		return _("User defined")
-	if 0 < hn < len(maintype):
-		return maintype[hn]
-#	return _("Reserved") + " " + str(hn)
+	if 0 < hn < len(genres.maintype):
+		return genres.maintype[hn]
+	# return _("Reserved") + " " + str(hn)
 	return ""
 
-def getGenreStringSub(hn, ln):
-#	if hn == 0:
-#		return _("Undefined content") + " " + str(ln)
+def __getGenreStringSub(hn, ln, genres):
+	# if hn == 0:
+	# 	return _("Undefined content") + " " + str(ln)
 	if hn == 15:
 		return _("User defined") + " " + str(ln)
-	if 0 < hn < len(maintype):
+	if 0 < hn < len(genres.maintype):
 		if ln == 15:
 			return _("User defined")
-		if ln < len(subtype[hn]):
-			return subtype[hn][ln]
-#		return _("Reserved") " " + str(ln)
-#	return _("Reserved") + " " + str(hn) + "," + str(ln)
+		if ln < len(genres.subtype[hn]):
+			return genres.subtype[hn][ln]
+	# 	return _("Reserved") " " + str(ln)
+	# return _("Reserved") + " " + str(hn) + "," + str(ln)
 	return ""
 
-def getGenreStringLong(hn, ln):
-#	if hn == 0:
-#		return _("Undefined content") + " " + str(ln)
+countries = {
+	"AUS": (__getGenreStringMain, __getGenreStringMain, GenresAUS()),
+}
+
+defaultGenre = GenresETSI()
+defaultCountryInfo = (__getGenreStringMain, __getGenreStringSub, defaultGenre)
+
+# Backwards compatibility - use deprecated
+
+maintype = defaultGenre.maintype
+subtype = defaultGenre.subtype
+
+
+def getGenreStringMain(hn, ln, country=None):
+	countryInfo = countries.get(country, defaultCountryInfo)
+	return countryInfo[0](hn, ln, countryInfo[2])
+
+def getGenreStringSub(hn, ln, country=None):
+	countryInfo = countries.get(country, defaultCountryInfo)
+	return countryInfo[1](hn, ln, countryInfo[2])
+
+def getGenreStringLong(hn, ln, country=None):
+	# if hn == 0:
+	# 	return _("Undefined content") + " " + str(ln)
 	if hn == 15:
 		return _("User defined") + " " + str(ln)
-	if 0 < hn < len(maintype):
-		return maintype[hn] + ": " + getGenreStringSub(hn, ln)
-#	return _("Reserved") + " " + str(hn) + "," + str(ln)
-	return ""
+	main = getGenreStringMain(hn, ln, country=country)
+	sub = getGenreStringSub(hn, ln)
+	if main and main != sub:
+		return main + ": " + sub
+	else:
+		return main
+# 	return _("Reserved") + " " + str(hn) + "," + str(ln)
 
 #
 # The End

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -658,6 +658,9 @@ def InitUsageConfig():
 	config.misc.epgcachepath.addNotifier(EpgCacheChanged, immediate_feedback = False)
 	config.misc.epgcachefilename.addNotifier(EpgCacheChanged, immediate_feedback = False)
 
+	config.misc.epgratingcountry = ConfigSelection(default="", choices=[("", _("Auto Detect")), ("ETSI", _("Generic")), ("AUS", _("Australia"))])
+	config.misc.epggenrecountry = ConfigSelection(default="", choices=[("", _("Auto Detect")), ("ETSI", _("Generic")), ("AUS", _("Australia"))])
+
 	config.misc.showradiopic = ConfigYesNo(default = True)
 
 	def setHDDStandby(configElement):


### PR DESCRIPTION
These changes are to implement the following:

- Add the infrastructure to localise the ratings and genres.  The current "ETSI" standard in maintained as the default but developers can add other standards as required.  To start things off I have added the structures for Australia ("AUS").  Other countries with different rules can be similarly added.

    The switch between versions of rating and genre are automatically triggered by the country coded in the transmission.  If required a setting option could be added to override this automatic selection and force a particular standard.

- Add options to the EventName converter to allow skin writers finer control on how the items offered by this converter are displayed.  The arguments and options are provided in a comma separated list.  (Given that some builds use commas and others semicolons to separate converter parameters this code will accept both!)

    - Option "Separated" places a blank line between the description and extended description in "FullDescription" displays.
    - Option "NotSeparated" places the extended description on the following line after the description in "FullDescription" displays.  This is the default.
    - Option "Trimmed" strips leading and trailing spaces from the item being displayed.
    - Option "NotTrimmed" shows the item as defined.  This is the default.

    The options have enable and disable values to allow the skin developer to specify the display they require that do not depend on the default defined in the code.

- Refactor the code to simplify the structure of the code while allowing the additional functionality.

Some of these changes are based on the efforts of Prl in the Beyonwiz repository.
