### PR TITLE
Remove LD_PRELOAD shell environment variable

### DIFF
--- a/mytest.py
+++ b/mytest.py
@@ -2,6 +2,14 @@ import sys
 import os
 from time import time
 
+# LD_PRELOAD is set when we start-up, but we don't want to pass it on
+# to sub-processes
+#
+try:
+	del os.environ["LD_PRELOAD"]
+except:
+	pass
+
 if os.path.isfile("/usr/lib/enigma2/python/enigma.zip"):
 	sys.path.append("/usr/lib/enigma2/python/enigma.zip")
 


### PR DESCRIPTION
This change removes the LD_PRELOAD shell environment variable from any subsequent shells launched by Enigma2.  This allows shells and programs run from those shells to create pipes and pass file handles between processes.
