### PR TITLE
Extend the functionality of Notifiers

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -38,6 +38,7 @@ class ConfigElement(object):
 		self.__notifiers_final = None
 		self.enabled = True
 		self.callNotifiersOnSaveAndCancel = False
+		self.callFinalNotifiersOnSaveAndCancel = False
 
 	def getNotifiers(self):
 		if self.__notifiers is None:
@@ -91,12 +92,24 @@ class ConfigElement(object):
 		else:
 			self.saved_value = self.tostring(self.value)
 		if self.callNotifiersOnSaveAndCancel:
+			self._callback_reason = 'save'
 			self.changed()
+			del self._callback_reason
+		if self.callFinalNotifiersOnSaveAndCancel:
+			self._callback_reason = 'save'
+			self.changedFinal()
+			del self._callback_reason
 
 	def cancel(self):
 		self.load()
 		if self.callNotifiersOnSaveAndCancel:
+			self._callback_reason = 'cancel'
 			self.changed()
+			del self._callback_reason
+		if self.callFinalNotifiersOnSaveAndCancel:
+			self._callback_reason = 'cancel'
+			self.changedFinal()
+			del self._callback_reason
 
 	def isChanged(self):
 # NOTE - sv should already be stringified!
@@ -154,9 +167,13 @@ class ConfigElement(object):
 		#     the entry could just be new.)
 		if initial_call:
 			if extra_args:
+				self._callback_reason = 'initial'
 				notifier(self,extra_args)
+				del self._callback_reason
 			else:
+				self._callback_reason = 'initial'
 				notifier(self)
+				del self._callback_reason
 
 	def removeNotifier(self, notifier):
 		notifier in self.notifiers and self.notifiers.remove(notifier)


### PR DESCRIPTION
This extends the functionality of ConfigElement notifiers by:

a) adding the ability to have callbacks when menus are Saved and Cancelled to FinalNotifiers (it already exists for non-Final ones).

b) Adding a _callback_reason to the callback ConfigElement during any initial call ('initial'), Save ('save') or Cancel ('cancel') action. This attribute is only set for the duration of the call and is not set for any  normal or user-activated call.

This enables callback function to initialize items and also to only perform configuration changes when the final value has been chosen (or do nothing if the actin is discarded).

This is required for the correct functioning of a two-item timezones menu (area then timezone in area) that will follow.