### PR TITLE
Fix crash on zap in RecordTimerEntry when timeshifted

### DIFF
--- a/RecordTimer.py
+++ b/RecordTimer.py
@@ -672,11 +672,7 @@ class RecordTimerEntry(timer.TimerEntry, object):
 			message += _("Timeshift is running. Select an action.\n")
 			choice = [(_("Zap"), "zap"), (_("Don't zap and disable timer"), "disable"), (_("Don't zap and remove timer"), "remove")]
 			if not self.InfoBarInstance.save_timeshift_file:
-				choice.insert(1, (_("Save timeshift in movie dir and zap"), "save_movie"))
-				if self.InfoBarInstance.timeshiftActivated():
-					choice.insert(0, (_("Save timeshift and zap"), "save"))
-				else:
-					choice.insert(1, (_("Save timeshift and zap"), "save"))
+				choice.insert(0, (_("Save timeshift and zap"), "save"))
 			else:
 				message += _("Reminder, you have chosen to save timeshift file.")
 			#if self.justplay or self.always_zap:
@@ -685,17 +681,14 @@ class RecordTimerEntry(timer.TimerEntry, object):
 			def zapAction(choice):
 				start_zap = True
 				if choice:
-					if choice in ("zap", "save", "save_movie"):
+					if choice in ("zap", "save"):
 						self.log(8, "zap to recording service")
-						if choice in ("save", "save_movie"):
+						if choice == "save":
 							ts = self.InfoBarInstance.getTimeshift()
 							if ts and ts.isTimeshiftEnabled():
-								if choice =="save_movie":
-									self.InfoBarInstance.save_timeshift_in_movie_dir = True
-								self.InfoBarInstance.save_timeshift_file = True
-								ts.saveTimeshiftFile()
 								del ts
-								self.InfoBarInstance.saveTimeshiftFiles()
+								self.InfoBarInstance.save_timeshift_file = True
+								self.InfoBarInstance.SaveTimeshift()
 					elif choice == "disable":
 						self.disable()
 						NavigationInstance.instance.RecordTimer.timeChanged(self)

--- a/lib/python/Components/Timeshift.py
+++ b/lib/python/Components/Timeshift.py
@@ -772,6 +772,7 @@ class InfoBarTimeshift:
 				self.save_timeshift_postaction = None
 				errormessage = str(timeshift_saveerror1) + "\n" + str(timeshift_saveerror2)
 				Notifications.AddNotification(MessageBox, _("Timeshift save failed!")+"\n\n%s" % errormessage, MessageBox.TYPE_ERROR)
+		self.save_timeshift_file = False
 		# print 'SAVE COMPLETED'
 
 	def ptsCleanTimeshiftFolder(self):


### PR DESCRIPTION
If a RecordTimerEntry needs to zap to a new service (zap timer,
zap+record timer or to avoid conflicts for a record timer) and
the user is currently timeshifted, the UI crashes.

The problem is due to what looks like an import of code from OpenPLi in
commit f90cfaa.

That import seems to have failed to adapt the code correctly for the
OpenViX and easy-ui-4 (Beyonwiz) images.

In RecordTimerEntry.openChoiceActionBeforeZap(),
self.InfoBarInstance.timeshiftActivated() is called, but
there is no such method in InfoBar (it would be expected to be in
the InfoBarTimeshift mixin if it existed).

In the zapAction() function defined inside
RecordTimerEntry.openChoiceActionBeforeZap(),
self.InfoBarInstance.saveTimeshiftFiles() is called,
which also doesn't exist in InfoBar.

Again in zapAction(), if choice is "save" or "save_movie"
self.InfoBarInstance.save_timeshift_file is set to True,
but it is never reset.

Again in zapAction, if choice is "save" or "save_movie",
self.InfoBarInstance.save_timeshift_in_movie_dir is set to True,
but the mechanism that this is intended to activate doesn't
exist in OpenViX or easy-ui-4.

Replication:

In live TV, initiate viewing timeshifted.

TIMER to open the timer list screen and add a new zap timer for a
few minutes ahead, and return to viewing timeshifted TV.

When the zap timer fires and the "You must switch to the service
... Timeshift is running. Select an action." popup appears, select
"Save timeshift and zap".

UI crashes.

The fix:

Removes the call to self.InfoBarInstance.timeshiftActivated()
and always inserts "Save timeshift and zap" in the first choice slot
if self.InfoBarInstance.save_timeshift_file is False (since
openChoiceActionBeforeZap() is only called when timeshift is being viewed
the test is redundant anyway).

Removes the "Save timeshift in movie dir and zap"/"save_movie" menu choice
and its associated code, since it does nothing in OpenViX or easy-ui-4.

Replaces the code in the "save" choice in zapAction() to use
self.InfoBarInstance.SaveTimeshift() instead of
self.InfoBarInstance.saveTimeshiftFiles().

Resets InfoBarTimeshift.save_timeshift_file in
self.InfoBarInstance.SaveTimeshift().

It's not entirely clear to me what the role of
InfoBarTimeshift.save_timeshift_file is intended to be, and I suspect
that it may not achieve what is intended.