### PR TITLE
Add a justLoad option to loadTimer() (passed on to record()) to disab…

### DIFF
--- a/RecordTimer.py
+++ b/RecordTimer.py
@@ -997,7 +997,9 @@ class RecordTimer(timer.Timer):
 				return True
 		return False
 
-	def loadTimer(self):
+# justLoad is passed on to record()
+#
+	def loadTimer(self, justLoad=False):
 		try:
 			file = open(self.Filename, 'r')
 			doc = xml.etree.cElementTree.parse(file)
@@ -1025,7 +1027,7 @@ class RecordTimer(timer.Timer):
 		timer_text = ""
 		for timer in root.findall("timer"):
 			newTimer = createTimer(timer)
-			conflict_list = self.record(newTimer, ignoreTSC=True, dosave=False, loadtimer=True)
+			conflict_list = self.record(newTimer, ignoreTSC=True, dosave=False, loadtimer=True, justLoad=justLoad)
 			if conflict_list:
 				checkit = True
 				if newTimer in conflict_list:
@@ -1154,9 +1156,16 @@ class RecordTimer(timer.Timer):
 				return True
 		return False
 
-	def record(self, entry, ignoreTSC=False, dosave=True, loadtimer=False):
+# If justLoad is True then we (temporarily) turn off conflict detection
+# as we load.  On a restore we may not have the correct tuner
+# configuration (and no USB tuners)...
+#
+	def record(self, entry, ignoreTSC=False, dosave=True, loadtimer=False, justLoad=False):
+		real_cd = entry.conflict_detection
+		if justLoad:
+			entry.conflict_detection = False
 		check_timer_list = self.timer_list[:]
-		timersanitycheck = TimerSanityCheck(check_timer_list,entry)
+		timersanitycheck = TimerSanityCheck(check_timer_list, entry)
 		answer = None
 		if not timersanitycheck.check():
 			if not ignoreTSC:
@@ -1175,6 +1184,7 @@ class RecordTimer(timer.Timer):
 		elif timersanitycheck.doubleCheck():
 			print "[RecordTimer] ignore double timer..."
 			return None
+		entry.conflict_detection = real_cd
 		entry.timeChanged()
 		print "[Timer] Record " + str(entry)
 		entry.Timer = self


### PR DESCRIPTION
…le conflict testing on loading. Needed when loading an initial backup, as the tuner configuration isn't necessarily correct then.