### PR TITLE
[ChannelSelectionContextMenu] fix shortcuts for nonexistent menu items

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -240,7 +240,7 @@ class ChannelContextMenu(Screen):
 							self.removeFunction = self.removeSatelliteService
 					else:
 						if not self.inBouquet:
-							_append_when_current_valid(current, menu, actions, (_("Add service to favourites"), self.addServiceToBouquetSelected), level=0, key="bullet")
+							_append_when_current_valid(current, menu, actions, (_("Add service to favourites"), self.addServiceToBouquetSelected), level=0, key="7")
 							self.addFunction = self.addServiceToBouquetSelected
 					if SystemInfo["PIPAvailable"]:
 						if not self.parentalControlEnabled or self.parentalControl.getProtectionLevel(current.toCompareString()) == -1:

--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -127,9 +127,19 @@ OFF = 0
 EDIT_BOUQUET = 1
 EDIT_ALTERNATIVES = 2
 
-def append_when_current_valid(current, menu, args, level=0, key=""):
+def _append_when_current_valid(current, menu, actions, args, level=0, key=""):
 	if current and current.valid() and level <= config.usage.setup_level.index:
+		if actions is not None and key not in ("", "expandable", "expanded", "verticalline", "bullet"):
+			if key not in actions:
+				actions[key] = args[1]
+			else:
+				print "[ChannelContextMenu] attempt to redefine shortcut using", key, "ignored"
+				key = "bullet"
 		menu.append(ChoiceEntryComponent(key, args))
+
+def append_when_current_valid(current, menu, args, level=0, key=""):
+	print "[ChannelContextMenu] append_when_current_valid is deprecated - use _append_when_current_valid"
+	_append_when_current_valid(current, menu, None, args, level=level, key=key)
 
 def removed_userbouquets_available():
 	for file in os.listdir("/etc/enigma2/"):
@@ -147,27 +157,29 @@ class ChannelContextMenu(Screen):
 		if self.isProtected():
 			self.onFirstExecBegin.append(boundFunction(self.session.openWithCallback, self.protectResult, PinInput, pinList=[x.value for x in config.ParentalControl.servicepin], triesEntry=config.ParentalControl.retries.servicepin, title=_("Please enter the correct pin code"), windowTitle=_("Enter pin code")))
 
-		self["actions"] = ActionMap(["OkCancelActions", "ColorActions", "NumberActions", "MenuActions"],
-			{
-				"ok": self.okbuttonClick,
-				"cancel": self.cancelClick,
-				"red": self.showMarkerInputBox,
-				"yellow": self.bouquetMarkStart,
-				"green": self.toggleMoveMode,
-				"blue": self.showServiceInPiP,
-				"menu": self.openSetup,
-				"0": self.showServiceInformations,
-				"1": self.setStartupService,
-				"2": self.unsetStartupService,
-				"3": self.addDedicated3DFlag,
-				"4": self.removeDedicated3DFlag,
-				"5": self.addHideVBIFlag,
-				"6": self.removeHideVBIFlag,
-				"7": self.editAlternativeServices,
-				"8": self.renameEntry,
-				"9": self.removeEntry
-			})
+		actions = {
+			"ok": self.okbuttonClick,
+			"cancel": self.cancelClick,
+			"menu": self.openSetup
+			# Added as necessary if the action is in the menu
+			#
+			# "red": self.showMarkerInputBox,
+			# "yellow": self.bouquetMarkStart,
+			# "green": self.toggleMoveMode,
+			# "blue": self.showServiceInPiP,
+			# "0": self.showServiceInformations,
+			# "1": self.setStartupService,
+			# "2": self.unsetStartupService,
+			# "3": self.addDedicated3DFlag,
+			# "4": self.removeDedicated3DFlag,
+			# "5": self.addHideVBIFlag,
+			# "6": self.removeHideVBIFlag,
+			# "7": self.addServiceToBouquetSelected,
+			# "8": self.renameEntry,
+			# "9": self.removeEntry
+		}
 		menu = [ ]
+
 
 		menu.append(ChoiceEntryComponent("menu", (_("Configuration..."), self.openSetup)))
 		self["menu"] = ChoiceList(menu)
@@ -186,34 +198,34 @@ class ChannelContextMenu(Screen):
 		self.parentalControl = parentalControl
 		self.parentalControlEnabled = config.ParentalControl.servicepinactive.value
 		if not (current_sel_path or current_sel_flags & (eServiceReference.isDirectory|eServiceReference.isMarker)):
-			append_when_current_valid(current, menu, (_("Show transponder info"), self.showServiceInformations), level=2, key="0")
+			_append_when_current_valid(current, menu, actions, (_("Show transponder info"), self.showServiceInformations), level=2, key="0")
 		if csel.bouquet_mark_edit == OFF and not csel.entry_marked:
 			if not inBouquetRootList:
 				isPlayable = not (current_sel_flags & (eServiceReference.isMarker|eServiceReference.isDirectory))
 				if isPlayable:
 					for p in plugins.getPlugins(PluginDescriptor.WHERE_CHANNEL_CONTEXT_MENU):
-						append_when_current_valid(current, menu, (p.name, boundFunction(self.runPlugin, p)), key="bullet")
+						_append_when_current_valid(current, menu, actions, (p.name, boundFunction(self.runPlugin, p)), key="bullet")
 					if config.servicelist.startupservice.value == current.toString():
-						append_when_current_valid(current, menu, (_("Stop using as startup service"), self.unsetStartupService), level=0, key="2")
+						_append_when_current_valid(current, menu, actions, (_("Stop using as startup service"), self.unsetStartupService), level=0, key="2")
 					else:
-						append_when_current_valid(current, menu, (_("Set as startup service"), self.setStartupService), level=0, key="1")
+						_append_when_current_valid(current, menu, actions, (_("Set as startup service"), self.setStartupService), level=0, key="1")
 					if self.parentalControlEnabled:
 						if self.parentalControl.getProtectionLevel(csel.getCurrentSelection().toCompareString()) == -1:
-							append_when_current_valid(current, menu, (_("Add to parental protection"), boundFunction(self.addParentalProtection, current)), level=0, key="bullet")
+							_append_when_current_valid(current, menu, actions, (_("Add to parental protection"), boundFunction(self.addParentalProtection, current)), level=0, key="bullet")
 						else:
-							append_when_current_valid(current, menu, (_("Remove from parental protection"), boundFunction(self.removeParentalProtection, current)), level=0, key="bullet")
+							_append_when_current_valid(current, menu, actions, (_("Remove from parental protection"), boundFunction(self.removeParentalProtection, current)), level=0, key="bullet")
 						if config.ParentalControl.hideBlacklist.value and not parentalControl.sessionPinCached and config.ParentalControl.storeservicepin.value != "never":
-							append_when_current_valid(current, menu, (_("Unhide parental control services"), self.unhideParentalServices), level=0, key="1")
+							_append_when_current_valid(current, menu, actions, (_("Unhide parental control services"), self.unhideParentalServices), level=0, key="bullet")
 					if SystemInfo["3DMode"]:
 						if eDVBDB.getInstance().getFlag(eServiceReference(current.toString())) & FLAG_IS_DEDICATED_3D:
-							append_when_current_valid(current, menu, (_("Unmark service as a dedicated 3D service"), self.removeDedicated3DFlag), level=0, key="4")
+							_append_when_current_valid(current, menu, actions, (_("Unmark service as a dedicated 3D service"), self.removeDedicated3DFlag), level=0, key="4")
 						else:
-							append_when_current_valid(current, menu, (_("Mark service as a dedicated 3D service"), self.addDedicated3DFlag), level=0, key="3")
+							_append_when_current_valid(current, menu, actions, (_("Mark service as a dedicated 3D service"), self.addDedicated3DFlag), level=0, key="3")
 					if not (current_sel_path):
 						if eDVBDB.getInstance().getFlag(eServiceReference(current.toString())) & FLAG_HIDE_VBI:
-							append_when_current_valid(current, menu, (_("Remove 'Hide dotted line on the top for this service'"), self.removeHideVBIFlag), level=0, key="6")
+							_append_when_current_valid(current, menu, actions, (_("Remove 'Hide dotted line on the top for this service'"), self.removeHideVBIFlag), level=0, key="6")
 						else:
-							append_when_current_valid(current, menu, (_("Hide dotted line on the top for this service"), self.addHideVBIFlag), level=0, key="5")
+							_append_when_current_valid(current, menu, actions, (_("Hide dotted line on the top for this service"), self.addHideVBIFlag), level=0, key="5")
 					if haveBouquets:
 						bouquets = self.csel.getBouquetList()
 						if bouquets is None:
@@ -221,91 +233,91 @@ class ChannelContextMenu(Screen):
 						else:
 							bouquetCnt = len(bouquets)
 						if not self.inBouquet or bouquetCnt > 1:
-							append_when_current_valid(current, menu, (_("Add service to bouquet"), self.addServiceToBouquetSelected), level=0, key="7")
+							_append_when_current_valid(current, menu, actions, (_("Add service to bouquet"), self.addServiceToBouquetSelected), level=0, key="7")
 							self.addFunction = self.addServiceToBouquetSelected
 						if not self.inBouquet:
-							append_when_current_valid(current, menu, (_("Remove entry"), self.removeEntry), level = 0, key="9")
+							_append_when_current_valid(current, menu, actions, (_("Remove entry"), self.removeEntry), level = 0, key="9")
 							self.removeFunction = self.removeSatelliteService
 					else:
 						if not self.inBouquet:
-							append_when_current_valid(current, menu, (_("Add service to favourites"), self.addServiceToBouquetSelected), level=0, key="bullet")
+							_append_when_current_valid(current, menu, actions, (_("Add service to favourites"), self.addServiceToBouquetSelected), level=0, key="bullet")
 							self.addFunction = self.addServiceToBouquetSelected
 					if SystemInfo["PIPAvailable"]:
 						if not self.parentalControlEnabled or self.parentalControl.getProtectionLevel(current.toCompareString()) == -1:
 #							if self.csel.dopipzap:
-#								append_when_current_valid(current, menu, (_("Play in main window"), self.playMain), level=0, key="red")
+#								_append_when_current_valid(current, menu, actions, (_("Play in main window"), self.playMain), level=0, key="red")
 #								else:	
-									append_when_current_valid(current, menu, (_("Play as picture in picture"), self.showServiceInPiP), level=0, key="blue")
-#					append_when_current_valid(current, menu, (_("Find currently played service"), self.findCurrentlyPlayed), level=0, key="4")
+									_append_when_current_valid(current, menu, actions, (_("Play as picture in picture"), self.showServiceInPiP), level=0, key="blue")
+#					_append_when_current_valid(current, menu, actions, (_("Find currently played service"), self.findCurrentlyPlayed), level=0, key="4")
 				else:
 					if 'FROM SATELLITES' in current_root.getPath() and current and _("Services") in eServiceCenter.getInstance().info(current).getName(current):
 						unsigned_orbpos = current.getUnsignedData(4) >> 16
 						if unsigned_orbpos == 0xFFFF:
-							append_when_current_valid(current, menu, (_("Remove cable services"), self.removeSatelliteServices), level = 0, key="bullet")
+							_append_when_current_valid(current, menu, actions, (_("Remove cable services"), self.removeSatelliteServices), level = 0, key="bullet")
 						elif unsigned_orbpos == 0xEEEE:
-							append_when_current_valid(current, menu, (_("Remove terrestrial services"), self.removeSatelliteServices), level = 0, key="bullet")
+							_append_when_current_valid(current, menu, actions, (_("Remove terrestrial services"), self.removeSatelliteServices), level = 0, key="bullet")
 						else:
-							append_when_current_valid(current, menu, (_("Remove selected satellite"), self.removeSatelliteServices), level = 0, key="bullet")
+							_append_when_current_valid(current, menu, actions, (_("Remove selected satellite"), self.removeSatelliteServices), level = 0, key="bullet")
 					if haveBouquets:
 						if not self.inBouquet and not "PROVIDERS" in current_sel_path:
-							append_when_current_valid(current, menu, (_("Copy to bouquets"), self.copyCurrentToBouquetList), level=0, key="bullet")
+							_append_when_current_valid(current, menu, actions, (_("Copy to bouquets"), self.copyCurrentToBouquetList), level=0, key="bullet")
 					if ("flags == %d" %(FLAG_SERVICE_NEW_FOUND)) in current_sel_path:
-						append_when_current_valid(current, menu, (_("Remove all new found flags"), self.removeAllNewFoundFlags), level=0, key="bullet")
+						_append_when_current_valid(current, menu, actions, (_("Remove all new found flags"), self.removeAllNewFoundFlags), level=0, key="bullet")
 				if self.inBouquet:
-					append_when_current_valid(current, menu, (_("Rename entry"), self.renameEntry), level=0, key="8")
+					_append_when_current_valid(current, menu, actions, (_("Rename entry"), self.renameEntry), level=0, key="8")
 					if not inAlternativeList:
-						append_when_current_valid(current, menu, (_("Remove entry"), self.removeEntry), level=0, key="9")
+						_append_when_current_valid(current, menu, actions, (_("Remove entry"), self.removeEntry), level=0, key="9")
 						self.removeFunction = self.removeCurrentService
 				if current_root and ("flags == %d" %(FLAG_SERVICE_NEW_FOUND)) in current_root.getPath():
-					append_when_current_valid(current, menu, (_("Remove new found flag"), self.removeNewFoundFlag), level=0, key="bullet")
+					_append_when_current_valid(current, menu, actions, (_("Remove new found flag"), self.removeNewFoundFlag), level=0, key="bullet")
 			else:
 					if self.parentalControlEnabled:
 						if self.parentalControl.getProtectionLevel(current.toCompareString()) == -1:
-							append_when_current_valid(current, menu, (_("Add bouquet to parental protection"), boundFunction(self.addParentalProtection, current)), level=0, key="bullet")
+							_append_when_current_valid(current, menu, actions, (_("Add bouquet to parental protection"), boundFunction(self.addParentalProtection, current)), level=0, key="bullet")
 						else:
-							append_when_current_valid(current, menu, (_("Remove bouquet from parental protection"), boundFunction(self.removeParentalProtection, current)), level=0, key="bullet")
+							_append_when_current_valid(current, menu, actions, (_("Remove bouquet from parental protection"), boundFunction(self.removeParentalProtection, current)), level=0, key="bullet")
 					menu.append(ChoiceEntryComponent(text=(_("Add bouquet"), self.showBouquetInputBox), key="bullet"))
-					append_when_current_valid(current, menu, (_("Rename entry"), self.renameEntry), level=0, key="8")
-					append_when_current_valid(current, menu, (_("Remove entry"), self.removeEntry), level=0, key="9")
+					_append_when_current_valid(current, menu, actions, (_("Rename entry"), self.renameEntry), level=0, key="8")
+					_append_when_current_valid(current, menu, actions, (_("Remove entry"), self.removeEntry), level=0, key="9")
 					self.removeFunction = self.removeBouquet
 					if removed_userbouquets_available():
-						append_when_current_valid(current, menu, (_("Purge deleted user bouquets"), self.purgeDeletedBouquets), level=0, key="bullet")
-						append_when_current_valid(current, menu, (_("Restore deleted user bouquets"), self.restoreDeletedBouquets), level=0, key="bullet")
+						_append_when_current_valid(current, menu, actions, (_("Purge deleted user bouquets"), self.purgeDeletedBouquets), level=0, key="bullet")
+						_append_when_current_valid(current, menu, actions, (_("Restore deleted user bouquets"), self.restoreDeletedBouquets), level=0, key="bullet")
 		if self.inBouquet: # current list is editable?
 			if csel.bouquet_mark_edit == OFF:
 				if csel.movemode:
-					append_when_current_valid(current, menu, (_("Disable move mode"), self.toggleMoveMode), level=0, key="green")
+					_append_when_current_valid(current, menu, actions, (_("Disable move mode"), self.toggleMoveMode), level=0, key="green")
 				else:
-					append_when_current_valid(current, menu, (_("Enable move mode"), self.toggleMoveMode), level=1, key="green")
+					_append_when_current_valid(current, menu, actions, (_("Enable move mode"), self.toggleMoveMode), level=1, key="green")
 				if not csel.entry_marked and not inBouquetRootList and current_root and not (current_root.flags & eServiceReference.isGroup):
-					if current.type != -1:
-						menu.append(ChoiceEntryComponent(text=(_("Add marker"), self.showMarkerInputBox), key="red"))
+					_append_when_current_valid(current, menu, actions, (_("Add marker"), self.showMarkerInputBox), level=0, key="red")
 					if not csel.movemode:
 						if haveBouquets:
-							append_when_current_valid(current, menu, (_("Enable bouquet edit"), self.bouquetMarkStart), level=0, key="yellow")
+							_append_when_current_valid(current, menu, actions, (_("Enable bouquet edit"), self.bouquetMarkStart), level=0, key="yellow")
 						else:
-							append_when_current_valid(current, menu, (_("Enable favourite edit"), self.bouquetMarkStart), level=0, key="yellow")
+							_append_when_current_valid(current, menu, actions, (_("Enable favourite edit"), self.bouquetMarkStart), level=0, key="yellow")
 					if current_sel_flags & eServiceReference.isGroup:
-						append_when_current_valid(current, menu, (_("Edit alternatives"), self.editAlternativeServices), level=2, key="bullet")
-						append_when_current_valid(current, menu, (_("Show alternatives"), self.showAlternativeServices), level=2, key="bullet")
-						append_when_current_valid(current, menu, (_("Remove all alternatives"), self.removeAlternativeServices), level=2, key="bullet")
+						_append_when_current_valid(current, menu, actions, (_("Edit alternatives"), self.editAlternativeServices), level=2, key="bullet")
+						_append_when_current_valid(current, menu, actions, (_("Show alternatives"), self.showAlternativeServices), level=2, key="bullet")
+						_append_when_current_valid(current, menu, actions, (_("Remove all alternatives"), self.removeAlternativeServices), level=2, key="bullet")
 					elif not current_sel_flags & eServiceReference.isMarker:
-						append_when_current_valid(current, menu, (_("Add alternatives"), self.addAlternativeServices), level=2, key="bullet")
+						_append_when_current_valid(current, menu, actions, (_("Add alternatives"), self.addAlternativeServices), level=2, key="bullet")
 			else:
 				if csel.bouquet_mark_edit == EDIT_BOUQUET:
 					if haveBouquets:
-						append_when_current_valid(current, menu, (_("End bouquet edit"), self.bouquetMarkEnd), level=0, key="bullet")
-						append_when_current_valid(current, menu, (_("Abort bouquet edit"), self.bouquetMarkAbort), level=0, key="bullet")
+						_append_when_current_valid(current, menu, actions, (_("End bouquet edit"), self.bouquetMarkEnd), level=0, key="bullet")
+						_append_when_current_valid(current, menu, actions, (_("Abort bouquet edit"), self.bouquetMarkAbort), level=0, key="bullet")
 					else:
-						append_when_current_valid(current, menu, (_("End favourites edit"), self.bouquetMarkEnd), level=0, key="bullet")
-						append_when_current_valid(current, menu, (_("Abort favourites edit"), self.bouquetMarkAbort), level=0, key="bullet")
+						_append_when_current_valid(current, menu, actions, (_("End favourites edit"), self.bouquetMarkEnd), level=0, key="bullet")
+						_append_when_current_valid(current, menu, actions, (_("Abort favourites edit"), self.bouquetMarkAbort), level=0, key="bullet")
 					if current_sel_flags & eServiceReference.isMarker:
-						append_when_current_valid(current, menu, (_("Rename entry"), self.renameEntry), level=0, key="8")
-						append_when_current_valid(current, menu, (_("Remove entry"), self.removeEntry), level=0, key="9")
+						_append_when_current_valid(current, menu, actions, (_("Rename entry"), self.renameEntry), level=0, key="8")
+						_append_when_current_valid(current, menu, actions, (_("Remove entry"), self.removeEntry), level=0, key="9")
 						self.removeFunction = self.removeCurrentService
 				else:
-					append_when_current_valid(current, menu, (_("End alternatives edit"), self.bouquetMarkEnd), level=0, key="bullet")
-					append_when_current_valid(current, menu, (_("Abort alternatives edit"), self.bouquetMarkAbort), level=0, key="bullet")
+					_append_when_current_valid(current, menu, actions, (_("End alternatives edit"), self.bouquetMarkEnd), level=0, key="bullet")
+					_append_when_current_valid(current, menu, actions, (_("Abort alternatives edit"), self.bouquetMarkAbort), level=0, key="bullet")
+		self["actions"] = ActionMap(["OkCancelActions", "ColorActions", "NumberActions", "MenuActions"], actions)
 
 	def set3DMode(self, value):
 		if config.osd.threeDmode.value == "auto" and self.session.nav.currentlyPlayingServiceReference == self.csel.getCurrentSelection():


### PR DESCRIPTION
ChannelSelectionContextMenu has a fixed ActionMap for its ChoiceList,
so that shortcut buttons (numbers, colours) are always active, even
if there is no menu item corresponding to the shortcut's action.

This can cause crashes and other inappropriate behaviour.

Now dynamically create the menu's ActionMap so that only the correct shortcut buttons are active.