### PR TITLE
Set the default debugTime to true, as logs without this lose a lot of…

### DIFF
--- a/lib/base/eerror.cpp
+++ b/lib/base/eerror.cpp
@@ -77,7 +77,7 @@ void DumpUnfreed()
 #endif
 
 int debugLvl = lvlDebug;
-static bool debugTime = false;
+static bool debugTime = true;
 
 static pthread_mutex_t DebugLock = PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP;
 #define RINGBUFFER_SIZE 16384


### PR DESCRIPTION
… relevance.

My debug logs on OpenViX 5.0 are now just a bunch of text lines with no way to relate consecutive lines at all. They may be related, or they may be many minutes apart. Useless.