### PR TITLE
Allow multiple genre values to be displayed in event information

### DIFF
--- a/lib/python/Components/Converter/EventName.py
+++ b/lib/python/Components/Converter/EventName.py
@@ -95,6 +95,7 @@ class EventName(Converter, object):
 	PDCTIME = 12
 	PDCTIMESHORT = 13
 	ISRUNNINGSTATUS = 14
+	GENRELIST = 15
 
 	NEXT_DESCRIPTION = 21
 	THIRD_NAME = 22
@@ -119,6 +120,7 @@ class EventName(Converter, object):
 		"NextNameOnly": ("type", NAME_NEXT2),
 		"NameNextOnly": ("type", NAME_NEXT2),
 		"Genre": ("type", GENRE),
+		"GenreList": ("type", GENRELIST),
 		"Rating": ("type", RATING),
 		"SmallRating": ("type", SRATING),
 		"Pdc": ("type", PDC),
@@ -135,6 +137,8 @@ class EventName(Converter, object):
 		# Options...
 		"Separated": ("separator", "\n\n"),
 		"NotSeparated": ("separator", "\n"),
+		"SeparatorSlash": ("separator", "/"),
+		"SeparatorComma": ("separator", ", "),
 		"Trimmed": ("trim", True),
 		"NotTrimmed": ("trim", False)
 	}
@@ -151,7 +155,7 @@ class EventName(Converter, object):
 		self.epgcache = eEPGCache.getInstance()
 
 		self.type = self.NAME
-		self.separator = "\n"
+		self.separator = None
 		self.trim = False
 
 		parse = ","
@@ -163,6 +167,9 @@ class EventName(Converter, object):
 				print "[EventName] ERROR: Unexpected / Invalid argument token '%s'!" % arg
 			else:
 				setattr(self, name, value)
+		if self.separator is None:
+			default_sep = "SeparatorComma" if self.type == self.GENRELIST else "NotSeparated"
+			self.separator = self.KEYWORDS[default_sep][1]
 
 	def trimText(self, text):
 		if self.trim:
@@ -215,11 +222,13 @@ class EventName(Converter, object):
 					elif self.type == self.SRATING:
 						return self.trimText(rating[self.RATSHORT])
 					return resolveFilename(SCOPE_ACTIVE_SKIN, rating[self.RATICON])
-		elif self.type == self.GENRE:
+		elif self.type in (self.GENRE, self.GENRELIST):
 			if not config.usage.show_genre_info.value:
 				return ""
-			genre = event.getGenreData()
-			if genre:
+			genres = event.getGenreDataList()
+			if genres:
+				if self.type == self.GENRE:
+					genres = genres[0:1]
 				rating = event.getParentalData()
 				if rating:
 					country = rating.getCountryCode().upper()
@@ -227,7 +236,7 @@ class EventName(Converter, object):
 					country = "ETSI"
 				if config.misc.epggenrecountry.value:
 					country = config.misc.epggenrecountry.value
-				return self.trimText(getGenreStringSub(genre.getLevel1(), genre.getLevel2(), country=country))
+				return self.separator.join((genretext for genretext in (self.trimText(getGenreStringSub(genre[0], genre[1], country=country)) for genre in genres) if genretext))
 		elif self.type == self.NAME_NOW:
 			return pgettext("now/next: 'now' event label", "Now") + ": " + self.trimText(event.getEventName())
 		elif self.type == self.SHORT_DESCRIPTION:

--- a/lib/service/event.cpp
+++ b/lib/service/event.cpp
@@ -267,7 +267,7 @@ RESULT eServiceEvent::getGenreData(ePtr<eGenreData> &dest) const
 	return -1;
 }
 
-PyObject *eServiceEvent::getGenreData() const
+PyObject *eServiceEvent::getGenreDataList() const
 {
 	ePyObject ret = PyList_New(m_genres.size());
 	int cnt=0;
@@ -295,7 +295,7 @@ RESULT eServiceEvent::getParentalData(ePtr<eParentalData> &dest) const
 	return -1;
 }
 
-PyObject *eServiceEvent::getParentalData() const
+PyObject *eServiceEvent::getParentalDataList() const
 {
 	ePyObject ret = PyList_New(m_ratings.size());
 	int cnt = 0;
@@ -325,7 +325,7 @@ RESULT eServiceEvent::getComponentData(ePtr<eComponentData> &dest, int tagnum) c
 	return -1;
 }
 
-PyObject *eServiceEvent::getComponentData() const
+PyObject *eServiceEvent::getComponentDataList() const
 {
 	ePyObject ret = PyList_New(m_component_data.size());
 	int cnt = 0;

--- a/lib/service/event.h
+++ b/lib/service/event.h
@@ -106,13 +106,30 @@ public:
 	std::string getExtendedDescription() const { return m_extended_description; }
 	std::string getBeginTimeString() const;
 	SWIG_VOID(RESULT) getComponentData(ePtr<eComponentData> &SWIG_OUTPUT, int tagnum) const;
-	PyObject *getComponentData() const;
+	// Naming to parallel getGenreDataList & getParentalDataList
+	PyObject *getComponentDataList() const;
+	PyObject *getComponentData() const
+	{
+		return getGenreDataList();
+	}
 	int getNumOfLinkageServices() const { return m_linkage_services.size(); }
 	SWIG_VOID(RESULT) getLinkageService(eServiceReference &SWIG_OUTPUT, eServiceReference &parent, int num) const;
 	SWIG_VOID(RESULT) getGenreData(ePtr<eGenreData> &SWIG_OUTPUT) const;
-	PyObject *getGenreData() const;
+	PyObject *getGenreDataList() const;
+	// Deprecated, doesn't differentiate from
+	// getGenreData(ePtr<eGenreData> &SWIG_OUTPUT) in Python
+	PyObject *getGenreData() const
+	{
+		return getGenreDataList();
+	}
 	SWIG_VOID(RESULT) getParentalData(ePtr<eParentalData> &SWIG_OUTPUT) const;
-	PyObject *getParentalData() const;
+	PyObject *getParentalDataList() const;
+	// Deprecated, doesn't differentiate from
+	// getGenreData(ePtr<eGenreData> &SWIG_OUTPUT) in Python
+	PyObject *getParentalData() const
+	{
+		return getParentalDataList();
+	}
 };
 SWIG_TEMPLATE_TYPEDEF(ePtr<eServiceEvent>, eServiceEvent);
 SWIG_EXTEND(ePtr<eServiceEvent>,


### PR DESCRIPTION
Fixes a bug that prevented access to genre & parental ratings lists from
Python.

Adds GenreList conversion type to EventName to support multiple
genres available in IceTV EPG (Australian non-broadcaster EPG provider).

Adding the GenreList conversion type simplifies keeping the OverlayHD
skin portable between Beyonwiz and OpenViX.

Genre conversion type in EventName now implemented on the genre list to
allow more flexibility in chosing a single genre from those available.

Added SeparatorSlash and SeparatorComma to separate items in genre list
display (defaults to SeparatorComma).

Add new methods PyObject *eServiceEvent::getGenreDataList() const and
PyObject *eServiceEvent::getParentalDataList() const so that their
Python/SWIG API signatures are differentiated from
RESULT eServiceEvent::getGenreData(ePtr<eGenreData> &dest) const and
RESULT eServiceEvent::getParentalData(ePtr<eParentalData> &dest) const

Add
PyObject *eServiceEvent::getComponentDataList() const
for consistent naming.

Re-implement
PyObject *getComponentData() const,
PyObject *getGenreData() const
and PyObject *getComponentData() const
as deprecated inline methods that call the respective new methods.

Add new GenreList type to the EventName converter to allow skin
access to the new genre list retrieval method.

The Rating types for the EventName converter have been left unchanged
because the use of a ratings list is more complicated is no way to
test the code for multiple country identifiers in Australian EPGs.