### PR TITLE
Add graphical switch icon option for Boolean settings

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -74,6 +74,7 @@
 		<item level="2" text="Show VCR scart on main menu" description="When enabled, the VCR scart option will be shown in the main menu" requires="ScartSwitch">config.usage.show_vcr_scart</item>
 		<item level="1" text="Behavior of 0 key in PiP-mode" description="Choose what you want the '0' button to do when PIP is active.">config.usage.pip_zero_button</item>
 		<item level="1" text="History buttons mode" description="Configure the function of the &lt;  &gt; buttons.">config.usage.historymode</item>
+		<item level="2" text="Show True/False as graphical switch" description="Enable to display all true/false, yes/no, on/off and enable/disable set up options as a graphical switch.">config.usage.boolean_graphic</item>
 	</setup>
 	<setup key="channelselection" title="Channel selection settings">
 		<item level="1" text="Alternative numbering mode" description="When enabled, channel numbering will start at '1' for every bouquet.">config.usage.alternative_number_mode</item>

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -517,6 +517,8 @@ def InitUsageConfig():
 		config.usage.time.enabled_display.value = False
 		config.usage.time.display.value = config.usage.time.display.default
 
+	config.usage.boolean_graphic = ConfigYesNo(default=False)
+
 	config.epg = ConfigSubsection()
 	config.epg.eit = ConfigYesNo(default = True)
 	config.epg.mhw = ConfigYesNo(default = False)

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -429,12 +429,12 @@ class ConfigSelection(ConfigElement):
 #
 boolean_descriptions = {False: _("false"), True: _("true")}
 class ConfigBoolean(ConfigElement):
-	def __init__(self, default=False, descriptions=boolean_descriptions, grafic=True):
+	def __init__(self, default=False, descriptions=boolean_descriptions, graphic=True):
 		ConfigElement.__init__(self)
 		self.descriptions = descriptions
 		self.value = self.last_value = self.default = default
-		self.grafic = False
-		if grafic:
+		self.graphic = False
+		if graphic:
 			from skin import switchPixmap
 			offPath = switchPixmap.get('menu_off')
 			onPath = switchPixmap.get('menu_on')
@@ -444,7 +444,7 @@ class ConfigBoolean(ConfigElement):
 				if falseIcon and trueIcon:
 					self.falseIcon = falseIcon
 					self.trueIcon = trueIcon
-					self.grafic = True
+					self.graphic = True
 
 	def handleKey(self, key):
 		if key in (KEY_LEFT, KEY_RIGHT):
@@ -462,7 +462,7 @@ class ConfigBoolean(ConfigElement):
 
 	def getMulti(self, selected):
 		from config import config
-		if self.grafic and config.usage.boolean_graphic.value:
+		if self.graphic and config.usage.boolean_graphic.value:
 			if self.value:
 				return ('pixmap', self.trueIcon)
 			else:

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -2,6 +2,7 @@ from enigma import getPrevAsciiCode
 from Tools.NumericalTextInput import NumericalTextInput
 from Tools.Directories import resolveFilename, SCOPE_CONFIG, fileExists
 from Components.Harddisk import harddiskmanager
+from Tools.LoadPixmap import LoadPixmap
 from copy import copy as copy_copy
 from os import path as os_path
 from time import localtime, strftime
@@ -428,10 +429,22 @@ class ConfigSelection(ConfigElement):
 #
 boolean_descriptions = {False: _("false"), True: _("true")}
 class ConfigBoolean(ConfigElement):
-	def __init__(self, default = False, descriptions = boolean_descriptions):
+	def __init__(self, default=False, descriptions=boolean_descriptions, grafic=True):
 		ConfigElement.__init__(self)
 		self.descriptions = descriptions
 		self.value = self.last_value = self.default = default
+		self.grafic = False
+		if grafic:
+			from skin import switchPixmap
+			offPath = switchPixmap.get('menu_off')
+			onPath = switchPixmap.get('menu_on')
+			if offPath and onPath:
+				falseIcon = LoadPixmap(offPath, cached=True)
+				trueIcon = LoadPixmap(onPath, cached=True)
+				if falseIcon and trueIcon:
+					self.falseIcon = falseIcon
+					self.trueIcon = trueIcon
+					self.grafic = True
 
 	def handleKey(self, key):
 		if key in (KEY_LEFT, KEY_RIGHT):
@@ -448,10 +461,17 @@ class ConfigBoolean(ConfigElement):
 		return descr
 
 	def getMulti(self, selected):
-		descr = self.descriptions[self.value]
-		if descr:
-			return "text", _(descr)
-		return "text", descr
+		from config import config
+		if self.grafic and config.usage.boolean_graphic.value:
+			if self.value:
+				return ('pixmap', self.trueIcon)
+			else:
+				return ('pixmap', self.falseIcon)
+		else:
+			descr = self.descriptions[self.value]
+			if descr:
+				return "text", _(descr)
+			return "text", descr
 
 	def tostring(self, value):
 		if not value or str(value).lower() == 'false':

--- a/skin.py
+++ b/skin.py
@@ -13,6 +13,8 @@ from Tools.LoadPixmap import LoadPixmap
 from Components.RcModel import rc_model
 
 colorNames = {}
+switchPixmap = {}  # dict()
+
 # Predefined fonts, typically used in built-in screens and for components like
 # the movie list and so.
 fonts = {
@@ -550,6 +552,7 @@ def loadSingleSkinData(desktop, skin, path_prefix):
 					parameters["EPGImportFilterListDescr"] = (30,3,500,30)
 					parameters["EPGImportFilterListLockOff"] = (0,0,30,30)
 					parameters["EPGImportFilterListLockOn"] = (0,0,30,30)
+
 	for skininclude in skin.findall("include"):
 		filename = skininclude.attrib.get("filename")
 		if filename:
@@ -559,6 +562,21 @@ def loadSingleSkinData(desktop, skin, path_prefix):
 			if fileExists(skinfile):
 				print "[Skin] loading include:", skinfile
 				loadSkin(skinfile)
+
+	for c in skin.findall('switchpixmap'):
+		for pixmap in c.findall('pixmap'):
+			get_attr = pixmap.attrib.get
+			name = get_attr('name')
+			if not name:
+				raise SkinError('[Skin] pixmap needs name attribute')
+			filename = get_attr('filename')
+			if not filename:
+				raise SkinError('[Skin] pixmap needs filename attribute')
+			resolved_png = resolveFilename(SCOPE_ACTIVE_SKIN, filename, path_prefix=path_prefix)
+			if fileExists(resolved_png):
+				switchPixmap[name] = resolved_png
+			else:
+				raise SkinError('[Skin] switchpixmap pixmap filename="%s" (%s) not found' % (filename, resolved_png))
 
 	for c in skin.findall("colors"):
 		for color in c.findall("color"):


### PR DESCRIPTION
This change adds the infrastructure for a skin to enable a graphical switch icon to replace the On/Off, Yes/No, True/False and Enabled/Disabled configuration selection options.

To be properly implements the switch images and a configuration block must be added to the active skin.  I propose to add the images to the default skin so that they will be available to all skins.  I also would like to add the appropriate block to the default skin.  Other skin maintainers can add the block and, if they desire, alternate images.
