### PR TITLE
Do not use Europe/Istanbul for non-Istanbul entires

### DIFF
--- a/data/timezone.xml
+++ b/data/timezone.xml
@@ -37,10 +37,10 @@
 	<zone name="(GMT+01:00) West Central Africa" zone="Africa/Kinshasa" />
 	<zone name="(GMT+01:00) Algiers, Tunis" zone="Africa/Kinshasa" />
 	<zone name="(GMT+02:00) Athens, Istanbul, Minsk" zone="Europe/Istanbul" />
-	<zone name="(GMT+02:00) Bucharest" zone="Europe/Istanbul" />
+	<zone name="(GMT+02:00) Bucharest" zone="Europe/Bucharest" />
 	<zone name="(GMT+02:00) Harare, Pretoria" zone="Africa/Harare" />
-	<zone name="(GMT+02:00) Helsinki, Kyiv, Sofia" zone="Europe/Istanbul" />
-	<zone name="(GMT+02:00) Riga, Tallinn, Vilnius" zone="Europe/Istanbul" />
+	<zone name="(GMT+02:00) Helsinki, Kyiv, Sofia" zone="Europe/Helsinki" />
+	<zone name="(GMT+02:00) Riga, Tallinn, Vilnius" zone="Europe/Riga" />
 	<zone name="(GMT+02:00) Jerusalem" zone="Asia/Jerusalem" />
 	<zone name="(GMT+03:00) Baghdad" zone="Asia/Baghdad" />
 	<zone name="(GMT+03:00) Kuwait, Riyadh" zone="Asia/Riyadh" />


### PR DESCRIPTION
Places such as Helsinki have had to set Asia/Jerusalem to get the correct time, but that goes on to DLST on Friday Mar 24th, so it will be wrong then to.
This changes "Helsinki, Kyiv, Sofia" to use Europe/Helsinki, "Riga, Tallinn, Vilnius" to use Europe/Riga and "Bucharest" to use Europe/Bucharest.  "Athens, Istanbul, Minsk" is left as Europe/Istanbul, so Athens and Minsk users will have to use one of the others.

NOTE: that this really needs to get into production by the end of this week!!