### PR TITLE
Remove use of non-existent self variable.

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -15,6 +15,8 @@ from Tools.BoundFunction import boundFunction
 from Components.About import about
 from config import config, ConfigSubsection, ConfigSelection, ConfigFloat, ConfigSatlist, ConfigYesNo, ConfigInteger, ConfigSubList, ConfigNothing, ConfigSubDict, ConfigOnOff, ConfigDateTime, ConfigText
 
+import NavigationInstance
+
 config.unicable = ConfigSubsection()
 
 def getConfigSatlist(orbpos, satlist):
@@ -1522,8 +1524,9 @@ def InitNimManager(nimmgr, update_slots = []):
 		try:
 			raw_channel = eDVBResourceManager.getInstance().allocateRawChannel(fe_id)
 			if raw_channel is None:
-				self.session.nav.stopService()
-				raw_channel = eDVBResourceManager.getInstance().allocateRawChannel(fe_id)
+				if NavigationInstance.instance:
+					NavigationInstance.instance.stopService()
+					raw_channel = eDVBResourceManager.getInstance().allocateRawChannel(fe_id)
 				if raw_channel is None:
 					print "[InitNimManager] %d: tunerTypeChanged to '%s' failed (BUSY)" %(fe_id, configElement.getText())
 					return


### PR DESCRIPTION
This produced errors:
<    25.307> [InitNimManager] tunerTypeChanged error:  global name 'self' is not defined

[you'll now get "tunerTypeChanged to 'DVB-T2' failed (BUSY)" instead, if "another linked frontend is in use.. so allocateFrontendByIndex not possible!"
but at least not an error about a non-existent variable]