### PR TITLE
EPG Enhancements

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -328,7 +328,7 @@
 		<item level="2" text="Picon width" description="Configure the width allocated to the picon.">config.epgselection.infobar_piconwidth</item>
 		<item level="2" text="Info icon width" description="Configure the minimum width before showing the 'i' icon, '0' is equal to not showing the icon at all.">config.epgselection.infobar_infowidth</item>
 		<item level="2" text="Timeline font size" description="Configure the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size.">config.epgselection.infobar_timelinefs</item>
-		<item level="2" text="Timeline 24 Hour" description="Show time in 24 hour clock format.">config.epgselection.infobar_timeline24h</item>
+		<item level="2" text="Timeline 24 Hour" description="Show time in 24 hour clock format.\nNOTE: This setting is not used if the global time format settings are available.">config.epgselection.infobar_timeline24h</item>
 		<item level="2" text="Time scale" description="Configure the amount of time that will be presented.">config.epgselection.infobar_prevtimeperiod</item>
 	</setup>
 	<setup key="epggraphical" title="GraphicalEPG settings">
@@ -359,7 +359,7 @@
 		<item level="2" text="Info icon width" description="Configure the minimum width before showing the 'i' icon, '0' is equal to not showing the icon at all.">config.epgselection.graph_infowidth</item>
 		<item level="2" text="Position of recording icons" description="Set the position of the recording icons">config.epgselection.graph_rec_icon_height</item>
 		<item level="2" text="Timeline font size" description="Configure the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size.">config.epgselection.graph_timelinefs</item>
-		<item level="2" text="Timeline 24 Hour" description="Show time in 24 hour clock format.">config.epgselection.graph_timeline24h</item>
+		<item level="2" text="Timeline 24 Hour" description="Show time in 24 hour clock format.\nNOTE: This setting is not used if the global time format settings are available.">config.epgselection.graph_timeline24h</item>
 		<item level="2" text="Time scale" description="Configure the amount of time that will be presented.">config.epgselection.graph_prevtimeperiod</item>
 	</setup>
 	<setup key="pluginbrowsersetup" title="Plugin browser settings">

--- a/lib/python/Components/EpgList.py
+++ b/lib/python/Components/EpgList.py
@@ -561,11 +561,10 @@ class EPGList(HTMLComponent, GUIComponent):
 		if self.type == EPG_TYPE_MULTI:
 			fontSize = self.eventFontSizeMulti + config.epgselection.multi_eventfs.value
 			servW = int((fontSize + 4) * 5.9)  # Service font is 4 px larger
-			if config.usage.time.wide.value:
-				progW = int(fontSize * 6.8)
-			else:
-				progW = int(fontSize * 6.8)
+			progW = int(fontSize * 6.8)
 			servLeft, servWidth, progLeft, progWidth, progHeight, descLeft = skin.parameters.get("EPGMultiEPGColumnFormats", (0, servW, servW + 10, progW, height - 8, servW + progW + 20))
+			# if config.usage.time.wide.value:
+			# 	progW = int(fontSize * 6.8)
 			progTop = int((height - progHeight) / 2)
 			self.service_rect = Rect(servLeft, 0, servWidth, height)
 			self.progress_rect = Rect(progLeft, progTop, progWidth, progHeight)
@@ -591,7 +590,6 @@ class EPGList(HTMLComponent, GUIComponent):
 				if self.showServiceNumber:
 					font = gFont(self.serviceFontNameGraph, self.serviceFontSizeGraph + config.epgselection.infobar_servfs.value)
 					channelw = getTextBoundarySize(self.instance, font, self.instance.size(), "0000" ).width()
-
 			w = (channelw + piconw + servicew)
 			self.service_rect = Rect(0, 0, w, height)
 			self.event_rect = Rect(w, 0, width - w, height)
@@ -603,13 +601,13 @@ class EPGList(HTMLComponent, GUIComponent):
 		else:
 			fontSize = self.eventFontSizeSingle + config.epgselection.enhanced_eventfs.value
 			dayW = int(fontSize * 2.1)
+			timeW = int(fontSize * 6.3)
+			dayLeft, dayWidth, timeLeft, timeWidth, descOffset = skin.parameters.get("EPGSingleEPGColumnFormats", (0, dayW, dayW + 10, timeW, 20))
 			if config.usage.time.wide.value:
-				timeW = int(fontSize * 7.4)
-			else:
-				timeW = int(fontSize * 6.3)
-			dayLeft, dayWidth, timeLeft, timeWidth, descLeft = skin.parameters.get("EPGSingleEPGColumnFormats", (0, dayW, dayW + 10, timeW, dayW + timeW + 30))
+				timeWidth = int(timeWidth * 1.25)
 			self.weekday_rect = Rect(dayLeft, 0, dayWidth, height)
 			self.datetime_rect = Rect(timeLeft, 0, timeWidth, height)
+			descLeft = timeLeft + timeWidth + descOffset
 			self.descr_rect = Rect(descLeft, 0, width - descLeft, height)
 
 	def calcEntryPosAndWidthHelper(self, stime, duration, start, end, width):
@@ -1533,7 +1531,17 @@ class TimelineText(HTMLComponent, GUIComponent):
 					border_width = self.borderWidth, border_color = self.borderColor))
 
 			for x in range(0, num_lines):
-				timetext = strftime(config.usage.time.short.value, localtime(time_base + (x * timeStepsCalc)))
+				ttime = localtime(time_base + (x * timeStepsCalc))
+				if config.usage.time.enabled.value:
+					timetext = strftime(config.usage.time.short.value, ttime)
+				else:
+					if (self.type == EPG_TYPE_GRAPH and config.epgselection.graph_timeline24h.value) or (self.type == EPG_TYPE_INFOBARGRAPH and config.epgselection.infobar_timeline24h.value):
+						timetext = strftime("%H:%M", ttime)
+					else:
+						if int(strftime("%H", ttime)) > 12:
+							timetext = strftime("%-I:%M", ttime) + _('pm')
+						else:
+							timetext = strftime("%-I:%M", ttime) + _('am')
 				res.append(MultiContentEntryText(
 					pos = (service_rect.width() + xpos, 0),
 					size = (incWidth, self.listHeight),


### PR DESCRIPTION
- Restore manual EPG timeline configuration.  This change restores the ability to separately configure the timeline clock display (between 12 and 24 hour times). The settings defined are remembered but ignored if the system wide time settings are available.  The settings selected will be used if the current skin does not allow for the system wide time settings.

- Add an advisory note to the two EPG timeline setting options to warn users that these settings will be ignored if the current skin uses the system wide time formats.

- The MultiEPG column width code has been simplified.  There is no functional change.

- The SingleEPG column width code has been refined to improved the skin based parameter overrides.  The date/time column is now specified as the desired width assuming a 24 hour clock and will be automatically expanded for 12 hour clocks.  The description column is now specified as an offset from the end of dynamic date/time column rather than a hard starting point.  This change reduces wasted space between the date/time and description columns.

- Add an advisory note to the two EPG timeline setting options to warn users that these settings will be ignored if the current skin uses the system wide time formats.
