### PR TITLE
Expand date / time formats

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -5,8 +5,8 @@
 		<item level="0" text="Sync time using" description="Synchronize system time using transponder or internet.">config.misc.SyncTimeUsing</item>
 		<item level="0" text="NTP server" description="Configure your NTP server.">config.misc.NTPserver</item>
 		<item level="0" text="Sync NTP every (minutes)" description="Setup network time synchronization interval." requires="config.misc.SyncTimeUsing" >config.misc.useNTPminutes</item>
-		<item level="0" text="Date style" description="Choose the display formatting style for dates. The screen display will be based on your choice but can be influenced by the skin." requires="config.usage.date.enabled">config.usage.date.dayfull</item>
-		<item level="0" text="Time style" description="Choose the display formatting style for times. The screen display will be based on your choice but can be influenced by the skin." requires="config.usage.time.enabled">config.usage.time.long</item>
+		<item level="0" text="Date style" description="Choose the display formatting style for dates. 'D' / 'DD' is the date and 'M' / 'MM' is the month in digits.  ('DD' and 'MM' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin." requires="config.usage.date.enabled">config.usage.date.dayfull</item>
+		<item level="0" text="Time style" description="Choose the display formatting style for times. 'H' / 'HH' is the hour for a 24 hour clock, 'h' / 'hh' is the hour for a 12 hour clock, 'mm' is the minutes and 'ss' is the seconds.  ('HH' and 'hh' have leading zeros for single digit values.) The screen display will be based on your choice but can be influenced by the skin." requires="config.usage.time.enabled">config.usage.time.long</item>
 	</setup>
 	<setup key="avsetup">
 		<!-- This is just a placeholder, the Videomode plugin implements this submenu -->
@@ -234,7 +234,7 @@
 		<item level="2" text="Final scroll delay" description="Delay in miliseconds after finish scrolling text on display." requires="VFD_final_scroll_delay">config.usage.vfd_final_scroll_delay</item>
 		<item level="1" text="Repeat Display Message" description="If the text is too long to be displayed on the front panel, it will be repeated (number of times):" requires="VFD_scroll_repeats">config.usage.vfd_scroll_repeats</item>
 		<item level="1" text="Scrolling Speed" description="Set the scrolling speed of text on the front display." requires="VFD_scroll_delay">config.usage.vfd_scroll_delay</item>
-		<item level="0" text="Time style" description="Choose the front panel display formatting style for times. The front panel display will be based on your choice but can be influenced any applicable skin." requires="config.usage.time.enabled_display">config.usage.time.display</item>
+		<item level="0" text="Time style" description="Choose the front panel display formatting style for times. 'H' / 'HH' is the hour for a 24 hour clock, 'h' / 'hh' is the hour for a 12 hour clock, 'mm' is the minutes and 'ss' is the seconds.  ('HH' and 'hh' have leading zeros for single digit values.) The front panel display will be based on your choice but can be influenced any applicable skin." requires="config.usage.time.enabled_display">config.usage.time.display</item>
 		<item level="1" text="Show Display Icons" description="Allows you to enable/disable displaying icons on the front panel.">config.lcd.mode</item>
 		<item level="1" text="Show Time Remaining/Elapsed" description="This option allows you choose how to display remaining time, or elapsed time, or both.">config.usage.swap_time_remaining_on_vfd</item>
 		<item level="1" text="Show Transponder Remaining/Elapsed as" description="This option allows you choose how to display the remaining/elapsed time for live TV.">config.usage.swap_time_display_on_vfd</item>

--- a/lib/python/Components/Converter/ClockToText.py
+++ b/lib/python/Components/Converter/ClockToText.py
@@ -40,6 +40,8 @@ class ClockToText(Converter, object):
 		# 		TRANSLATORS: VFD08 hour:minute in strftime() format! See 'man strftime'
 		"VFD08": lambda t: strftime(config.usage.time.display.value, localtime(t)),  # _("%R")
 		# 		TRANSLATORS: VFD daynum short monthname hour:minute in strftime() format! See 'man strftime'
+		"VFD11": lambda t: strftime(config.usage.date.compressed.value + config.usage.time.display.value, localtime(t)),  # _("%e%b%R")
+		# 		TRANSLATORS: VFD daynum short monthname hour:minute in strftime() format! See 'man strftime'
 		"VFD12": lambda t: strftime(config.usage.date.compact.value + config.usage.time.display.value, localtime(t)),  # _("%e%b%R")
 		# 		TRANSLATORS: VFD daynum short monthname hour:minute in strftime() format! See 'man strftime'
 		"VFD14": lambda t: strftime(config.usage.date.short.value + " " + config.usage.time.display.value, localtime(t)),  # _("%e/%b %R")

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -347,19 +347,25 @@ def InitUsageConfig():
 
 	# TRANSLATORS: full date representation dayname daynum monthname year in strftime() format! See 'man strftime'
 	config.usage.date.dayfull = ConfigSelection(default=_("%A %-e %B %Y"), choices=[
-		(_("%A %d %B %Y"), _("Dayname 99 Month 9999")),
-		(_("%A %-e %B %Y"), _("Dayname 9 Month 9999")),
-		(_("%A %-e-%B-%Y"), _("Dayname 9-Month-9999")),
-		(_("%A %-e/%m/%Y"), _("Dayname 9/99/9999")),
-		(_("%A %B %d %Y"), _("Dayname Month 99 9999")),
-		(_("%A %B %-e %Y"), _("Dayname Month 9 9999")),
-		(_("%A %B-%-e-%Y"), _("Dayname Month-9-9999")),
-		(_("%A %-m/%-e/%Y"), _("Dayname 9/9/9999")),
-		(_("%A %Y %B %d"), _("Dayname 9999 Month 99")),
-		(_("%A %Y %B %-e"), _("Dayname 9999 Month 9")),
-		(_("%A %Y-%B-%d"), _("Dayname 9999-Month-99")),
-		(_("%A %Y-%B-%-e"), _("Dayname 9999-Month-9")),
-		(_("%A %Y/%m/%-e"), _("Dayname 9999/99/9"))
+		(_("%A %d %B %Y"), _("Dayname DD Month Year")),
+		(_("%A %-e %B %Y"), _("Dayname D Month Year")),
+		(_("%A %d-%B-%Y"), _("Dayname DD-Month-Year")),
+		(_("%A %-e-%B-%Y"), _("Dayname D-Month-Year")),
+		(_("%A %d/%m/%Y"), _("Dayname DD/MM/Year")),
+		(_("%A %-e/%m/%Y"), _("Dayname D/MM/Year")),
+		(_("%A %B %d %Y"), _("Dayname Month DD Year")),
+		(_("%A %B %-e %Y"), _("Dayname Month D Year")),
+		(_("%A %B-%d-%Y"), _("Dayname Month-DD-Year")),
+		(_("%A %B-%-e-%Y"), _("Dayname Month-D-Year")),
+		(_("%A %m/%d/%Y"), _("Dayname MM/DD/Year")),
+		(_("%A %m/%-e/%Y"), _("Dayname MM/D/Year")),
+		(_("%A %-m/%-e/%Y"), _("Dayname M/D/Year")),
+		(_("%A %Y %B %d"), _("Dayname Year Month DD")),
+		(_("%A %Y %B %-e"), _("Dayname Year Month D")),
+		(_("%A %Y-%B-%d"), _("Dayname Year-Month-DD")),
+		(_("%A %Y-%B-%-e"), _("Dayname Year-Month-D")),
+		(_("%A %Y/%m/%d"), _("Dayname Year/MM/DD")),
+		(_("%A %Y/%m/%-e"), _("Dayname Year/MM/D"))
 	])
 
 	# TRANSLATORS: long date representation short dayname daynum monthname year in strftime() format! See 'man strftime'
@@ -387,24 +393,31 @@ def InitUsageConfig():
 	config.usage.date.short = ConfigText(default=_("%-e %b"))
 
 	# TRANSLATORS: compact date representation (for VFD) daynum short monthname in strftime() format! See 'man strftime'
-	config.usage.date.compact_template = ConfigText(default=_("%-e_%b_"))
-	config.usage.date.compact = ConfigText(default=_("%-e_%b_"))
+	config.usage.date.compact_template = ConfigText(default=_("%-e+%b_"))
+	config.usage.date.compact = ConfigText(default=_("%-e+%b_"))
+	config.usage.date.compressed = ConfigText(default=_("%-e+%b_"))
 
 	def setDateStyles(configElement):
 		dateStyles = {
 			# dayfull            shortdayfull      daylong           dayshortfull   dayshort       daysmall    full           long           short       compact_template
-			_("%A %d %B %Y"): (_("%a %d %B %Y"), _("%a %d %b %Y"), _("%A %d %B"), _("%a %d %b"), _("%a %d"), _("%d %B %Y"), _("%d %b %Y"), _("%d %b"), _("%d_%b_")),
-			_("%A %-e %B %Y"): (_("%a %-e %B %Y"), _("%a %-e %b %Y"), _("%A %-e %B"), _("%a %-e %b"), _("%a %-e"), _("%-e %B %Y"), _("%-e %b %Y"), _("%-e %b"), _("%-e_%b_")),
+			_("%A %d %B %Y"): (_("%a %d %B %Y"), _("%a %d %b %Y"), _("%A %d %B"), _("%a %d %b"), _("%a %d"), _("%d %B %Y"), _("%d %b %Y"), _("%d %b"), _("%d+%b_")),
+			_("%A %-e %B %Y"): (_("%a %-e %B %Y"), _("%a %-e %b %Y"), _("%A %-e %B"), _("%a %-e %b"), _("%a %-e"), _("%-e %B %Y"), _("%-e %b %Y"), _("%-e %b"), _("%-e+%b_")),
+			_("%A %d-%B-%Y"): (_("%a %d-%B-%Y"), _("%a %d-%b-%Y"), _("%A %d-%B"), _("%a %d-%b"), _("%a %d"), _("%d-%B-%Y"), _("%d-%b-%Y"), _("%d-%b"), _("%d=%b_")),
 			_("%A %-e-%B-%Y"): (_("%a %-e-%B-%Y"), _("%a %-e-%b-%Y"), _("%A %-e-%B"), _("%a %-e-%b"), _("%a %-e"), _("%-e-%B-%Y"), _("%-e-%b-%Y"), _("%-e-%b"), _("%-e=%b_")),
+			_("%A %d/%m/%Y"): (_("%a %d/%m/%Y"), _("%a %d/%m/%Y"), _("%A %d/%m"), _("%a %d/%m"), _("%a %d"), _("%d/%m/%Y"), _("%d/%m/%Y"), _("%d/%m"), _("%d/%m ")),
 			_("%A %-e/%m/%Y"): (_("%a %-e/%m/%Y"), _("%a %-e/%m/%Y"), _("%A %-e/%m"), _("%a %-e/%m"), _("%a %-e"), _("%-e/%m/%Y"), _("%-e/%m/%Y"), _("%-e/%m"), _("%-e/%m ")),
-			_("%A %B %d %Y"): (_("%a %B %d %Y"), _("%a %b %d %Y"), _("%A %B %d"), _("%a %b %d"), _("%a %d"), _("%B %d %Y"), _("%b %d %Y"), _("%b %d"), _("%d_%b_")),
-			_("%A %B %-e %Y"): (_("%a %B %-e %Y"), _("%a %b %-e %Y"), _("%A %B %-e"), _("%a %b %-e"), _("%a %-e"), _("%B %-e %Y"), _("%b %-e %Y"), _("%b %-e"), _("%-e_%b_")),
+			_("%A %B %d %Y"): (_("%a %B %d %Y"), _("%a %b %d %Y"), _("%A %B %d"), _("%a %b %d"), _("%a %d"), _("%B %d %Y"), _("%b %d %Y"), _("%b %d"), _("%d+%b_")),
+			_("%A %B %-e %Y"): (_("%a %B %-e %Y"), _("%a %b %-e %Y"), _("%A %B %-e"), _("%a %b %-e"), _("%a %-e"), _("%B %-e %Y"), _("%b %-e %Y"), _("%b %-e"), _("%-e+%b_")),
+			_("%A %B-%d-%Y"): (_("%a %B-%d-%Y"), _("%a %b-%d-%Y"), _("%A %B-%d"), _("%a %b-%d"), _("%a %d"), _("%B-%d-%Y"), _("%b-%d-%Y"), _("%b-%d"), _("%d=%b_")),
 			_("%A %B-%-e-%Y"): (_("%a %B-%-e-%Y"), _("%a %b-%-e-%Y"), _("%A %B-%-e"), _("%a %b-%-e"), _("%a %-e"), _("%B-%-e-%Y"), _("%b-%-e-%Y"), _("%b-%-e"), _("%-e=%b_")),
+			_("%A %m/%d/%Y"): (_("%a %m/%d/%Y"), _("%a %m/%d/%Y"), _("%A %m/%d"), _("%a %m/%d"), _("%a %d"), _("%m/%d/%Y"), _("%m/%d/%Y"), _("%m/%d"), _("%m/%d ")),
+			_("%A %m/%-e/%Y"): (_("%a %m/%-e/%Y"), _("%a %m/%-e/%Y"), _("%A %m/%-e"), _("%a %m/%-e"), _("%a %-e"), _("%m/%-e/%Y"), _("%m/%-e/%Y"), _("%m/%-e"), _("%m/%-e ")),
 			_("%A %-m/%-e/%Y"): (_("%a %-m/%-e/%Y"), _("%a %-m/%-e/%Y"), _("%A %-m/%-e"), _("%a %-m/%-e"), _("%a %-e"), _("%-m/%-e/%Y"), _("%-m/%-e/%Y"), _("%-m/%-e"), _("%-m/%-e ")),
-			_("%A %Y %B %d"): (_("%a %Y %B %d"), _("%a %Y %b %d"), _("%A %B %d"), _("%a %b %d"), _("%a %d"), _("%Y %B %d"), _("%Y %b %d"), _("%b %d"), _("%d_%b_")),
-			_("%A %Y %B %-e"): (_("%a %Y %B %-e"), _("%a %Y %b %-e"), _("%A %B %-e"), _("%a %b %-e"), _("%a %-e"), _("%Y %B %-e"), _("%Y %b %-e"), _("%b %-e"), _("%-e_%b_")),
+			_("%A %Y %B %d"): (_("%a %Y %B %d"), _("%a %Y %b %d"), _("%A %B %d"), _("%a %b %d"), _("%a %d"), _("%Y %B %d"), _("%Y %b %d"), _("%b %d"), _("%d+%b_")),
+			_("%A %Y %B %-e"): (_("%a %Y %B %-e"), _("%a %Y %b %-e"), _("%A %B %-e"), _("%a %b %-e"), _("%a %-e"), _("%Y %B %-e"), _("%Y %b %-e"), _("%b %-e"), _("%-e+%b_")),
 			_("%A %Y-%B-%d"): (_("%a %Y-%B-%d"), _("%a %Y-%b-%d"), _("%A %B-%d"), _("%a %b-%d"), _("%a %d"), _("%Y-%B-%d"), _("%Y-%b-%d"), _("%b-%d"), _("%d=%b_")),
 			_("%A %Y-%B-%-e"): (_("%a %Y-%B-%-e"), _("%a %Y-%b-%-e"), _("%A %B-%-e"), _("%a %b-%-e"), _("%a %-e"), _("%Y-%B-%-e"), _("%Y-%b-%-e"), _("%b-%-e"), _("%-e=%b_")),
+			_("%A %Y/%m/%d"): (_("%a %Y/%m/%d"), _("%a %Y/%m/%d"), _("%A %m/%d"), _("%a %m/%d"), _("%a %d"), _("%Y/%m/%d"), _("%Y/%m/%d"), _("%m/%d"), _("%m/%d ")),
 			_("%A %Y/%m/%-e"): (_("%a %Y/%m/%-e"), _("%a %Y/%m/%-e"), _("%A %m/%-e"), _("%a %m/%-e"), _("%a %-e"), _("%Y/%m/%-e"), _("%Y/%m/%-e"), _("%m/%-e"), _("%m/%-e "))
 		}
 		style = dateStyles.get(configElement.value, ((_("Invalid")) * 9))
@@ -430,29 +443,34 @@ def InitUsageConfig():
 
 	def adjustCompactDate():
 		if config.usage.time.wide_display.value:
-			config.usage.date.compact.value = config.usage.date.compact_template.value.replace("_", "").replace("=", "")
+			config.usage.date.compact.value = config.usage.date.compact_template.value.replace("_", "").replace("=", "").replace("+", "")
 		else:
-			config.usage.date.compact.value = config.usage.date.compact_template.value.replace("_", " ").replace("=", "-")
+			config.usage.date.compact.value = config.usage.date.compact_template.value.replace("_", " ").replace("=", "-").replace("+", " ")
+		config.usage.date.compressed.value = config.usage.date.compact_template.value.replace("_", " ").replace("=", "").replace("+", "")
 
 	config.usage.date.dayfull.addNotifier(setDateStyles)
 
 	# TRANSLATORS: full time representation hour:minute:seconds
 	if locale.nl_langinfo(locale.AM_STR) and locale.nl_langinfo(locale.PM_STR):
 		config.usage.time.long = ConfigSelection(default=_("%T"), choices=[
-			(_("%T"), _("99:99:99")),
-			(_("%-H:%M:%S"), _("9:99:99")),
-			(_("%I:%M:%S%^p"), _("99:99:99AM/PM")),
-			(_("%-I:%M:%S%^p"), _("9:99:99AM/PM")),
-			(_("%I:%M:%S%P"), _("99:99:99am/pm")),
-			(_("%-I:%M:%S%P"), _("9:99:99am/pm"))
+			(_("%T"), _("HH:mm:ss")),
+			(_("%-H:%M:%S"), _("H:mm:ss")),
+			(_("%I:%M:%S%^p"), _("hh:mm:ssAM/PM")),
+			(_("%-I:%M:%S%^p"), _("h:mm:ssAM/PM")),
+			(_("%I:%M:%S%P"), _("hh:mm:ssam/pm")),
+			(_("%-I:%M:%S%P"), _("h:mm:ssam/pm")),
+			(_("%I:%M:%S"), _("hh:mm:ss")),
+			(_("%-I:%M:%S"), _("h:mm:ss"))
 		])
 	else:
 		config.usage.time.long = ConfigSelection(default=_("%T"), choices=[
-			(_("%T"), _("99:99:99")),
-			(_("%-H:%M:%S"), _("9:99:99")),
+			(_("%T"), _("HH:mm:ss")),
+			(_("%-H:%M:%S"), _("H:mm:ss")),
+			(_("%I:%M:%S"), _("hh:mm:ss")),
+			(_("%-I:%M:%S"), _("h:mm:ss"))
 		])
 
-	# TRANSLATORS: time representation hour:minute:seconds for 24 hour clock and hour:minute for 12 hour clocks
+	# TRANSLATORS: time representation hour:minute:seconds for 24 hour clock or 12 hour clock without AM/PM and hour:minute for 12 hour clocks with AM/PM
 	config.usage.time.mixed = ConfigText(default=_("%T"))
 
 	# TRANSLATORS: short time representation hour:minute (Same as "Default")
@@ -466,7 +484,9 @@ def InitUsageConfig():
 			_("%I:%M:%S%^p"): (_("%I:%M%^p"), _("%I:%M%^p")),
 			_("%-I:%M:%S%^p"): (_("%-I:%M%^p"), _("%-I:%M%^p")),
 			_("%I:%M:%S%P"): (_("%I:%M%P"), _("%I:%M%P")),
-			_("%-I:%M:%S%P"): (_("%-I:%M%P"), _("%-I:%M%P"))
+			_("%-I:%M:%S%P"): (_("%-I:%M%P"), _("%-I:%M%P")),
+			_("%I:%M:%S"): (_("%I:%M:%S"), _("%I:%M")),
+			_("%-I:%M:%S"): (_("%-I:%M:%S"), _("%-I:%M"))
 		}
 		style = timeStyles.get(configElement.value, ((_("Invalid")) * 2))
 		config.usage.time.mixed.value = style[0]
@@ -480,17 +500,21 @@ def InitUsageConfig():
 	# TRANSLATORS: short time representation hour:minute (Same as "Default")
 	if locale.nl_langinfo(locale.AM_STR) and locale.nl_langinfo(locale.PM_STR):
 		config.usage.time.display = ConfigSelection(default=_("%R"), choices=[
-			(_("%R"), _("99:99")),
-			(_("%-H:%M"), _("9:99")),
-			(_("%I:%M%^p"), _("99:99AM/PM")),
-			(_("%-I:%M%^p"), _("9:99AM/PM")),
-			(_("%I:%M%P"), _("99:99am/pm")),
-			(_("%-I:%M%P"), _("9:99am/pm"))
+			(_("%R"), _("HH:mm")),
+			(_("%-H:%M"), _("H:mm")),
+			(_("%I:%M%^p"), _("hh:mmAM/PM")),
+			(_("%-I:%M%^p"), _("h:mmAM/PM")),
+			(_("%I:%M%P"), _("hh:mmam/pm")),
+			(_("%-I:%M%P"), _("h:mmam/pm")),
+			(_("%I:%M"), _("hh:mm")),
+			(_("%-I:%M"), _("h:mm"))
 		])
 	else:
-		config.usage.time.display = ConfigSelection(default=_("%T"), choices=[
-			(_("%T"), _("99:99:99")),
-			(_("%-H:%M:%S"), _("9:99:99")),
+		config.usage.time.display = ConfigSelection(default=_("%R"), choices=[
+			(_("%R"), _("HH:mm")),
+			(_("%-H:%M"), _("H:mm")),
+			(_("%I:%M"), _("hh:mm")),
+			(_("%-I:%M"), _("h:mm"))
 		])
 
 	def setTimeDisplayStyles(configElement):


### PR DESCRIPTION
This change updates the config screen prompt strings for the date and time settings.  Rather than using the generic "9" marker the displays use more descriptive tokens.  "D" and "DD" for day of the month, "M" and "MM" for the numeric representation of the month, "H" and "HH" for the hour in a 24 hour clock, "h" and "hh" for the hour in a 12 hour clock, "mm" for the minutes of the time and "ss" for the seconds of the time.

With these new distinctions in place some more date and time formats have been added to both the date and time options.  With the previous prompt labels some of these options were not viable.

Add a new ClockToText option called VFD11 that addresses issues on the Beyonwiz T3 that only has an 11 character VFD display.  To add this option the processing logic needed to be slightly adjusted.  These changes should have no effect on any other hardware and only take effect when the Beyonwiz T3 display skin uses the VFD11 rather than the VFD12 option.
