### PR TITLE
[MenuList.py] Enhance list movement methods

### DIFF
--- a/lib/python/Components/MenuList.py
+++ b/lib/python/Components/MenuList.py
@@ -45,11 +45,11 @@ class MenuList(HTMLComponent, GUIComponent):
 		if self.instance is not None:
 			self.instance.moveSelectionTo(idx)
 
-	def first(self):
+	def moveTop(self):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.moveTop)
 
-	def last(self):
+	def moveBottom(self):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.moveEnd)
 
@@ -61,13 +61,23 @@ class MenuList(HTMLComponent, GUIComponent):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.pageDown)
 
-	def up(self):
+	# Add new moveUp method for symmetry with ConfigList
+	def moveUp(self):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.moveUp)
 
-	def down(self):
+	# Add new moveDown method for symmetry with ConfigList
+	def moveDown(self):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.moveDown)
+
+	# Maintain the old up method for legacy compatibility
+	def up(self):
+		self.moveUp()
+
+	# Maintain the old down method for legacy compatibility
+	def down(self):
+		self.moveDown()
 
 	def selectionEnabled(self, enabled):
 		if self.instance is not None:


### PR DESCRIPTION
This change renames the recently added first and last methods to moveTop and moveBottom respectively. This better aligns with the underlying C++ code. The underlying C++ code is a little odd in that the functions provided moveTop and moveEnd are not natural opposites (which is why I originally chose the different names). I have gone with moveTop and moveBottom rather than moveStart and moveEnd as this works better with the other navigation methods.

Add new methods moveUp and moveDown as synonyms for the existing up and down methods. These additional new names also better match the underlying C++ code and offer symmetry with the equivalent methods in the ConfigList.py code.
