### PR TITLE
Fix pixmap renderer not cleared on CHANGED_CLEAR

### DIFF
--- a/lib/python/Components/Renderer/Pixmap.py
+++ b/lib/python/Components/Renderer/Pixmap.py
@@ -16,4 +16,6 @@ class Pixmap(Renderer):
 			if self.source and hasattr(self.source, "pixmap"):
 				if self.instance:
 					self.instance.setPixmap(self.source.pixmap)
+		elif self.instance:
+			self.instance.setPixmap(None)
 


### PR DESCRIPTION
Clear the pixmap displayed in Components.Renderer.Pixmap when changed()
receives a CHANGED_CLEAR.

CHANGED_CLEAR is issued upstream in sources like Event and EventInfo
when no event can be found, and so this change clears the displayed
pixmap when no pixmap can be found because no upstream event has
been found.

Previously CHANGED_CLEAR was ignored.