### PR TITLE
Honour autotime startup delay

### DIFF
--- a/lib/python/Components/EpgList.py
+++ b/lib/python/Components/EpgList.py
@@ -307,8 +307,6 @@ class EPGList(GUIComponent):
 		self.showServiceNumber = "servicenumber" in value
 		self.showServiceTitle = "servicename" in value
 		self.showPicon = "picon" in value
-		self.recalcEntrySize()
-		self.selEntry(0) #Select entry again so that the clipping region gets updated if needed
 
 	def setOverjump_Empty(self, overjump_empty):
 		if overjump_empty:

--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -37,7 +37,7 @@ def sorttz(tzlist):
 class Timezones:
 	tzbase = "/usr/share/zoneinfo"
 	gen_label = "Generic"
-	AT_POLL_DELAY = 3  # Minutes
+	at_poll_delay = 3  # Minutes
 
 	def __init__(self):
 		self.timezones = {}
@@ -53,14 +53,17 @@ class Timezones:
 			self.autotimer = None
 		self.timer = eTimer()
 		self.ATupdate = None
+		at_poll_delay = config.plugins.autotimer.delay.value
+		if at_poll_delay is None:
+			at_poll_delay = 3
 
 	def startATupdate(self):
 		if self.ATupdate:
 			self.timer.stop()
 		if self.query not in self.timer.callback:
 			self.timer.callback.append(self.query)
-		print "[Timezones] AutoTimer poll will be run in", self.AT_POLL_DELAY, "minutes"
-		self.timer.startLongTimer(self.AT_POLL_DELAY * 60)
+		print "[Timezones] AutoTimer poll will be run in", self.at_poll_delay, "minutes"
+		self.timer.startLongTimer(self.at_poll_delay * 60)
 
 	def stopATupdate(self):
 		self.ATupdate = None

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -1085,7 +1085,13 @@ def InitUsageConfig():
 	config.epgselection.graph_prevtimeperiod = ConfigSelection(default = "180", choices = [("60", _("%d minutes") % 60), ("90", _("%d minutes") % 90), ("120", _("%d minutes") % 120), ("150", _("%d minutes") % 150), ("180", _("%d minutes") % 180), ("210", _("%d minutes") % 210), ("240", _("%d minutes") % 240), ("270", _("%d minutes") % 270), ("300", _("%d minutes") % 300)])
 	config.epgselection.graph_primetimehour = ConfigSelectionNumber(default = 20, stepwidth = 1, min = 00, max = 23, wraparound = True)
 	config.epgselection.graph_primetimemins = ConfigSelectionNumber(default = 00, stepwidth = 1, min = 00, max = 59, wraparound = True)
-	config.epgselection.graph_servicetitle_mode = ConfigSelection(default = "servicename", choices = [("servicename", _("Service Name")), ("picon", _("Picon")), ("picon+servicename", _("Picon and Service Name")), ("servicenumber+servicename", _("Service Number and Service Name")), ("servicenumber+picon+servicename", _("Service Number, Picon and Service Name"))])
+	config.epgselection.graph_servicetitle_mode = ConfigSelection(default = "servicename", choices = [
+		("servicename", _("Service Name")), 
+		("picon", _("Picon")),
+		("picon+servicename", _("Picon and Service Name")), 
+		("servicenumber+picon", _("Service Number and Picon")), 
+		("servicenumber+servicename", _("Service Number, Picon and Service Name")), 
+		("servicenumber+picon+servicename", _("Service Number, Picon and Service Name"))])
 	config.epgselection.graph_channel1 = ConfigYesNo(default = False)
 	possibleAlignmentChoices = [
 			( str(RT_HALIGN_LEFT   | RT_VALIGN_CENTER          ) , _("left")),

--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -458,6 +458,7 @@ class EPGSelection(Screen, HelpableScreen):
 			if self.StartBouquet.toString().startswith('1:7:0'):
 				self.BouquetRoot = True
 			self.services = self.getBouquetServices(self.StartBouquet)
+			self['list'].setShowServiceMode(config.epgselection.graph_servicetitle_mode.value)
 			self['list'].fillGraphEPG(self.services, self.ask_time)
 			self['list'].moveToService(serviceref)
 			self['list'].setCurrentlyPlaying(serviceref)
@@ -467,12 +468,10 @@ class EPGSelection(Screen, HelpableScreen):
 			self['bouquetlist'].setCurrentBouquet(self.StartBouquet)
 			self.setTitle(self['bouquetlist'].getCurrentBouquet())
 			if self.type == EPG_TYPE_GRAPH:
-				self['list'].setShowServiceMode(config.epgselection.graph_servicetitle_mode.value)
 				self.moveTimeLines()
 				if config.epgselection.graph_channel1.value:
 					self['list'].instance.moveSelectionTo(0)
 			elif self.type == EPG_TYPE_INFOBARGRAPH:
-				self['list'].setShowServiceMode(config.epgselection.infobar_servicetitle_mode.value)
 				self.moveTimeLines()
 		elif self.type == EPG_TYPE_MULTI:
 			self['bouquetlist'].recalcEntrySize()


### PR DESCRIPTION
Autotimer has a setting for startup delay, which was not being used by the timezones module, thus the setting was effectively ignored. Changed the const to pick up the value from config.plugins.autotimer.delay