### PR TITLE
Remove a destroy() call so the VirtualKeyboard works for FIW Wifi set…

### DIFF
--- a/lib/python/Screens/Wizard.py
+++ b/lib/python/Screens/Wizard.py
@@ -595,11 +595,12 @@ class Wizard(Screen):
 						self.configInstance.setAnimationMode(0)
 						self["config"].l.setList(self.configInstance["config"].list)
 						callbacks = self.configInstance["config"].onSelectionChanged
-						self.configInstance["config"].destroy()
-						print "[Wizard] clearConfigList", self.configInstance["config"], self["config"]
+# The following line is commented out as it prevents the VirtualKeyboard
+# from working for Wifi SSID/key setting in the FirstInstallWizard.
+#						self.configInstance["config"].destroy()
+#						print "[Wizard] clearConfigList", self.configInstance["config"], self["config"]
 						self.configInstance["config"] = self["config"]
 						self.configInstance["config"].onSelectionChanged = callbacks
-						print "[Wizard] clearConfigList", self.configInstance["config"], self["config"]
 				else:
 					self["config"].l.setList([])
 					self.handleInputHelpers()


### PR DESCRIPTION
…ting.

I've also removed a (was duplicated) print statement, as it no longer applies.