### PR TITLE
Ensure save current timeshift event doesn't sometimes save wrong file

### DIFF
--- a/lib/python/Components/Timeshift.py
+++ b/lib/python/Components/Timeshift.py
@@ -610,7 +610,7 @@ class InfoBarTimeshift:
 			# print 'TEST1'
 			for filename in os.listdir(config.usage.timeshift_path.value):
 				# print 'filename',filename
-				if filename.startswith("timeshift.") and not filename.endswith(".del") and not filename.endswith(".copy"):
+				if filename.startswith("timeshift.") and not filename.endswith((".del", ".copy", ".sc")):
 					statinfo = os.stat("%s%s" % (config.usage.timeshift_path.value,filename))
 					if statinfo.st_mtime > (time()-5.0):
 						savefilename=filename


### PR DESCRIPTION
If InfoBarTimeshift.SaveTimeshift() is called without an explicit
timeshift file argument, and in the timeshift buffer directory
(/media/hdd/timeshift) the file timeshift.XXXXXX.sc is listed after
timeshift.XXXXXX (the .ts file) when os.listdir("/media/hdd/timeshift")
is called by SaveTimeshift() and timeshift.XXXXXX.sc has been updated
in the last 5 seconds, then timeshift.XXXXXX.sc will be used as the
saved timeshift buffer's .ts file, instead of timeshift.XXXXXX,
which is the actual TS file.

*** Replication steps ***

Change to a new channel, view ite timeshifted for a minute or two,
then change channels.

In the the "You seem to be in timeshift, Do you want to leave
timeshift ?" popup, select "Yes, but save timeshift as movie and
stop recording".

When timeshift has been saved check the size of the saved timeshift
file.  About half the time it will be small and not playable,
because the timeshift .sc file has been saved as the recording;'s
.ts instead of the timeshift TS file (no extension).

There is a more detailed bug report in the Beyonwiz bug tracker at
https://bitbucket.org/beyonwiz/easy-ui-4/issues/490/save-current-timeshift-event-sometimes

Fix:

Exclude files that end with ".sc" from matching as the savefilename.
Rewrite the endswith() exclusions as a single endswith() call using
a tuple.