### PR TITLE
NTPserverChanged() fixes:

### DIFF
--- a/mytest.py
+++ b/mytest.py
@@ -100,8 +100,6 @@ def useSyncUsingChanged(configelement):
 config.misc.SyncTimeUsing.addNotifier(useSyncUsingChanged)
 
 def NTPserverChanged(configelement):
-	if configelement.value == "pool.ntp.org":
-		return
 	f = open("/etc/default/ntpdate", "w")
 	f.write('NTPSERVERS="' + configelement.value + '"\n')
 	f.close()
@@ -109,7 +107,8 @@ def NTPserverChanged(configelement):
 	from Components.Console import Console
 	Console = Console()
 	Console.ePopen('/usr/bin/ntpdate-sync')
-config.misc.NTPserver.addNotifier(NTPserverChanged, immediate_feedback = True)
+config.misc.NTPserver.addNotifier(NTPserverChanged, immediate_feedback = False)
+config.misc.NTPserver.callNotifiersOnSaveAndCancel = True
 
 profile("Twisted")
 try:


### PR DESCRIPTION
   DON'T call  for *every* keystroke in setting new value.
   DON'T skip the `/etc/default/ntpdate` update for (re)setting "pool.ntp.org".
   DO ensure it is called on Save *and* Cancel.