### PR TITLE
[EventName] Use date / time formats for PDC data

### DIFF
--- a/lib/python/Components/Converter/EventName.py
+++ b/lib/python/Components/Converter/EventName.py
@@ -4,6 +4,7 @@ from Components.Converter.Converter import Converter
 from Components.Element import cached
 from Components.Converter.genre import getGenreStringSub
 from Components.config import config
+from time import localtime, strftime
 
 
 class ETSIClassifications(dict):
@@ -218,9 +219,17 @@ class EventName(Converter, object):
 		elif self.type in (self.PDCTIME, self.PDCTIMESHORT):
 			pil = event.getPdcPil()
 			if pil:
+				# if self.type == self.PDCTIMESHORT:
+				# 	return _("%02d:%02d") % ((pil & 0x7C0) >> 6, (pil & 0x3F))
+				# return _("%d.%02d. %02d:%02d") % ((pil & 0xF8000) >> 15, (pil & 0x7800) >> 11, (pil & 0x7C0) >> 6, (pil & 0x3F))
+				start = localtime()
+				start.tm_mon = (pil & 0x7800) >> 11
+				start.tm_mday = (pil & 0xF8000) >> 15
+				start.tm_hour = (pil & 0x7C0) >> 6
+				start.tm_min = (pil & 0x3F)
 				if self.type == self.PDCTIMESHORT:
-					return _("%02d:%02d") % ((pil & 0x7C0) >> 6, (pil & 0x3F))
-				return _("%d.%02d. %02d:%02d") % ((pil & 0xF8000) >> 15, (pil & 0x7800) >> 11, (pil & 0x7C0) >> 6, (pil & 0x3F))
+					return strftime(config.usage.time.short.value, start)
+				return strftime(config.usage.date.short.value + " " + config.usage.time.short.value, start)
 		elif self.type == self.ISRUNNINGSTATUS:
 			if event.getPdcPil():
 				running_status = event.getRunningStatus()


### PR DESCRIPTION
This change allows the "PdcTime" and "PdcTimeShort" values to follow the user selected date and time formats.
