### PR TITLE
Fix crash in "Skip forward/back (min)" on empty skip field

### DIFF
--- a/lib/python/Screens/MinuteInput.py
+++ b/lib/python/Screens/MinuteInput.py
@@ -1,6 +1,7 @@
 from Screens.Screen import Screen
 from Components.ActionMap import NumberActionMap
 from Components.Input import Input
+from Screens.MessageBox import MessageBox
 
 class MinuteInput(Screen):
 	def __init__(self, session, basemins = 5):
@@ -61,7 +62,11 @@ class MinuteInput(Screen):
 		self["minutes"].down()
 
 	def ok(self):
-		self.close(int(self["minutes"].getText()))
+		try:
+			self.close(int(self["minutes"].getText()))
+		except:
+			self.session.open(MessageBox, _("Incorrect format for skip value: '%s'\nSkip cancelled.") % self["minutes"].getText(), MessageBox.TYPE_WARNING, timeout=5)
+			self.cancel()
 
 	def cancel(self):
 		self.close(0)


### PR DESCRIPTION
If long-FF/long-REW are used to skip forward or back a number of
minutes in timeshift or a recording and OK is pressed when the
number entry field is empty, then the UI crashes.

The cause is an exception when int() is used to convert an empty
string.

Replication steps

Enter the media player (MEDIA from live TV).

Navigate to a recording, press OK to start play.

Then press long-FF to open the "Skip forward (min)" popup, then
PREV to clear the number entry field. Then press OK: crash.

Fix

Catch the exception in MinuteInput.ok(), show a warning popup and
cancel the skip.