### PR TITLE
Update usb dvb device detection with device ep_84.

### DIFF
--- a/lib/dvb/dvb.cpp
+++ b/lib/dvb/dvb.cpp
@@ -244,6 +244,10 @@ bool eDVBAdapterLinux::isusb(int nr)
 {
 	char devicename[256];
 	snprintf(devicename, sizeof(devicename), "/sys/class/dvb/dvb%d.frontend0/device/ep_00", nr);
+	if (::access(devicename, X_OK) < 0 )
+	{
+		snprintf(devicename, sizeof(devicename), "/sys/class/dvb/dvb%d.frontend0/device/ep_84", nr);
+	}
 	return ::access(devicename, X_OK) >= 0;
 }
 


### PR DESCRIPTION
This is the OpenATV commit:
   https://github.com/openatv/enigma2/commit/16c47dd2e78ca70c5ad2467d0d2952628050a3ec
It enables a PCTV 292e DVB stick to work on later kernels.