### PR TITLE
Only set a recording start/end mark once for each event

### DIFF
--- a/lib/service/servicedvbrecord.cpp
+++ b/lib/service/servicedvbrecord.cpp
@@ -551,8 +551,12 @@ void eDVBServiceRecord::gotNewEvent(int /*error*/)
 			eDebug("[eDVBServiceRecord] getting PCR failed!");
 		else
 		{
-			m_event_timestamps[event_id] = p;
-			eDebug("[eDVBServiceRecord] pcr of eit change: %llx", p);
+			std::pair<std::map<int, pts_t>::iterator, bool> ret;
+			ret = m_event_timestamps.insert(std::pair<int, pts_t>(event_id, p));
+			if (ret.second)
+				eDebug("[eDVBServiceRecord] pcr of eit change for event %d: %llx", ret.first->first, ret.first->second);
+			else
+				eDebug("[eDVBServiceRecord] pcr of eit change for event %d at %llx already set to: %llx", ret.first->first, p, ret.first->second);
 		}
 	}
 


### PR DESCRIPTION
If a tuner used for recording loses and then regains sync, a call
is made to eDVBServiceRecord::gotNewEvent(), and that will reset
eDVBServiceRecord::m_event_timestamps to the PCR at the time that
tuner sync is regained.

It should not reset the event timestamp for the event.

This problem can happen for tuners operating near the "digital
cliff".

It has also been recorded as happening on some recordings from
Network Ten Australia in Melbourne without the loss of tuner sync.
This manifestation of the problem results in the start/end mark
being late by about 5 minutes. I have a debug log for an instance
of this problem (I'm not in Melbourne), but there's not enough
information in it for me to find the cause of this version of the
problem.

The fix changes the setting of m_event_timestamps from using
map::operation[]() to using map::insert(), so that the first value
set for the event stays in the map if there is an attempt to update
it. The debug output has been changed to indicate cases where there
has been an attempt to change an existing m_event_timestamps entry
for an event.

Replication:

These instructions assume that the firmware has had commit
2573b59 Start / End bookmarks missing on recordings after being
chaseplayed (#163) applied, and the changes described can be most
easily seen if MENU>Setup>User interface >Settings>1st infobar timeout
is set to No timeout.

Start a recording that has enough pre-recording margin to ensure
that the next event's start marker will be in the recording.

Wait until the recording has been running for a few minutes and
start playing in in MoviePlayer.

Then wait until the next event's start marker appears in the infobar
progress bar. When that has happened, wait a few minutes for the
start marker to move a reasonable distance from the right-hand end
of the progress bar.

Then disconnect the antenna and wait ~5 seconds. Re-connect the
antenna and watch the start marker in the progress bar. A short
time after re-connecting the antenna, the start marker will move
to the right-hand end of the progress bar.

The error can also be seen in the debug log. For each antenna
connection/disconnection, there will be an additional "pcr of eit
change for event" message logged as the event's start marker is
moved.