### PR TITLE
Add support for KA-SAT (9°E) LNBs

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -339,6 +339,10 @@ class SecConfigure:
 					sec.setLNBLOFL(10750000)
 					sec.setLNBLOFH(10750000)
 					sec.setLNBThreshold(10750000)
+				elif currLnb.lof.value == "ka_sat":
+					sec.setLNBLOFL(21200000)
+					sec.setLNBLOFH(21200000)
+					sec.setLNBThreshold(21200000)
 
 				if currLnb.increased_voltage.value:
 					sec.setLNBIncreasedVoltage(True)
@@ -1154,6 +1158,7 @@ def InitNimManager(nimmgr, update_slots = []):
 		"unicable": _("SCR (Unicable/JESS)"),
 		"c_band": _("C-Band"),
 		"circular_lnb": _("Circular LNB"),
+                "ka_sat": _("KA-SAT"),
 		"user_defined": _("User defined")}
 
 	lnb_choices_default = "universal_lnb"

--- a/po/ar.po
+++ b/po/ar.po
@@ -4747,6 +4747,9 @@ msgstr ""
 msgid "Just zap"
 msgstr ""
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #, fuzzy
 msgid "Keep service"
 msgstr "إضافة قماه"

--- a/po/bg.po
+++ b/po/bg.po
@@ -4460,6 +4460,9 @@ msgstr ""
 msgid "Just zap"
 msgstr ""
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #, fuzzy
 msgid "Keep service"
 msgstr "добави Канал"

--- a/po/ca.po
+++ b/po/ca.po
@@ -4939,6 +4939,9 @@ msgstr ""
 msgid "Just zap"
 msgstr ""
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/cs.po
+++ b/po/cs.po
@@ -5524,6 +5524,9 @@ msgstr "celá obrazovka (nedodržuje poměr stran)"
 msgid "Just zap"
 msgstr "celá obrazovka (nedodržuje poměr stran)"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/da.po
+++ b/po/da.po
@@ -5082,6 +5082,9 @@ msgstr "Fyld billede helt ud"
 msgid "Just zap"
 msgstr "Fyld billede helt ud"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/de.po
+++ b/po/de.po
@@ -5387,6 +5387,9 @@ msgstr "Nur Skalieren"
 msgid "Just zap"
 msgstr "Nur Umschalten"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 msgid "Keep service"
 msgstr "Sender beibehalten"
 

--- a/po/el.po
+++ b/po/el.po
@@ -4300,6 +4300,9 @@ msgstr "Κλιμάκωση"
 msgid "Just zap"
 msgstr "Απλά μετάβαση"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 msgid "Keep service"
 msgstr "Διατήρηση υπηρεσίας"
 

--- a/po/en.po
+++ b/po/en.po
@@ -4465,6 +4465,9 @@ msgstr "Just scale"
 msgid "Just zap"
 msgstr "Just zap"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 msgid "Keep service"
 msgstr "Keep service"
 

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -4299,6 +4299,9 @@ msgstr "Just scale"
 msgid "Just zap"
 msgstr "Just zap"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 msgid "Keep service"
 msgstr "Keep service"
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -4302,6 +4302,9 @@ msgstr "Just scale"
 msgid "Just zap"
 msgstr "Just zap"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 msgid "Keep service"
 msgstr "Keep service"
 

--- a/po/es.po
+++ b/po/es.po
@@ -5035,6 +5035,9 @@ msgstr "Sólo escalar"
 msgid "Just zap"
 msgstr "Zapear"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/et.po
+++ b/po/et.po
@@ -5721,6 +5721,9 @@ msgstr "Alati täisekraan"
 msgid "Just zap"
 msgstr "Kanalivahetus"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 msgid "Kazakhstan"
 msgstr "Kasashtan"
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -4541,6 +4541,9 @@ msgstr "فقط Scale"
 msgid "Just zap"
 msgstr "فقط Scale"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #, fuzzy
 msgid "Keep service"
 msgstr "اضافه کردن کانال"

--- a/po/fi.po
+++ b/po/fi.po
@@ -5658,6 +5658,9 @@ msgstr "Aina kokoruutu"
 msgid "Just zap"
 msgstr "Vain kanavanvaihto"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 msgid "Keep service"
 msgstr "Säilytä kanava"

--- a/po/fr.po
+++ b/po/fr.po
@@ -4305,6 +4305,9 @@ msgstr "Juste mettre à l’échelle"
 msgid "Just zap"
 msgstr "Juste zapper"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 msgid "Keep service"
 msgstr "Garder service"
 

--- a/po/fy.po
+++ b/po/fy.po
@@ -5028,6 +5028,9 @@ msgstr "Alinne skale"
 msgid "Just zap"
 msgstr "Alinne skale"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/he.po
+++ b/po/he.po
@@ -4710,6 +4710,9 @@ msgstr ""
 msgid "Just zap"
 msgstr ""
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #, fuzzy
 msgid "Keep service"
 msgstr "add Service"

--- a/po/hr.po
+++ b/po/hr.po
@@ -4954,6 +4954,9 @@ msgstr ""
 msgid "Just zap"
 msgstr ""
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/hu.po
+++ b/po/hu.po
@@ -5103,6 +5103,9 @@ msgstr "Skálázás (nyújtás)"
 msgid "Just zap"
 msgstr "Skálázás (nyújtás)"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/is.po
+++ b/po/is.po
@@ -4851,6 +4851,9 @@ msgstr "Bara full mynd"
 msgid "Just zap"
 msgstr "Bara full mynd"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/it.po
+++ b/po/it.po
@@ -5064,6 +5064,9 @@ msgstr "Scalare solamente"
 msgid "Just zap"
 msgstr "Scalare solamente"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/ku.po
+++ b/po/ku.po
@@ -4658,6 +4658,9 @@ msgstr "Just scale"
 msgid "Just zap"
 msgstr "Just scale"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #, fuzzy
 msgid "Keep service"
 msgstr "Hizmeté Nu girédi"

--- a/po/lt.po
+++ b/po/lt.po
@@ -4506,6 +4506,9 @@ msgstr "Tik skalė"
 msgid "Just zap"
 msgstr "Tik skalė"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #, fuzzy
 msgid "Keep service"
 msgstr "pridėti Kanalą"

--- a/po/lv.po
+++ b/po/lv.po
@@ -5072,6 +5072,9 @@ msgstr "Vienkārši mērogot"
 msgid "Just zap"
 msgstr "Vienkārši mērogot"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/nb.po
+++ b/po/nb.po
@@ -4183,6 +4183,9 @@ msgstr ""
 msgid "Just zap"
 msgstr ""
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 msgid "Keep service"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -5213,6 +5213,9 @@ msgstr "Alleen schalen"
 msgid "Just zap"
 msgstr "Alleen zappen"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 msgid "Keep service"
 msgstr "Behoud zender"
 

--- a/po/no.po
+++ b/po/no.po
@@ -4969,6 +4969,9 @@ msgstr "Bare skaler"
 msgid "Just zap"
 msgstr "Bare zap"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 msgid "Keep service"
 msgstr "Beholde kanal"

--- a/po/pl.po
+++ b/po/pl.po
@@ -5166,6 +5166,9 @@ msgstr "Po prostu skaluj"
 msgid "Just zap"
 msgstr "Po prostu skaluj"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/pt.po
+++ b/po/pt.po
@@ -5059,6 +5059,9 @@ msgstr "Modo Escala"
 msgid "Just zap"
 msgstr "Modo Escala"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4666,6 +4666,9 @@ msgstr "Modo escala"
 msgid "Just zap"
 msgstr "Modo escala"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #, fuzzy
 msgid "Keep service"
 msgstr "Adicionar serviço"

--- a/po/ro.po
+++ b/po/ro.po
@@ -4461,6 +4461,9 @@ msgstr "Doar dimensiune"
 msgid "Just zap"
 msgstr "Doar dimensiune"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #, fuzzy
 msgid "Keep service"
 msgstr "adauga Serviciu"

--- a/po/ru.po
+++ b/po/ru.po
@@ -4514,6 +4514,9 @@ msgstr "только масштабирование"
 msgid "Just zap"
 msgstr "только переключ."
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #, fuzzy
 msgid "Keep service"
 msgstr "Нет каналов"

--- a/po/sk.po
+++ b/po/sk.po
@@ -4470,6 +4470,9 @@ msgstr "Len prispôsobiť"
 msgid "Just zap"
 msgstr "Len prepnúť"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 msgid "Keep service"
 msgstr "Ponechať službu"
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -5139,6 +5139,9 @@ msgstr "Samodejno"
 msgid "Just zap"
 msgstr "Samodejno"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/sr.po
+++ b/po/sr.po
@@ -5103,6 +5103,9 @@ msgstr "Samo razmeri"
 msgid "Just zap"
 msgstr "Samo razmeri"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/sv.po
+++ b/po/sv.po
@@ -4958,6 +4958,9 @@ msgstr "Endast skalning"
 msgid "Just zap"
 msgstr "Kanalbyte"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"

--- a/po/th.po
+++ b/po/th.po
@@ -4488,6 +4488,9 @@ msgstr "ขยายเต็มจอ"
 msgid "Just zap"
 msgstr "ขยายเต็มจอ"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #, fuzzy
 msgid "Keep service"
 msgstr "เพิ่มบริการ"

--- a/po/tr.po
+++ b/po/tr.po
@@ -5702,6 +5702,9 @@ msgstr "Sadece ölçek"
 msgid "Just zap"
 msgstr "Sadece kanal değiştir"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 msgid "Keep service"
 msgstr "Kanalı tut"

--- a/po/uk.po
+++ b/po/uk.po
@@ -5056,6 +5056,9 @@ msgstr "Просто масштабувати"
 msgid "Just zap"
 msgstr "Просто масштабувати"
 
+msgid "KA-SAT"
+msgstr "KA-SAT (9°E)"
+
 #
 #, fuzzy
 msgid "Keep service"


### PR DESCRIPTION
This adds LOF settings for the official KA-SAT LNB ([Inverto IDLW-TWNLRA20-D212O-OPP](http://www.inverto.tv/products/product.php?section=1&id=241&cat=92)) used by the Irish Saorsat service.