### PR TITLE
Refactor NetworkPassword class

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -210,6 +210,9 @@
 		<item text="Nameserver" description="Configure the nameserver (DNS).">config.network.dns</item>
 		<item text="Activate network settings" description="Activate the configured network settings.">config.network.activate</item>
 	</setup>
+	<setup key="networkpassword" title="Network password" titleshort="Settings">
+		<item text="New password" description="You should set a root password to secure network services such as FTP, telnet or ssh. The password can be blank but this is NOT recommended, particularly if the device is open to the Internet.\nPress YELLOW to select a random password.">config.network.password</item>
+	</setup>
 	<setup key="RFmod" title="RF output settings" titleshort="Settings">
 		<item level="1" text="Modulator">config.rfmod.enable</item>
 		<item level="2" text="Test mode">config.rfmod.test</item>

--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -27,6 +27,7 @@ from Screens.Screen import Screen
 from Screens.MessageBox import MessageBox
 from Screens.Standby import TryQuitMainloop
 from Screens.HelpMenu import HelpableScreen
+from Screens.Setup import Setup
 from Screens.VirtualKeyBoard import VirtualKeyBoard
 from Tools.Directories import fileExists, resolveFilename, SCOPE_PLUGINS, SCOPE_ACTIVE_SKIN
 from Tools.LoadPixmap import LoadPixmap
@@ -3591,91 +3592,61 @@ class NetworkServicesSummary(Screen):
 		self["autostartstatus_summary"].text = autostartstatus_summary
 
 
-class NetworkPassword(Screen):
-	def __init__(self, session, menu_path = ""):
-		Screen.__init__(self, session)
-		screentitle = _("Password setup")
-		if config.usage.show_menupath.value == 'large':
-			menu_path += screentitle
-			title = menu_path
-			self["menu_path_compressed"] = StaticText("")
-		elif config.usage.show_menupath.value == 'small':
-			title = screentitle
-			self["menu_path_compressed"] = StaticText(menu_path + " >" if not menu_path.endswith(' / ') else menu_path[:-3] + " >" or "")
-		else:
-			title = screentitle
-			self["menu_path_compressed"] = StaticText("")
-		Screen.setTitle(self, title)
-		self.skinName = "NetworkSetPassword"
+class NetworkPassword(Setup):
+	def __init__(self, session, menu_path=None, PluginLanguageDomain=None):
+		config.network.password = NoSave(ConfigPassword(default=""))
+		Setup.__init__(self, session=session, setup="networkpassword", plugin=None, menu_path=menu_path, PluginLanguageDomain=PluginLanguageDomain)
+		self.skinName = ["NetworkPassword", "Setup"]
+		self.setup_title = _("Network password")
 
-		self.user = "root"
-		self.list = []
-		self["passwd"] = ConfigList(self.list)
-		self["key_red"] = StaticText(_("Delete Password"))
-		self["key_green"] = StaticText(_("Set Password"))
-		self["key_yellow"] = StaticText(_("New Random Password"))
-		self["key_blue"] = StaticText(_("Keyboard"))
+		self["key_yellow"] = StaticText(_("Random password"))
 
-		self["actions"] = ActionMap(["OkCancelActions", "ColorActions"],
-				{
-						"red": self.DelPasswd,
-						"green": self.SetPasswd,
-						"yellow": self.newRandom,
-						"blue": self.bluePressed,
-						"cancel": self.close
-				}, -1)
-	
-		self.buildList(self.GeneratePassword())
+		self["password_actions"] = ActionMap(["ColorActions"], {
+			"yellow": self.newRandom
+		})
+
+		self.user="root"
+		self.output_line = ""
 
 	def newRandom(self):
-		self.buildList(self.GeneratePassword())
+		config.network.password.value = self.GeneratePassword()
+		self["config"].invalidateCurrent()
 	
-	def buildList(self, password):
-		self.password=password
-		self.list = []
-		self.list.append(getConfigListEntry(_('Enter a new password'), ConfigText(default = self.password, fixed_size = False)))
-		self["passwd"].setList(self.list)
-		
 	def GeneratePassword(self): 
 		passwdChars = string.letters + string.digits
 		passwdLength = 10
 		return ''.join(Random().sample(passwdChars, passwdLength)) 
 
-	def SetPasswd(self):
+	def keySave(self):
+		password = config.network.password.value
+		# print "[NetworkPassword] Changing the password for '%s' to '%s'." % (self.user, password) 
 		self.container = eConsoleAppContainer()
 		self.container.appClosed.append(self.runFinished)
 		self.container.dataAvail.append(self.dataAvail)
-		retval = self.container.execute("passwd %s" % self.user)
-		if retval == 0:
-			message = _("Sucessfully changed the password for the root user to ") + self.password
+		retval = self.container.execute("echo -e '%s\n%s' | (passwd %s)"  % (password, password, self.user))
+		if retval:
+			message = _("Unable to change password!")
+			self.session.open(MessageBox, message, MessageBox.TYPE_ERROR)
 		else:
-			message = _("Unable to change/reset the password for the root user")
-		self.session.open(MessageBox, message , MessageBox.TYPE_INFO)
+			message = _("Password changed.")
+			self.session.open(MessageBox, message, MessageBox.TYPE_INFO, timeout=5)
+			Setup.keySave(self)
 
-	def DelPasswd(self):
-		self.container = eConsoleAppContainer()
-		self.container.appClosed.append(self.runFinished)
-		self.container.dataAvail.append(self.dataAvail)
-		retval = self.container.execute("passwd --delete %s" % self.user)
-		if retval == 0:
-			message = _("Password deleted sucessfully for the root user")
-		else:
-			message = _("Unable to delete the password for the root user")
-		self.session.open(MessageBox, message , MessageBox.TYPE_INFO)
-
-	def dataAvail(self, data):
-		if data.find('password'):
-			self.container.write("%s\n" % self.password)
-
-	def runFinished(self,retval):
+	def runFinished(self, retval):
 		del self.container.dataAvail[:]
 		del self.container.appClosed[:]
 		del self.container
 		self.close()
-		
-	def bluePressed(self):
-		self.session.openWithCallback(self.VirtualKeyBoardTextEntry, VirtualKeyBoard, title = (_("Enter your password here:")), text = self.password)
-	
-	def VirtualKeyBoardTextEntry(self, callback = None):
-		if callback is not None and len(callback):
-			self.buildList(callback)
+
+	def dataAvail(self, data):
+		self.output_line += data
+		while True:
+			i = self.output_line.find("\n")
+			if i == -1:
+				break
+			self.processOutputLine(self.output_line[:i+1])
+			self.output_line = self.output_line[i+1:]
+
+	def processOutputLine(self, line):
+		if line.find('password: '):
+			self.container.write("%s\n" % config.network.password.value)


### PR DESCRIPTION
- [NetworkSetup.py] Refactor NetworkPassword class

  This change makes NetworkPassword use the existing Setup class rather than duplicating some of the code from within the Setup class.  The configuration list is now stored in the setup.xml file like all other standardised Setup screens.

  The new code uses the standard Setup way of showing the text-style keyboard as well as the TEXT button to bring up the virtual keyboard to enter the password. This new code still offers access to the YELLOW button to select a random password but because the new code uses the standard Setup code this button will not be shown on skins that do not have a Setup screen that supports the display of all four colour buttons.

  If the current skin does not support the four colour buttons then a new screen named "NetworkPassword" can be created to display the complete screen. The "NetworkPassword" screen should have all the elements of a standard "Setup" screen but should also include the YELLOW button. The "NetworkPassword" screen can also be used by skin authors who would like this screen to be differentiated from the standard "Setup" screen.

  The old screen 'NetworkSetPassword' is no longer being used and can be deleted from the skins.

  NOTE: I recommend that all skins should be updated to support the new button proposals in /doc/BUTTONGUIDE.  This will allow more efficient skin development and usage moving forward.

  Users should be reminded that while blank passwords can be used for the network password they are VERY INSECURE and are NOT recommended for devices connected to the Internet (i.e. if a port is forwarded to the box).

- [setup.xml] Add NetworkPassword setup option

  This setup option is used by the refactored NetworkPassword class in the NetworkSetup.py screen code.
