### PR TITLE
[MovieSelection.py] Allow context menu reskin

### DIFF
--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -343,7 +343,7 @@ class MovieContextMenu(Screen, ProtectedScreen):
 	# Contract: On OK returns a callable object (e.g. delete)
 	def __init__(self, session, csel, service):
 		Screen.__init__(self, session)
-		self.skinName = "Setup"
+		self.skinName = [self.skinName, "Setup"]
 		self.setup_title = _("Movie List Setup")
 		Screen.setTitle(self, _(self.setup_title))
 


### PR DESCRIPTION
Add an optional ability to reskin the MovieSelection context menu.

The current code inappropriately forces the use of the Setup screen.
