### PR TITLE
Add possibility to run a Script when Entering/Leaving Standby

### DIFF
--- a/lib/python/Screens/Standby.py
+++ b/lib/python/Screens/Standby.py
@@ -1,6 +1,8 @@
+import os
 from Screens.Screen import Screen
 from Components.ActionMap import ActionMap
 from Components.config import config
+from Components.Console import Console
 from Components.AVSwitch import AVSwitch
 from Components.SystemInfo import SystemInfo
 from Components.Sources.StaticText import StaticText
@@ -25,6 +27,9 @@ def setLCDMiniTVMode(value):
 class Standby2(Screen):
 	def Power(self):
 		print "[Standby] leave standby"
+		#Run Custom Script on standby
+		if os.path.exists("/usr/scripts/StandbyLeave.sh"):
+			Console().ePopen("/usr/scripts/StandbyLeave.sh &")
 		#set input to encoder
 		self.avswitch.setInput("ENCODER")
 		#restart last played service
@@ -51,6 +56,10 @@ class Standby2(Screen):
 		self.avswitch = AVSwitch()
 
 		print "[Standby] enter standby"
+		
+		# Run custom script when entering standby
+        	if os.path.exists('/usr/script/StandbyEnter.sh'):
+            		Console().ePopen('/usr/script/StandbyEnter.sh &')
 
 		self["actions"] = ActionMap( [ "StandbyActions" ],
 		{


### PR DESCRIPTION

Scripts must be located under /usr/scripts and Scripts must have permissions to execute (chmod 755).

/usr/scripts/StandbyLeave.sh (Script is used, when leaving Standby)
/usr/scripts/StandbyEnter.sh (Script is used, when entering Standby)

OpenATV Commit https://github.com/openatv/enigma2/commit/f8f20c86f73748ee30564fcb8df66739990b3d26#diff-540acf08816e2c9c140f420d5390a0c1

Commit to using Standby - use Console().ePopen instead of os.system https://github.com/openatv/enigma2/commit/1e54b1be4e2f526fc9b84678a42deaee18fef486#diff-540acf08816e2c9c140f420d5390a0c1