### PR TITLE
Update list-based EPGs after setup changes

### DIFF
--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -405,9 +405,14 @@ class EPGSelection(Screen, HelpableScreen):
 				self.close('reopengraph')
 			elif self.type == EPG_TYPE_INFOBARGRAPH:
 				self.close('reopeninfobargraph')
-		else:
-			if self.type == EPG_TYPE_INFOBAR:
+		elif self.type == EPG_TYPE_INFOBAR:
 				self.close('reopeninfobar')
+		else:
+			if  self.type in (EPG_TYPE_SINGLE, EPG_TYPE_ENHANCED, EPG_TYPE_INFOBAR):
+				self['list'].sortSingleEPG(int(config.epgselection.sort.value))
+			self['list'].setFontsize()
+			self['list'].setItemsPerPage()
+			self['list'].recalcEntrySize()
 
 	def togglePIG(self):
 		if not config.epgselection.graph_pig.value:


### PR DESCRIPTION
In the EPG types EPG_TYPE_SINGLE, EPG_TYPE_SIMILAR, EPG_TYPE_MULTI
& EPG_TYPE_ENHANCED, update the EPG list's font size and items/page,
and recalculate the entry sizes on close of their respective setup
screens.

In the EPG types EPG_TYPE_SINGLE, EPG_TYPE_ENHANCED & EPG_TYPE_INFOBAR,
re-sort the EPG list on close of their respective setup screens.

This reflects changes of the EPG's Number of rows, Event font size
and Sort list by settings instead of the user having to exit and
then re-enter the EPG to see the changes.