### PR TITLE
Start / End bookmarks missing on recordings after being chaseplayed

### DIFF
--- a/lib/service/iservice.h
+++ b/lib/service/iservice.h
@@ -1020,6 +1020,10 @@ public:
 	virtual SWIG_VOID(RESULT) stream(ePtr<iStreamableService> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) subServices(ePtr<iSubserviceList> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) getFilenameExtension(std::string &SWIG_OUTPUT)=0;
+	virtual PyObject *getCutList()
+	{
+		return PyList_New(0);
+	}
 };
 SWIG_TEMPLATE_TYPEDEF(ePtr<iRecordableService>, iRecordableServicePtr);
 

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1433,6 +1433,13 @@ RESULT eDVBServicePlay::stop()
 
 	m_nownext_timer->stop();
 	m_event((iPlayableService*)this, evStopped);
+
+	// In case the event callout changes the cue sheet
+	if ((m_is_pvr || m_timeshift_enabled) && m_cuesheet_changed)
+	{
+		saveCuesheet();
+	}
+
 	return 0;
 }
 

--- a/lib/service/servicedvbrecord.cpp
+++ b/lib/service/servicedvbrecord.cpp
@@ -561,36 +561,69 @@ void eDVBServiceRecord::gotNewEvent(int /*error*/)
 	m_event((iRecordableService*)this, evNewEventInfo);
 }
 
-void eDVBServiceRecord::saveCutlist()
+void eDVBServiceRecord::fixupCuts(std::list<pts_t> &offsets)
 {
-			/* XXX: dupe of eDVBServicePlay::saveCuesheet, refactor plz */
-	std::string filename = m_filename + ".cuts";
-
 	eDVBTSTools tstools;
+	offsets.clear();
 
 	if (tstools.openFile(m_filename.c_str()))
 	{
-		eDebug("[eDVBServiceRecord] saving cutlist failed because tstools failed");
+		eDebug("[eDVBServiceRecord] fetching cutlist failed because tstools failed");
 		return;
 	}
+
+	for (std::map<int,pts_t>::iterator i(m_event_timestamps.begin()); i != m_event_timestamps.end(); ++i)
+	{
+		pts_t p = i->second;
+		off_t offset = 0; // fixme, we need to note down both
+		if (tstools.fixupPTS(offset, p))
+		{
+			eDebug("[eDVBServiceRecord] fixing up PTS failed, not saving");
+			continue;
+		}
+		eDebug("[eDVBServiceRecord] fixed up %llx to %llx (offset %llx)", i->second, p, offset);
+		offsets.push_back(p);
+	}
+}
+
+PyObject *eDVBServiceRecord::getCutList()
+{
+        ePyObject list = PyList_New(0);
+	std::list<pts_t> offsets;
+	fixupCuts(offsets);
+
+	for (std::list<pts_t>::iterator i(offsets.begin()); i != offsets.end(); ++i)
+	{
+		pts_t p = *i;
+		eDebug("[eDVBServiceRecord] getCutList %llx", p);
+		ePyObject tuple = PyTuple_New(2);
+		PyTuple_SET_ITEM(tuple, 0, PyLong_FromLongLong(p));
+		PyTuple_SET_ITEM(tuple, 1, PyInt_FromLong(2)); /* mark */
+		PyList_Append(list, tuple);
+		Py_DECREF(tuple);
+	}
+
+	return list;
+}
+
+void eDVBServiceRecord::saveCutlist()
+{
+	std::string filename = m_filename + ".cuts";
 
 	// If a cuts file exists, append to it (who cares about sorting it)
 	FILE *f = fopen(filename.c_str(), "a+b");
 	if (f)
 	{
-		unsigned long long where;
-		int what;
+		std::list<pts_t> offsets;
+		fixupCuts(offsets);
 
-		for (std::map<int,pts_t>::iterator i(m_event_timestamps.begin()); i != m_event_timestamps.end(); ++i)
+		for (std::list<pts_t>::iterator i(offsets.begin()); i != offsets.end(); ++i)
 		{
-			pts_t p = i->second;
-			off_t offset = 0; // fixme, we need to note down both
-			if (tstools.fixupPTS(offset, p))
-			{
-				eDebug("[eDVBServiceRecord] fixing up PTS failed, not saving");
-				continue;
-			}
-			eDebug("[eDVBServiceRecord] fixed up %llx to %llx (offset %llx)", i->second, p, offset);
+			unsigned long long where;
+			int what;
+			pts_t p = *i;
+
+			eDebug("[eDVBServiceRecord] saveCutlist %llx", p);
 			where = htobe64(p);
 			what = htonl(2); /* mark */
 			fwrite(&where, sizeof(where), 1, f);
@@ -598,7 +631,6 @@ void eDVBServiceRecord::saveCutlist()
 		}
 		fclose(f);
 	}
-
 }
 
 RESULT eDVBServiceRecord::subServices(ePtr<iSubserviceList> &ptr)

--- a/lib/service/servicedvbrecord.h
+++ b/lib/service/servicedvbrecord.h
@@ -28,6 +28,7 @@ public:
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr);
 	RESULT subServices(ePtr<iSubserviceList> &ptr);
 	RESULT getFilenameExtension(std::string &ext) { ext = ".ts"; return 0; };
+	PyObject *getCutList();
 
 		// iStreamableService
 	ePtr<iStreamData> getStreamingData();
@@ -73,6 +74,7 @@ private:
 	void recordEvent(int event);
 
 			/* eit updates */
+	void fixupCuts(std::list<pts_t>&);
 	void gotNewEvent(int error);
 	void saveCutlist();
 };


### PR DESCRIPTION
The start and end bookmarks can be lost in an active recording if
the recording is played back via the media player while the recording
is still happening.

Replication: Start a recording, and while the recording is still
in progress, start playback in the MoviePlayer.

When the recording finishes, stop playback or allow playback to
end.

Play the recording again. The start/end bookmarks will be missing.

This fix preserves the bookmarks and has the additional benefit of
displaying "start/end" bookmarks in chaseplay as soon as the bookmarks
are generated in the corresponding recording object.

[InfoBarGenerics]

If a recording is played while it is still being recorded, identify
the corresponding eDVBServiceRecord object, and when it issues
evNewEventInfo events, update the InfoBarCueSheetSupport.cut_list
and playback's eDVBServicePlay object's cut list.

This will ensure that the playback has the recording's "start/end"
bookmarks available to write to the .cuts file when the playback
is stopped.

If the recording is still being made when playback is finished,
remove the recording's "start/end" marks up to that point from the
eDVBServicePlay object's cut list. The corresponding eDVBServiceRecord
object will write these "start/end" marks, and any that are defined
later in the recording, when the recording finishes.

If the recording is played once more while it is still being recorded,
the current "start/end" marks will be retrieved from the from the
eDVBServicePlay object's cut list.

Because the eDVBServicePlay object's cut list is updated in real
time, the "start/end" marks appear dynamically in the media playback's
infobar.

[iRecordableService,eDVBServiceRecord]

Add new method getCutList() that returns a list of the "start/end"
bookmarks in a recording object.

A default iRecordableService::getCutList(), which returns an empty
cut list, is defined so that other classes that derive from
iRecordableService need not define getCutList().

Extract common code in eDVBServiceRecord::saveCutlist() and
eDVBServiceRecord::getCutList() into private member function
eDVBServiceRecord::fixupCuts().

Remove comment about refactoring eDVBServicePlay::saveCuesheet()
and eDVBServiceRecord::saveCutlist(), because they are really only
superficially similar, and don't share much code.

[eDVBServicePlay]

In stop(), test whether the cuesheen needs to be saves after stop()
issues an evStopped event. This is required because new code in
Screens.InfoBarGenerics.InfoBarCueSheetSupport may call setCutList()
during in code called by the evStopped event.