### PR TITLE
[Setup.py] Improve getSetupTitle

### DIFF
--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -33,12 +33,6 @@ def getConfigMenuItem(configElement):
 			return _(item.attrib["text"]), eval(configElement)
 	return "", None
 
-class SetupError(Exception):
-	def __init__(self, message):
-		self.msg = message
-
-	def __str__(self):
-		return self.msg
 
 class SetupSummary(Screen):
 	def __init__(self, session, parent):
@@ -224,10 +218,14 @@ class Setup(ConfigListScreen, Screen):
 
 def getSetupTitle(id):
 	xmldata = setupdom().getroot()
+	id = str(id)
+	title = ""
 	for x in xmldata.findall("setup"):
 		if x.get("key") == id:
-			if x.get("titleshort", "").encode("UTF-8") != "":
-				return _(x.get("titleshort", "").encode("UTF-8"))
-			else:
-				return _(x.get("title", "").encode("UTF-8"))
-	raise SetupError("unknown setup id '%s'!" % repr(id))
+			title = x.get("titleshort", "").encode("UTF-8")
+			if title == "":
+				title = x.get("title", "Settings").encode("UTF-8")
+	if title == "":
+		print "[Setup] Error: Setup ID '%s' not found in setup file!" % id
+		title = "** Setup error: '%s' section not found! **" % id
+	return _(title)


### PR DESCRIPTION
This change eliminates the forced crash if a setup menu id is not found in the setup.xml file.  This sort of error should be identified during development and not reach production code.  Forcing a crash is unnecessary and anti-social.  The crash could have nasty side effects like stopping running recordings.  Instead of the crash an error condition is logged and the user is provided with a dummy menu item indicating that this menu item is unavailable.  The error contains the ID tag so that the issue can be reported to developers for correction.

Blank "title=" attributes now have a default value of "Settings" to stop blank titles being fed into the translation system.

To test the change edit setup.xml and change the "key=" attribute for an item in a Setup based menu.  Before the code change loading the menu containing this menu item will force a crash of the GUI.  After the code change an error will be logged and the menu will be displayed but the menu item that can't be found will be shown as an error message.  (It is not fatal to select this menu item.  If selected a blank Setup screen will be shown.)
