### PR TITLE
[config.py] Tweak AttributeError message

### DIFF
--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -1889,7 +1889,7 @@ class ConfigSubsection(object):
 	def __getattr__(self, name):
 		if name in self.content.items:
 			return self.content.items[name]
-		raise AttributeError("Error: Attribute not defined!")
+		raise AttributeError(name)
 
 	def getSavedValue(self):
 		res = self.content.stored_values


### PR DESCRIPTION
Make the AttributeException a more conventional format and include the offending attribute name if the exception is not caught.
