### PR TITLE
[MenuList.py] Create first / last position jumps

### DIFF
--- a/lib/python/Components/MenuList.py
+++ b/lib/python/Components/MenuList.py
@@ -45,6 +45,14 @@ class MenuList(HTMLComponent, GUIComponent):
 		if self.instance is not None:
 			self.instance.moveSelectionTo(idx)
 
+	def first(self):
+		if self.instance is not None:
+			self.instance.moveSelection(self.instance.moveTop)
+
+	def last(self):
+		if self.instance is not None:
+			self.instance.moveSelection(self.instance.moveEnd)
+
 	def pageUp(self):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.pageUp)


### PR DESCRIPTION
This change exposes the "moveTop" and "moveEnd" methods in the eListBox GUI object as the functions "first" and "last" respectively.  This allows programmers to jump to the first and last item in the MenuList list.
