### PR TITLE
multiboot add base code and reboot to any multiboot image

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -244,6 +244,7 @@ self.session.open(HdmiCECSetupScreen)
 			<item text="Standby" entryID="standby"><screen module="Standby" screen="Standby"/></item>
 			<item text="Restart GUI" entryID="restart_enigma"><screen module="Standby" screen="TryQuitMainloop">3</screen></item>
 			<item text="Reboot" entryID="restart"><screen module="Standby" screen="TryQuitMainloop">2</screen></item>
+			<item text="Multiboot" entryID="multiboot" requires="canMultiBoot"><screen module="Multiboot" screen="MultiBoot">1</screen></item>
 			<item text="Deep standby" requires="DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
 			<item text="Shut down" requires="!DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
 		</menu>

--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -74,3 +74,5 @@ SystemInfo["HasHDMIin"] = getMachineBuild() in ('inihdp', 'hd2400', 'et10000', '
 SystemInfo["HasHDMI-CEC"] = fileExists("/usr/lib/enigma2/python/Plugins/SystemPlugins/HdmiCEC/plugin.pyo")
 SystemInfo["HasInfoButton"] = getBrandOEM() in ('broadmedia', 'ceryon', 'dags', 'formuler', 'gfutures', 'gigablue', 'ini', 'octagon', 'odin', 'skylake', 'tiviar', 'xcore', 'xp', 'xtrend')
 SystemInfo["Has24hz"] = fileCheck("/proc/stb/video/videomode_24hz")
+SystemInfo["canMultiBoot"] = getMachineBuild() in ('hd51') and (1, 4) or getBoxType() in ('gbue4k', 'gbquad4k') and (3, 3)
+SystemInfo["canMode12"] = getMachineBuild() in ('hd51') and ('440M@328M brcm_cma=192M@768M', '520M@248M brcm_cma=200M@768M')

--- a/lib/python/Screens/Multiboot.py
+++ b/lib/python/Screens/Multiboot.py
@@ -1,0 +1,119 @@
+from Screens.Screen import Screen
+from Screens.Standby import TryQuitMainloop
+from Screens.MessageBox import MessageBox
+from boxbranding import getMachineBuild
+from Components.Sources.StaticText import StaticText
+from Components.ActionMap import ActionMap
+from Components.Label import Label
+from Components.SystemInfo import SystemInfo
+from Tools.Multiboot import GetImagelist, GetCurrentImage, WriteStartup
+
+class MultiBoot(Screen):
+
+	skin = """
+	<screen name="MultiBoot" position="center,center" size="500,200"  flags="wfNoBorder" title="ReBootGB" backgroundColor="transparent">
+		<eLabel name="b" position="0,0" size="500,200" backgroundColor="#00ffffff" zPosition="-2" />
+		<eLabel name="a" position="1,1" size="498,198" backgroundColor="#00000000" zPosition="-1" />
+		<widget source="Title" render="Label" position="10,10" foregroundColor="#00ffffff" size="480,50" halign="center" font="Regular; 28" backgroundColor="#00000000" />
+		<eLabel name="line" position="1,60" size="498,1" backgroundColor="#00ffffff" zPosition="1" />
+		<widget source="config" render="Label" position="2,70" size="480,60" halign="center" font="Regular; 22" backgroundColor="#00000000" foregroundColor="#00ffffff" />
+		<widget source="key_red" render="Label" position="35,162" size="75,30" noWrap="1" zPosition="1" valign="center" font="Regular; 20" halign="left" backgroundColor="#00000000" foregroundColor="#00ffffff" />
+		<widget source="key_green" render="Label" position="150,162" size="75,30" noWrap="1" zPosition="1" valign="center" font="Regular; 20" halign="left" backgroundColor="#00000000" foregroundColor="#00ffffff" />
+		<widget source="key_yellow" render="Label" position="250,162" size="150,30" noWrap="1" zPosition="1" valign="center" font="Regular; 20" halign="left" backgroundColor="#00000000" foregroundColor="#00ffffff" />
+		<eLabel position="25,159" size="6,40" backgroundColor="#00e61700" />
+		<eLabel position="125,159" size="6,40" backgroundColor="#0061e500" />
+		<eLabel position="225,159" size="6,40" backgroundColor="#00e5b243" />
+	</screen>
+	"""
+
+	def __init__(self, session, *args):
+		Screen.__init__(self, session)
+		self["key_red"] = StaticText(_("Cancel"))
+		self["key_green"] = StaticText(_("ReBoot"))
+		self["config"] = StaticText(_("Select Image: STARTUP_1"))
+		self.STARTUPslot = 0
+		self.images = []
+		self.mode = 0
+		self.boxmode = 1
+		self.STARTUPslot = GetCurrentImage()
+		self.getImageList = None
+		self.selection = 0
+		self.slotno = SystemInfo["canMultiBoot"][1]
+		self.startit()
+
+		if not SystemInfo["canMode12"]:
+			self["actions"] = ActionMap(["WizardActions", "SetupActions", "ColorActions"],
+			{
+				"left": self.left,
+				"right": self.right,
+				"red": self.cancel,
+				"green": self.reboot,
+				"cancel": self.cancel,
+				"ok": self.reboot,
+			}, -2)
+		else:
+			self["key_yellow"] = StaticText(_("ReBoot_mode12"))
+			self["actions"] = ActionMap(["WizardActions", "SetupActions", "ColorActions"],
+			{
+				"left": self.left,
+				"right": self.right,
+				"red": self.cancel,
+				"green": self.reboot,
+				"yellow": self.reboot12,
+				"cancel": self.cancel,
+				"ok": self.reboot,
+			}, -2)
+		self.onLayoutFinish.append(self.layoutFinished)
+
+	def layoutFinished(self):
+		self.setTitle(self.title)
+
+	def startit(self):
+		self.getImageList = GetImagelist(self.startup0)
+
+	def startup0(self, imagedict):
+		self.images = imagedict
+		self.title = "Current Image: STARTUP_" + str(GetCurrentImage())
+		self.startup()
+
+	def startup(self):
+		self.slot = self.selection + 1
+#		print "Multiboot OldImage %s NewFlash %s FlashType %s" % (self.STARTUPslot, self.selection, x)
+		if self.images[self.slot]['imagename'] != _("Empty slot"):
+			self["config"].setText(_("Reboot Image: STARTUP_%s: %s\n Use < > keys to select Image and Reboot.") %(self.slot, self.images[self.slot]['imagename']))
+		else:
+			self.right()
+
+
+	def cancel(self):
+		self.close()
+
+	def left(self):
+		self.selection = self.selection - 1
+		if self.selection == -1:
+			self.selection = self.slotno - 1
+		self.startup()
+
+	def right(self):
+		self.selection = self.selection + 1
+		if self.selection == self.slotno:
+			self.selection = 0
+		self.startup()
+
+	def reboot(self):
+				slot = self.slot
+				model = getMachineBuild()
+				if SystemInfo["canMultiBoot"] and 'coherent_poll=2M' in open("/proc/cmdline", "r").read():
+					WriteStartup(self.slot, self.ReExit)
+				else: 
+					startupFileContents = "boot emmcflash0.kernel%s 'brcm_cma=%s root=/dev/mmcblk0p%s rw rootwait %s_4.boxmode=%s'\n" % (slot, SystemInfo["canMode12"][self.mode], slot * 2 + SystemInfo["canMultiBoot"][0], model, self.boxmode)
+					WriteStartup(startupFileContents, self.ReExit)
+
+
+	def reboot12(self):
+				self.mode = 1
+				self.boxmode = 12
+				self.reboot()
+
+	def ReExit(self):
+		self.session.open(TryQuitMainloop, 2)

--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -1,0 +1,95 @@
+from Components.SystemInfo import SystemInfo
+from Components.Console import Console
+import os
+#		#default layout for 				Mut@nt HD51						& Giga4K
+# boot								/dev/mmcblk0p1						/dev/mmcblk0p1
+# STARTUP_1 			Image 1: boot emmcflash0.kernel1 'root=/dev/mmcblk0p3 rw rootwait'	boot emmcflash0.kernel1: 'root=/dev/mmcblk0p5 
+# STARTUP_2 			Image 2: boot emmcflash0.kernel2 'root=/dev/mmcblk0p5 rw rootwait'      boot emmcflash0.kernel2: 'root=/dev/mmcblk0p7
+# STARTUP_3		        Image 3: boot emmcflash0.kernel3 'root=/dev/mmcblk0p7 rw rootwait'	boot emmcflash0.kernel3: 'root=/dev/mmcblk0p9
+# STARTUP_4		        Image 4: boot emmcflash0.kernel4 'root=/dev/mmcblk0p9 rw rootwait'	NOT IN USE due to Rescue mode in mmcblk0p3
+
+def GetCurrentImage():
+	return SystemInfo["canMultiBoot"] and (int(open('/sys/firmware/devicetree/base/chosen/bootargs', 'r').read().replace('\0', '').split('mmcblk0p')[1].split(' ')[0])-SystemInfo["canMultiBoot"][0])/2
+
+def GetCurrentImageMode():
+	return SystemInfo["canMultiBoot"] and SystemInfo["canMode12"] and int(open('/sys/firmware/devicetree/base/chosen/bootargs', 'r').read().replace('\0', '').split('=')[-1])
+
+class GetImagelist():
+	MOUNT = 0
+	UNMOUNT = 1
+
+	def __init__(self, callback):
+		if SystemInfo["canMultiBoot"]:
+			(self.firstslot, self.numberofslots) = SystemInfo["canMultiBoot"]
+			self.callback = callback
+			self.imagelist = {}
+			if not os.path.isdir('/tmp/testmount'):
+				os.mkdir('/tmp/testmount')
+			self.container = Console()
+			self.slot = 1
+			self.phase = self.MOUNT
+			self.run()
+		else:	
+			callback({})
+	
+	def run(self):
+		self.container.ePopen('mount /dev/mmcblk0p%s /tmp/testmount' % str(self.slot * 2 + self.firstslot) if self.phase == self.MOUNT else 'umount /tmp/testmount', self.appClosed)
+			
+	def appClosed(self, data, retval, extra_args):
+		if retval == 0 and self.phase == self.MOUNT:
+			BuildVersion = "  "
+			Build = " "
+			Version = " "
+			if os.path.isfile("/tmp/testmount/usr/bin/enigma2") and os.path.isfile('/tmp/testmount/etc/image-version'):
+				file = open('/tmp/testmount/etc/image-version', 'r')
+				lines = file.read().splitlines()
+				for x in lines:
+					splitted = x.split('= ')
+					if len(splitted) > 1:
+						if splitted[0].startswith("Version"):
+							Version = splitted[1].split(' ')[0]
+						elif splitted[0].startswith("Build"):
+							Build = splitted[1].split(' ')[0]
+				file.close()
+				BuildVersion = " " + Build
+			if os.path.isfile("/tmp/testmount/usr/bin/enigma2"):
+				self.imagelist[self.slot] =  { 'imagename': open("/tmp/testmount/etc/issue").readlines()[-2].capitalize().strip()[:-6] + BuildVersion}
+			else:
+				self.imagelist[self.slot] = { 'imagename': _("Empty slot")}
+			self.phase = self.UNMOUNT
+			self.run()
+		elif self.slot < self.numberofslots:
+			self.slot += 1
+			self.imagelist[self.slot] = { 'imagename': _("Empty slot")}
+			self.phase = self.MOUNT
+			self.run()
+		else:
+			self.container.killAll()
+			if not os.path.ismount('/tmp/testmount'):
+				os.rmdir('/tmp/testmount')
+			self.callback(self.imagelist)
+
+
+class WriteStartup():
+
+	def __init__(self, Contents, callback):
+		self.callback = callback
+		self.container = Console()
+		self.slotContents = Contents
+		if os.path.isdir('/tmp/startupmount'):
+			self.ContainerFallback()
+		else:
+			os.mkdir('/tmp/startupmount')
+			self.container.ePopen('mount /dev/mmcblk0p1 /tmp/startupmount', self.ContainerFallback)
+
+	
+	def ContainerFallback(self, data=None, retval=None, extra_args=None):
+		self.container.killAll()
+#	If GigaBlue then slotContents = slot, use slot to read STARTUP_slot
+#	If multimode and bootmode 1 or 12, then slotContents is STARTUP, so just write it to boot STARTUP.			
+		if 'coherent_poll=2M' in open("/proc/cmdline", "r").read():
+			import shutil
+			shutil.copyfile("/tmp/startupmount/STARTUP_%s" % self.slotContents, "/tmp/startupmount/STARTUP")
+		else:
+			open('/tmp/startupmount/STARTUP', 'w').write(self.slotContents)
+		self.callback()


### PR DESCRIPTION
adds multiboot core function (in Tools) and an option (Multiboot) to the Standby/restart/power off menu to allow restart on any valid image for multiboot capable receivers - for OpenVix currently the hd51 and giga4K receivers only.   
In multiboot restart provides Image Identifier (OpenViX/OpenPli etc)  and version (for ViX)

There is a 2nd pull request to follow for ImageManager which is dependent on this code.