### PR TITLE
Fix "Auto" recording timers sometimes not shutting down

### DIFF
--- a/Navigation.py
+++ b/Navigation.py
@@ -1,7 +1,7 @@
 from time import time
 from os import path
 
-from enigma import eServiceCenter, eServiceReference, eTimer, pNavigation, getBestPlayableServiceReference, iPlayableService, setPreferredTuner
+from enigma import eServiceCenter, eServiceReference, eTimer, pNavigation, getBestPlayableServiceReference, iPlayableService, setPreferredTuner, eDVBLocalTimeHandler
 
 from Components.ParentalControl import parentalControl
 from Components.config import config
@@ -39,27 +39,42 @@ class Navigation:
 		self.RecordTimer = RecordTimer.RecordTimer()
 		self.PowerTimer = PowerTimer.PowerTimer()
 		self.__wasTimerWakeup = False
+		self.__nextRecordTimerAfterEventActionAuto = nextRecordTimerAfterEventActionAuto
+		self.__nextPowerManagerAfterEventActionAuto = nextPowerManagerAfterEventActionAuto
 		if getFPWasTimerWakeup():
 			self.__wasTimerWakeup = True
-			if nextRecordTimerAfterEventActionAuto and abs(self.RecordTimer.getNextRecordingTime() - time()) <= 360:
-				print '[Navigation] RECTIMER: wakeup to standby detected.'
-				f = open("/tmp/was_rectimer_wakeup", "w")
-				f.write('1')
-				f.close()
-				# as we woke the box to record, place the box in standby.
-				self.standbytimer = eTimer()
-				self.standbytimer.callback.append(self.gotostandby)
-				self.standbytimer.start(15000, True)
+			self._processTimerWakeup()
 
-			elif nextPowerManagerAfterEventActionAuto:
-				print '[Navigation] POWERTIMER: wakeup to standby detected.'
-				f = open("/tmp/was_powertimer_wakeup", "w")
-				f.write('1')
-				f.close()
-				# as a PowerTimer WakeToStandby was actiond to it.
-				self.standbytimer = eTimer()
-				self.standbytimer.callback.append(self.gotostandby)
-				self.standbytimer.start(15000, True)
+	def _processTimerWakeup(self):
+		now = time()
+		timeHandlerCallbacks =  eDVBLocalTimeHandler.getInstance().m_timeUpdated.get()
+		if self.__nextRecordTimerAfterEventActionAuto and now < eDVBLocalTimeHandler.timeOK:  # 01.01.2004
+			print '[Navigation] RECTIMER: wakeup to standby but system time not set.'
+			if self._processTimerWakeup not in timeHandlerCallbacks:
+				timeHandlerCallbacks.append(self._processTimerWakeup)
+			return
+		if self._processTimerWakeup in timeHandlerCallbacks:
+			timeHandlerCallbacks.remove(self._processTimerWakeup)
+
+		if self.__nextRecordTimerAfterEventActionAuto and abs(self.RecordTimer.getNextRecordingTime() - now) <= 360:
+			print '[Navigation] RECTIMER: wakeup to standby detected.'
+			f = open("/tmp/was_rectimer_wakeup", "w")
+			f.write('1')
+			f.close()
+			# as we woke the box to record, place the box in standby.
+			self.standbytimer = eTimer()
+			self.standbytimer.callback.append(self.gotostandby)
+			self.standbytimer.start(15000, True)
+
+		elif self.__nextPowerManagerAfterEventActionAuto:
+			print '[Navigation] POWERTIMER: wakeup to standby detected.'
+			f = open("/tmp/was_powertimer_wakeup", "w")
+			f.write('1')
+			f.close()
+			# as a PowerTimer WakeToStandby was actiond to it.
+			self.standbytimer = eTimer()
+			self.standbytimer.callback.append(self.gotostandby)
+			self.standbytimer.start(15000, True)
 
 	def wasTimerWakeup(self):
 		return self.__wasTimerWakeup

--- a/Navigation.py
+++ b/Navigation.py
@@ -191,9 +191,10 @@ class Navigation:
 
 	def recordService(self, ref, simulate=False):
 		service = None
-		if not simulate: print "[Navigation] recording service: %s" % (str(ref))
 		if isinstance(ref, ServiceReference.ServiceReference):
 			ref = ref.ref
+		if not simulate:
+			print "[Navigation] recording service:", (ref and ref.toString())
 		if ref:
 			if ref.flags & eServiceReference.isGroup:
 				ref = getBestPlayableServiceReference(ref, eServiceReference(), simulate)

--- a/lib/dvb/dvbtime.cpp
+++ b/lib/dvb/dvbtime.cpp
@@ -254,7 +254,7 @@ eDVBLocalTimeHandler::eDVBLocalTimeHandler()
 	{
 		res_mgr->connectChannelAdded(sigc::mem_fun(*this,&eDVBLocalTimeHandler::DVBChannelAdded), m_chanAddedConn);
 		time_t now = time(0);
-		if ( now < 1072224000 ) // 01.01.2004
+		if ( now < timeOK ) // 01.01.2004
 			eDebug("[eDVBLocalTimeHandler] RTC not ready... wait for transponder time");
 		else // inform all who's waiting for valid system time..
 		{
@@ -324,7 +324,7 @@ void eDVBLocalTimeHandler::setUseDVBTime(bool b)
 		if (!b)
 		{
 			time_t now = time(0);
-			if (now < 1072224000) /* 01.01.2004 */
+			if (now < timeOK) /* 01.01.2004 */
 			{
 				eDebug("[eDVBLocalTimeHandler] invalid system time, refuse to disable transponder time sync");
 				return;

--- a/lib/dvb/dvbtime.h
+++ b/lib/dvb/dvbtime.h
@@ -101,6 +101,9 @@ public:
 	eDVBLocalTimeHandler();
 	~eDVBLocalTimeHandler();
 #endif
+	// 1.1.2004 - system time can be assumed to be OK if >= timeOK
+	static const time_t timeOK = 1072915200;
+
 	bool getUseDVBTime() { return m_use_dvb_time; }
 	void setUseDVBTime(bool b);
 	void syncDVBTime();


### PR DESCRIPTION
On a PVRs where the RTC resets on shutdown and where "auto" timers
are supported: if there's no Internet available at startup, at the
time when it's being checked whether the startup is for a recording
timer with "auto" set for its "After event" action, the correct
system time is not set, and so the test for that condition fails.

That then means that the system will not go to standby to complete
the recording, and at the end of the recording, the system will not
shut down.

Detailed replication instructions in the commit message for commit 104c651.

Fix:

Detect that the system time has not been correctly set when
```Navigation.__init__()``` is called, and if the time has not been set
correctly, arrange for the code that should be run on a timer wakeup
to be re-run after the system clock has been set.
