### PR TITLE
[Profile.py] Support Beyonwiz T3 reduced VFD

### DIFF
--- a/lib/python/Tools/Profile.py
+++ b/lib/python/Tools/Profile.py
@@ -1,5 +1,5 @@
 # the implementation here is a bit crappy.
-from boxbranding import getBoxType
+from boxbranding import getBoxType, getMachineBuild
 import time
 from Directories import resolveFilename, SCOPE_CONFIG
 
@@ -47,6 +47,8 @@ def profile(id):
 		dev_fmt = ("/dev/mcu", "%d  \n")
 	elif box_type == "ebox5000":
 		dev_fmt = ("/proc/progress", "%d"),
+	elif getMachineBuild() in ("inihdp", "inihdx"):
+		dev_fmt = ("/proc/vfd", "Loading %d%%\n")
 	else:
 		dev_fmt = ("/proc/progress", "%d \n")
 	(dev, fmt) = dev_fmt


### PR DESCRIPTION
This changes adds support for the Beyonwiz T3's 11 character VFD.

Removing the space between the boot progress number and the percentage symbol stops the display scrolling when the system pauses during processing.

I think it would look better is all displays eliminated this spurious space.  That is, in my opinion, "Loading 88%" looks better than "Loading 88 %".
