### PR TITLE
[InputDeviceSetup.py] Remove unused colours

### DIFF
--- a/lib/python/Screens/InputDeviceSetup.py
+++ b/lib/python/Screens/InputDeviceSetup.py
@@ -34,8 +34,6 @@ class InputDeviceSelection(Screen, HelpableScreen):
 
 		self["key_red"] = StaticText(_("Close"))
 		self["key_green"] = StaticText(_("Select"))
-		self["key_yellow"] = StaticText("")
-		self["key_blue"] = StaticText("")
 		self["introduction"] = StaticText(self.edittext)
 
 		self.devices = [(iInputDevices.getDeviceName(x),x) for x in iInputDevices.getDeviceList()]
@@ -158,8 +156,6 @@ class InputDeviceSetup(Screen, ConfigListScreen):
 
 		self["key_red"] = StaticText(_("Cancel"))
 		self["key_green"] = StaticText(_("OK"))
-		self["key_yellow"] = StaticText()
-		self["key_blue"] = StaticText()
 		self["introduction"] = StaticText()
 
 		# for generating strings into .po only


### PR DESCRIPTION
Remove the unused YELLOW and BLUE button labels.  This will suppress the display of these buttons on skins that check for the existence of the button text definition.
