### PR TITLE
[menu.xml] make all Information menu keys unique

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -26,8 +26,8 @@
 			<id val="information"/>
 			<item level="0" text="About" entryID="about_screen"><screen module="About" screen="About"/></item>
 			<item level="0" text="Devices" entryID="device_screen"><screen module="About" screen="Devices"/></item>
-			<item level="0" text="Memory" entryID="device_screen"><screen module="About" screen="SystemMemoryInfo"/></item>
-			<item level="0" text="Network" entryID="device_screen"><screen module="About" screen="SystemNetworkInfo"/></item>
+			<item level="0" text="Memory" entryID="memory_screen"><screen module="About" screen="SystemMemoryInfo"/></item>
+			<item level="0" text="Network" entryID="network_screen"><screen module="About" screen="SystemNetworkInfo"/></item>
 			<item level="1" text="Service" entryID="service_info_screen"><screen module="ServiceInfo" screen="ServiceInfo"/></item>
 			<item level="2" text="Streaming clients info" entryID="streaming_clients_info_screen"><screen module="StreamingClientsInfo"/></item>
 		</menu>


### PR DESCRIPTION
In order to reference which Information menu item is currently selected the entry_ID needs to be unique.  This was previously not the case.  This change separates the three occurrences of entry_ID "device_screen" into tree more appropriately named unique entries
.