### PR TITLE
[ValueToPixmap] Fix potential crash

### DIFF
--- a/lib/python/Components/Converter/ValueToPixmap.py
+++ b/lib/python/Components/Converter/ValueToPixmap.py
@@ -23,13 +23,13 @@ class ValueToPixmap(Converter, object):
 			val = self.source.text
 			if val in (None, ""):
 				return None
-		if self.type == self.PATH:
-			return LoadPixmap(val)
-		if self.type == self.LANGUAGE_CODE:
-			png = LoadPixmap(cached=True, path=resolveFilename(SCOPE_ACTIVE_SKIN, "countries/" + val[3:].lower() + ".png"))
-			if png is None:
-				png = LoadPixmap(cached=True, path=resolveFilename(SCOPE_SKIN_IMAGE, "countries/missing.png"))
-			return png
+			if self.type == self.PATH:
+				return LoadPixmap(val)
+			if self.type == self.LANGUAGE_CODE:
+				png = LoadPixmap(cached=True, path=resolveFilename(SCOPE_ACTIVE_SKIN, "countries/" + val[3:].lower() + ".png"))
+				if png is None:
+					png = LoadPixmap(cached=True, path=resolveFilename(SCOPE_SKIN_IMAGE, "countries/missing.png"))
+				return png
 		return None
 
 	pixmap = property(getPixmap)


### PR DESCRIPTION
Components.Converter.ValueToPixmap.getPixmap() tests whether
self.source is valid, but if it's not, it continues on to use
an undefined variable (val).

Change the code so that None is returned if self.source is not valid.