### PR TITLE
Add trashcan to default movie location if not from "movie"

### DIFF
--- a/lib/python/Tools/Trashcan.py
+++ b/lib/python/Tools/Trashcan.py
@@ -14,11 +14,12 @@ def getTrashFolder(path=None):
 			print 'path is none'
 			return ""
 		else:
+			trashcan = Harddisk.findMountPoint(os.path.realpath(path))
 			if '/movie' in path:
-				mountpoint = Harddisk.findMountPoint(os.path.realpath(path))
-				trashcan = os.path.join(mountpoint, 'movie')
-			else:
-				trashcan = Harddisk.findMountPoint(os.path.realpath(path))
+				trashcan = os.path.join(trashcan, 'movie')
+			elif config.usage.default_path.value in path:
+				# if default_path happens to not be the default /hdd/media/movie, then we can have a trash folder there instead
+				trashcan = os.path.join(trashcan, config.usage.default_path.value)
 			return os.path.realpath(os.path.join(trashcan, ".Trash"))
 	except:
 		return None


### PR DESCRIPTION
Not so much of a fix; rather makes a trash folder appear in the folder you set in the movielist options for the _Default movie location_ (_usage.default_path_ in the config) if it happens to not contain _/movies_

This means you can pick any folder for your default movies folder and still get to the trash folder. The existing behaviour of using /movies or the root folder of a mount is unchanged.

BTW fixes issue 279