### PR TITLE
[MovieInfo.py] Add FullDescription option

### DIFF
--- a/lib/python/Components/Converter/MovieInfo.py
+++ b/lib/python/Components/Converter/MovieInfo.py
@@ -4,26 +4,61 @@ from enigma import iServiceInformation, eServiceReference
 from ServiceReference import ServiceReference
 
 class MovieInfo(Converter, object):
-	MOVIE_SHORT_DESCRIPTION = 0 # meta description when available.. when not .eit short description
-	MOVIE_META_DESCRIPTION = 1 # just meta description when available
-	MOVIE_REC_SERVICE_NAME = 2 # name of recording service
-	MOVIE_REC_SERVICE_REF = 3 # referance of recording service
-	MOVIE_REC_FILESIZE = 4 # filesize of recording
+	MOVIE_SHORT_DESCRIPTION = 0  # meta description when available.. when not .eit short description
+	MOVIE_META_DESCRIPTION = 1  # just meta description when available
+	MOVIE_REC_SERVICE_NAME = 2  # name of recording service
+	MOVIE_REC_SERVICE_REF = 3  # referance of recording service
+	MOVIE_REC_FILESIZE = 4  # filesize of recording
+	MOVIE_FULL_DESCRIPTION = 5  # combination of short and long description when available
+
+	KEYWORDS = {
+		# Arguments...
+		"FileSize": ("type", MOVIE_REC_FILESIZE),
+		"FullDescription": ("type", MOVIE_FULL_DESCRIPTION),
+		"MetaDescription": ("type", MOVIE_META_DESCRIPTION),
+		"RecordServiceName": ("type", MOVIE_REC_SERVICE_NAME),
+		"RecordServiceRef": ("type", MOVIE_REC_SERVICE_REF),
+		"ShortDescription": ("type", MOVIE_SHORT_DESCRIPTION),
+		# Options...
+		"Separated": ("separator", "\n\n"),
+		"NotSeparated": ("separator", "\n"),
+		"Trimmed": ("trim", True),
+		"NotTrimmed": ("trim", False)
+	}
 
 	def __init__(self, type):
-		if type == "ShortDescription":
-			self.type = self.MOVIE_SHORT_DESCRIPTION
-		elif type == "MetaDescription":
-			self.type = self.MOVIE_META_DESCRIPTION
-		elif type == "RecordServiceName":
-			self.type = self.MOVIE_REC_SERVICE_NAME
-		elif type == "FileSize":
-			self.type = self.MOVIE_REC_FILESIZE
-		elif type == "RecordServiceRef":
-			self.type = self.MOVIE_REC_SERVICE_REF
-		else:
-			raise ElementError("'%s' is not <ShortDescription|MetaDescription|RecordServiceName|FileSize> for MovieInfo converter" % type)
+		self.type = None
+		self.separator = "\n"
+		self.trim = False
+
+		parse = ","
+		type.replace(";", parse)  # Some builds use ";" as a separator, most use ",".
+		args = [arg.strip() for arg in type.split(parse)]
+		for arg in args:
+			name, value = self.KEYWORDS.get(arg, ("Error", None))
+			if name == "Error":
+				print "[MovieInfo] ERROR: Unexpected / Invalid argument token '%s'!" % arg
+			else:
+				setattr(self, name, value)
+		if ((name == "Error") or (type is None)):
+			print "[MovieInfo] Valid arguments are: ShortDescription|MetaDescription|FullDescription|RecordServiceName|RecordServiceRef|FileSize."
+			print "[MovieInfo] Valid options for descriptions are: Separated|NotSeparated|Trimmed|NotTrimmed."
 		Converter.__init__(self, type)
+
+	def trimText(self, text):
+		if self.trim:
+			return str(text).strip()
+		else:
+			return str(text)
+
+	def formatDescription(self, description, extended):
+		description = self.trimText(description)
+		extended = self.trimText(extended)
+		if description[0:20] == extended[0:20]:
+			return extended
+		if description and extended:
+			description += self.separator
+		return description + extended
 
 	@cached
 	def getText(self):
@@ -35,13 +70,23 @@ class MovieInfo(Converter, object):
 				if (service.flags & eServiceReference.flagDirectory) == eServiceReference.flagDirectory:
 					# Short description for Directory is the full path
 					return service.getPath()
-				return (info.getInfoString(service, iServiceInformation.sDescription)
-				    or (event and event.getShortDescription())
-				    or service.getPath())
+				return (
+					info.getInfoString(service, iServiceInformation.sDescription)
+					or (event and self.trimText(event.getShortDescription()))
+					or service.getPath()
+				)
 			elif self.type == self.MOVIE_META_DESCRIPTION:
-				return ((event and (event.getExtendedDescription() or event.getShortDescription()))
-				    or info.getInfoString(service, iServiceInformation.sDescription)
-				    or service.getPath())
+				return (
+					(event and (self.trimText(event.getExtendedDescription()) or self.trimText(event.getShortDescription())))
+					or info.getInfoString(service, iServiceInformation.sDescription)
+					or service.getPath()
+				)
+			elif self.type == self.MOVIE_FULL_DESCRIPTION:
+				return (
+					(event and self.formatDescription(event.getShortDescription(), event.getExtendedDescription()))
+					or info.getInfoString(service, iServiceInformation.sDescription)
+					or service.getPath()
+				)
 			elif self.type == self.MOVIE_REC_SERVICE_NAME:
 				rec_ref_str = info.getInfoString(service, iServiceInformation.sServiceref)
 				return ServiceReference(rec_ref_str).getServiceName()


### PR DESCRIPTION
This change adds the FullDescription option for descriptions obtained from the EPG. The code has been refactored to allow for options in the presentation of the data. ([Not]Separated and [Not]Trimmed)

This change is based on similar changes made to the EventName converter a long time ago.
