### PR TITLE
Remove positioner test pattern on exit or cancel

### DIFF
--- a/lib/python/Screens/UserInterfacePositioner.py
+++ b/lib/python/Screens/UserInterfacePositioner.py
@@ -25,16 +25,16 @@ def setPositionParameter(parameter, configElement):
 		f.write('1')
 		f.close()
 
-	#	InitOsd is now the 2nd Initialisation routine and is called after LCD iniialisation
-	#	by mytest.py .. this was historically the case before the 3D modification
-	#	It is important that this call remains in mytest.py at this position!
-
+# InitOsd is now the 2nd Initialisation routine and is called after LCD iniialisation
+# by mytest.py .. this was historically the case before the 3D modification
+# It is important that this call remains in mytest.py at this position!
+#
 def InitOsd():
 	SystemInfo["CanChangeOsdAlpha"] = access('/proc/stb/video/alpha', R_OK) and True or False
 	SystemInfo["CanChangeOsdPosition"] = access('/proc/stb/fb/dst_left', R_OK) and True or False
 	SystemInfo["OsdSetup"] = SystemInfo["CanChangeOsdPosition"]
 
-	if SystemInfo["CanChangeOsdAlpha"] == True or SystemInfo["CanChangeOsdPosition"] == True:
+	if SystemInfo["CanChangeOsdAlpha"] is True or SystemInfo["CanChangeOsdPosition"] is True:
 		SystemInfo["OsdMenu"] = True
 	else:
 		SystemInfo["OsdMenu"] = False
@@ -58,7 +58,7 @@ def InitOsd():
 		if SystemInfo["CanChangeOsdPosition"]:
 			setPositionParameter("height", configElement)
 	config.osd.dst_height.addNotifier(setOSDHeight)
-	print '[UserInterfacePositioner] Setting OSD position: %s %s %s %s' %  (config.osd.dst_left.value, config.osd.dst_width.value, config.osd.dst_top.value, config.osd.dst_height.value)
+	print '[UserInterfacePositioner] Setting OSD position: %s %s %s %s' % (config.osd.dst_left.value, config.osd.dst_width.value, config.osd.dst_top.value, config.osd.dst_height.value)
 
 	def setOSDAlpha(configElement):
 		if SystemInfo["CanChangeOsdAlpha"]:
@@ -69,10 +69,9 @@ def InitOsd():
 			f.close()
 	config.osd.alpha.addNotifier(setOSDAlpha)
 
-
-	#	InitOsd3D is the 1st Initialisation routine and is called by mytest.py to enable 3D setup by Videomode.py
-	#	It is important that this call remains in mytest.py at this position! 
-
+# InitOsd3D is the 1st Initialisation routine and is called by mytest.py to enable 3D setup by Videomode.py
+# It is important that this call remains in mytest.py at this position!
+#
 def InitOsd3D():
 	SystemInfo["CanChange3DOsd"] = (access('/proc/stb/fb/3dmode', R_OK) or access('/proc/stb/fb/primary/3d', R_OK)) and True or False
 
@@ -80,21 +79,21 @@ def InitOsd3D():
 		language.activateLanguage(configElement.value)
 
 	config.osd = ConfigSubsection()
-	config.osd.language = ConfigText(default = "en_GB")
+	config.osd.language = ConfigText(default="en_GB")
 	config.osd.language.addNotifier(languageNotifier)
-	config.osd.dst_left = ConfigSelectionNumber(default = 0, stepwidth = 1, min = 0, max = 720, wraparound = False)
-	config.osd.dst_width = ConfigSelectionNumber(default = 720, stepwidth = 1, min = 0, max = 720, wraparound = False)
-	config.osd.dst_top = ConfigSelectionNumber(default = 0, stepwidth = 1, min = 0, max = 576, wraparound = False)
-	config.osd.dst_height = ConfigSelectionNumber(default = 576, stepwidth = 1, min = 0, max = 576, wraparound = False)
-	config.osd.alpha = ConfigSelectionNumber(default = 255, stepwidth = 1, min = 0, max = 255, wraparound = False)
-	config.av.osd_alpha = NoSave(ConfigNumber(default = 255))
-	config.osd.threeDmode = ConfigSelection([("off", _("Off")), ("auto", _("Auto")), ("sidebyside", _("Side by Side")),("topandbottom", _("Top and Bottom"))], "auto")
-	config.osd.threeDznorm = ConfigSlider(default = 50, increment = 1, limits = (0, 100))
-	config.osd.show3dextensions = ConfigYesNo(default = False)
+	config.osd.dst_left = ConfigSelectionNumber(default=0, stepwidth=1, min=0, max=720, wraparound=False)
+	config.osd.dst_width = ConfigSelectionNumber(default=720, stepwidth=1, min=0, max=720, wraparound=False)
+	config.osd.dst_top = ConfigSelectionNumber(default=0, stepwidth=1, min=0, max=576, wraparound=False)
+	config.osd.dst_height = ConfigSelectionNumber(default=576, stepwidth=1, min=0, max=576, wraparound=False)
+	config.osd.alpha = ConfigSelectionNumber(default=255, stepwidth=1, min=0, max=255, wraparound=False)
+	config.av.osd_alpha = NoSave(ConfigNumber(default=255))
+	config.osd.threeDmode = ConfigSelection([("off", _("Off")), ("auto", _("Auto")), ("sidebyside", _("Side by Side")), ("topandbottom", _("Top and Bottom"))], "auto")
+	config.osd.threeDznorm = ConfigSlider(default=50, increment=1, limits=(0, 100))
+	config.osd.show3dextensions = ConfigYesNo(default=False)
 
 	def set3DMode(configElement):
 		if SystemInfo["CanChange3DOsd"] and getBoxType() not in ('spycat'):
-			print '[UserInterfacePositioner] Setting 3D mode:',configElement.value
+			print '[UserInterfacePositioner] Setting 3D mode:', configElement.value
 			file3d = fileCheck('/proc/stb/fb/3dmode') or fileCheck('/proc/stb/fb/primary/3d')
 			f = open(file3d, "w")
 			f.write(configElement.value)
@@ -103,11 +102,12 @@ def InitOsd3D():
 
 	def set3DZnorm(configElement):
 		if SystemInfo["CanChange3DOsd"] and getBoxType() not in ('spycat'):
-			print '[UserInterfacePositioner] Setting 3D depth:',configElement.value
+			print '[UserInterfacePositioner] Setting 3D depth:', configElement.value
 			f = open("/proc/stb/fb/znorm", "w")
 			f.write('%d' % int(configElement.value))
 			f.close()
 	config.osd.threeDznorm.addNotifier(set3DZnorm)
+
 
 class UserInterfacePositioner(Screen, ConfigListScreen):
 	def __init__(self, session, menu_path=""):
@@ -127,23 +127,26 @@ class UserInterfacePositioner(Screen, ConfigListScreen):
 			self.setup_title = title
 			self["menu_path_compressed"] = StaticText("")
 		self.Console = Console()
+
+		self.oldref = self.session.nav.getCurrentlyPlayingServiceReference()
+		self.session.nav.stopService()
+
 		self["status"] = StaticText()
 		self["key_red"] = StaticText(_("Cancel"))
 		self["key_green"] = StaticText(_("OK"))
 		self["key_yellow"] = StaticText(_("Defaults"))
 
-		self["actions"] = ActionMap(["SetupActions", "ColorActions"],
-			{
-				"cancel": self.keyCancel,
-				"save": self.keySave,
-				"left": self.keyLeft,
-				"right": self.keyRight,
-				"yellow": self.keyDefault,
-			}, -2)
+		self["actions"] = ActionMap(["SetupActions", "ColorActions"], {
+			"cancel": self.keyCancel,
+			"save": self.keySave,
+			"left": self.keyLeft,
+			"right": self.keyRight,
+			"yellow": self.keyDefault,
+		}, -2)
 
-		self.onChangedEntry = [ ]
+		self.onChangedEntry = []
 		self.list = []
-		ConfigListScreen.__init__(self, self.list, session = self.session, on_change = self.changedEntry)
+		ConfigListScreen.__init__(self, self.list, session=self.session, on_change=self.changedEntry)
 		if SystemInfo["CanChangeOsdAlpha"]:
 			self.list.append(getConfigListEntry(_("User interface visibility"), config.osd.alpha, _("This option lets you adjust the transparency of the user interface")))
 		if SystemInfo["CanChangeOsdPosition"]:
@@ -155,7 +158,7 @@ class UserInterfacePositioner(Screen, ConfigListScreen):
 		self["config"].l.setList(self.list)
 
 		self.onLayoutFinish.append(self.layoutFinished)
-		if not self.selectionChanged in self["config"].onSelectionChanged:
+		if self.selectionChanged not in self["config"].onSelectionChanged:
 			self["config"].onSelectionChanged.append(self.selectionChanged)
 		self.selectionChanged()
 
@@ -191,7 +194,6 @@ class UserInterfacePositioner(Screen, ConfigListScreen):
 
 	def keyDefault(self):
 		config.osd.alpha.setValue(255)
-
 		config.osd.dst_left.setValue(0)
 		config.osd.dst_width.setValue(720)
 		config.osd.dst_top.setValue(0)
@@ -210,12 +212,17 @@ class UserInterfacePositioner(Screen, ConfigListScreen):
 			dst_width = int(dst_width) - 1
 		while dst_height + (dst_top / float(dsk_h)) >= 576.5 or dst_height + dst_top > 576:
 			dst_height = int(dst_height) - 1
-
 		config.osd.dst_left.setValue(dst_left)
 		config.osd.dst_width.setValue(dst_width)
 		config.osd.dst_top.setValue(dst_top)
 		config.osd.dst_height.setValue(dst_height)
-		print '[UserInterfacePositioner] Setting OSD position: %s %s %s %s' %  (config.osd.dst_left.value, config.osd.dst_width.value, config.osd.dst_top.value, config.osd.dst_height.value)
+		print '[UserInterfacePositioner] Setting OSD position: %s %s %s %s' % (config.osd.dst_left.value, config.osd.dst_width.value, config.osd.dst_top.value, config.osd.dst_height.value)
+
+	def playOldService(self):
+		try:
+			self.session.nav.playService(self.oldref)
+		except:
+			pass
 
 	def saveAll(self):
 		for x in self["config"].list:
@@ -226,21 +233,23 @@ class UserInterfacePositioner(Screen, ConfigListScreen):
 	# you have to call them by yourself.
 	def keySave(self):
 		self.saveAll()
+		self.playOldService()
 		self.close()
 
 	def cancelConfirm(self, result):
 		if not result:
 			return
-
 		for x in self["config"].list:
 			x[1].cancel()
+		self.playOldService()
 		self.close()
 
 	def keyCancel(self):
 		if self["config"].isChanged():
 			from Screens.MessageBox import MessageBox
-			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"), default = False)
+			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"), default=False)
 		else:
+			self.playOldService()
 			self.close()
 
 	def run(self):
@@ -249,6 +258,7 @@ class UserInterfacePositioner(Screen, ConfigListScreen):
 		config.osd.dst_top.save()
 		config.osd.dst_height.save()
 		configfile.save()
+		self.playOldService()
 		self.close()
 
 class OSD3DSetupScreen(Screen, ConfigListScreen):
@@ -276,23 +286,22 @@ class OSD3DSetupScreen(Screen, ConfigListScreen):
 		self["key_red"] = StaticText(_("Cancel"))
 		self["key_green"] = StaticText(_("OK"))
 
-		self["actions"] = ActionMap(["SetupActions"],
-			{
-				"cancel": self.keyCancel,
-				"save": self.keySave,
-			}, -2)
+		self["actions"] = ActionMap(["SetupActions"], {
+			"cancel": self.keyCancel,
+			"save": self.keySave,
+		}, -2)
 
-		self.onChangedEntry = [ ]
+		self.onChangedEntry = []
 		self.list = []
-		ConfigListScreen.__init__(self, self.list, session = self.session, on_change = self.changedEntry)
+		ConfigListScreen.__init__(self, self.list, session=self.session, on_change=self.changedEntry)
 		self.list.append(getConfigListEntry(_("3D Mode"), config.osd.threeDmode, _("This option lets you choose the 3D mode")))
 		self.list.append(getConfigListEntry(_("Depth"), config.osd.threeDznorm, _("This option lets you adjust the 3D depth")))
-		self.list.append(getConfigListEntry(_("Show in extensions list ?"), config.osd.show3dextensions, _("This option lets you show the option in the extension screen")))
+		self.list.append(getConfigListEntry(_("Show in extensions list"), config.osd.show3dextensions, _("This option lets you show the option in the extension screen")))
 		self["config"].list = self.list
 		self["config"].l.setList(self.list)
 
 		self.onLayoutFinish.append(self.layoutFinished)
-		if not self.selectionChanged in self["config"].onSelectionChanged:
+		if self.selectionChanged not in self["config"].onSelectionChanged:
 			self["config"].onSelectionChanged.append(self.selectionChanged)
 		self.selectionChanged()
 


### PR DESCRIPTION
This change stops the current service when loading the screen position test pattern and restarts the service when the settings are saved or the operation is cancelled.

Also perform a PEP8 cleanup.
