### PR TITLE
[skin.py] Stop (Fix) file handle leak

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -52,8 +52,7 @@ def addSkin(name, scope = SCOPE_SKIN):
 	if fileExists(filename):
 		mpath = os.path.dirname(filename) + "/"
 		try:
-			file = open(filename, 'r')
-			dom_skins.append((mpath, xml.etree.cElementTree.parse(file).getroot()))
+			dom_skins.append((mpath, xml.etree.cElementTree.parse(filename).getroot()))
 		except:
 			print "[Skin] error in %s" % filename
 			return False


### PR DESCRIPTION
Use the file name rather than file handle version of the xml.etree.cElementTree.parse() call.  This eliminates the need for the file open() call which has no matching close()  method call.

This change also brings the code into alignment with OpenPLi and Beyonwiz.
