### PR TITLE
[ServiceName2.py] Fix DVB-T bandwidth conversion

### DIFF
--- a/lib/python/Components/Converter/ServiceName2.py
+++ b/lib/python/Components/Converter/ServiceName2.py
@@ -312,8 +312,9 @@ class ServiceName2(Converter, object):
 					result += x in range(5) and {0:'1/32',1:'1/16',2:'1/8',3:'1/4',4:'Auto'}[x] or ''
 			elif f == 'b':	# %b - bandwidth (dvb-t)
 				if type == 'DVB-T':
-					x = self.tpdata.get('bandwidth', 1)
-					result += x in range(4) and {0:'8 MHz',1:'7 MHz',2:'6 MHz',3:'Auto'}[x] or ''
+					x = self.tpdata.get('bandwidth', 0)
+					if isinstance(x, int):
+						result += str("%.3f" % (float(x) / 1000000.0)).rstrip('0').rstrip('.') + " MHz" if x else "Auto"
 			elif f == 'e':	# %e - hierarchy_information (dvb-t)
 				if type == 'DVB-T':
 					x = self.tpdata.get('hierarchy_information', 4)


### PR DESCRIPTION
This correction fixes an issue where the DVB-T bandwidth reported by the C++ layer is no longer an index into a bandwidth table but the real bandwidth in Hz.
