### PR TITLE
[ChannelSelection] Use fallback if no network time and not on DVB ser…

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -17,7 +17,7 @@ from Components.Renderer.Picon import getPiconName
 from Screens.TimerEdit import TimerSanityConflict
 profile("ChannelSelection.py 1")
 from EpgSelection import EPGSelection
-from enigma import eActionMap, eServiceReference, eEPGCache, eServiceCenter, eRCInput, eTimer, ePoint, eDVBDB, iPlayableService, iServiceInformation, getPrevAsciiCode, eEnv, loadPNG
+from enigma import eActionMap, eServiceReference, eEPGCache, eServiceCenter, eRCInput, eTimer, ePoint, eDVBDB, iPlayableService, iServiceInformation, getPrevAsciiCode, eEnv, loadPNG, eDVBLocalTimeHandler
 from Components.config import config, configfile, ConfigSubsection, ConfigText, ConfigYesNo
 from Tools.NumericalTextInput import NumericalTextInput
 profile("ChannelSelection.py 2")
@@ -2133,8 +2133,71 @@ class ChannelSelection(ChannelSelectionBase, ChannelSelectionEdit, ChannelSelect
 		else:
 			self.setModeTv()
 		lastservice = eServiceReference(self.lastservice.value)
+		# If the time still needs to be set, try to make the startup service a DVB service
+		if not lastservice.valid() or (lastservice.type != eServiceReference.idDVB and time() < eDVBLocalTimeHandler.timeOK):  # 01.01.2004
+			print "[ChannelSelection] invalid service or time not set and not on a DVB service - try to use fallback DVB service"
+			lastservice, bouquet, rootbouquet = self.findFallbackService()
+			self.forceZap(lastservice, bouquet, rootbouquet)
 		if lastservice.valid():
 			self.zap()
+
+	def findFallbackService(self):
+		mask = ~(eServiceReference.shouldSort | eServiceReference.hasSortKey | eServiceReference.sort1)
+		return self.findServiceBouquet(lambda ref: ref.type == eServiceReference.idDVB and not ref.flags & mask)
+
+	def forceZap(self, service, bouquet, rootbouquet):
+		if service.valid():
+			self.setRoot(bouquet)
+			self.clearPath()
+			self.enterPath(rootbouquet)
+			if config.usage.multibouquet.value:
+				self.enterPath(bouquet)
+			self.saveRoot()
+			self.saveChannel(service)
+			self.addToHistory(service)
+			self.setCurrentSelection(service)
+		return service
+
+	def findServiceBouquet(self, matchFunc):
+
+		def matchService(bouquet, serviceHandler, matchFunc):
+			servicelist = serviceHandler.list(bouquet)
+			if servicelist is not None:
+				serviceIterator = servicelist.getNext()
+				while serviceIterator.valid():
+					if matchFunc(serviceIterator):
+						return eServiceReference(serviceIterator.toString())
+					serviceIterator = servicelist.getNext()
+			return eServiceReference()
+
+		service_types_ref = eServiceReference(service_types_tv)
+		foundService = False
+		serviceHandler = eServiceCenter.getInstance()
+		if config.usage.multibouquet.value:
+			bqroot = eServiceReference(service_types_ref.toString())
+			bqroot.setPath('FROM BOUQUET "bouquets.tv" ORDER BY bouquet')
+			rootbouquet = bqroot
+			currentBouquet = self.getRoot()
+			for searchCurrent in (True, False):
+				bouquet = eServiceReference(rootbouquet.toString())
+				bouquetlist = serviceHandler.list(bouquet)
+				if bouquetlist is not None:
+					bouquet = bouquetlist.getNext()
+					while bouquet.valid():
+						if bouquet.flags & eServiceReference.isDirectory and (currentBouquet is None or (currentBouquet == bouquet) == searchCurrent):
+							foundService = matchService(bouquet, serviceHandler, matchFunc)
+							if foundService.valid():
+								break
+						bouquet = bouquetlist.getNext()
+					if foundService.valid():
+						break
+		else:
+			bqroot = serviceRefAppendPath(service_types_ref, ' FROM BOUQUET "userbouquet.favourites.tv" ORDER BY bouquet')
+			rootbouquet = bqroot
+			bouquet = eServiceReference(bqroot.toString())
+			if bouquet.valid() and bouquet.flags & eServiceReference.isDirectory:
+				foundService = matchService(bouquet, serviceHandler, matchFunc)
+		return foundService, bouquet, rootbouquet
 
 	def channelSelected(self):
 		ref = self.getCurrentSelection()


### PR DESCRIPTION
…vice

If the initial live TV service at startup isn't a DVB service
(more accurately, isn't a service that supports the Time Of Day table)
and the system has no internet connection, the system time will
remain at the system startup default of 00:00:00 1 Jan 1970. An
example of such a non-broadcast service is the HDMI IN service on the
Beyonwiz T4.

This will mean that the displayed time on the PVR will be wrong,
any recordings that are due won't be made, an the default view of
the EPG will be for 1 Jan 1970.

Replication steps

If possible, select a live TV service that is not a DVB broadcast,
disconnect the PVR from the network and reboot.

If that isn't feasible, in the command-line interface:

init 4

Edit /etc/enigma2/settings so that config.tv.lastservice is a valid
service ref, but not a DVB or similar service (i.e. has on Time Of
Day table), e.g. 8192:0:1:0:0:0:0:0:0:0:. For that particular
example, it doesn't matter whether the device supports HDMI in.

Then:

halt

Then disconnect the PVR from the network and restart.

In either case, the time will start from 00:00:00 1 Jan 1970 when
the system restarts, and continue from that time setting until a
valid DVB channel is selected.

Fix:

If at startup config.tv.lastservice is not valid or, if it is valid,
but not a DVB service and the time is < 1 Jan 2004, find the first
valid DVB service in the current bouquet, or if that fails and
config.usage.multibouquet is set, then the first valid DVB service
in any other bouquet.

As well as fixing this bug, the fix will try to find a valid DVB
service if config.tv.lastservice is not valid.

The new methods ChannelSelection::findServiceBouquet() and
ChannelSelection::forceZap() are intended to be able to be called
to replace most of the code in RecordTimer::failureCB(). They may also
be able to be adapted to replace most of the code involved in
zapping by channel number (and the channel panic button action).