### PR TITLE
Enable a temporary sort override for the current directory when Vix is

### DIFF
--- a/lib/python/Components/MovieList.py
+++ b/lib/python/Components/MovieList.py
@@ -10,7 +10,7 @@ from Components.config import config
 from Tools.LoadPixmap import LoadPixmap
 from Tools.Directories import SCOPE_ACTIVE_SKIN, resolveFilename
 from Screens.LocationBox import defaultInhibitDirs
-#GML:1
+#
 from Tools.Trashcan import getTrashFolder
 import NavigationInstance
 import skin
@@ -146,11 +146,12 @@ class MovieList(GUIComponent):
 	HIDE_DESCRIPTION = 1
 	SHOW_DESCRIPTION = 2
 
-#GML:1
 # So MovieSelection.selectSortby() can find out whether we are 
 # in a Trash folder and, if so, what the last sort was
 # The numbering starts after SORT_* values above.
 # in MovieSelection.py (that has no SORT_GROUPWISE)
+# NOTE! that these two *must* *follow on* from the end of the
+#       SORT_* items above!
 #
 	TRASHSORT_SHOWRECORD = 13
 	TRASHSORT_SHOWDELETE = 14
@@ -580,7 +581,6 @@ class MovieList(GUIComponent):
 				self.list.append((ref, None, 0, -1))
 				numberOfDirs += 1
 
-#GML:1
 		if config.usage.movielist_trashcan.value:
 			here = os.path.realpath(rootPath)
 			MovieList.InTrashFolder = here.startswith(getTrashFolder(here))
@@ -605,8 +605,6 @@ class MovieList(GUIComponent):
 			if info is None:
 				info = justStubInfo
 			begin = info.getInfo(serviceref, iServiceInformation.sTimeCreate)
-
-#GML:1
 			begin2 = 0
 			if MovieList.UsingTrashSort:
 				f_path = serviceref.getPath()
@@ -651,8 +649,6 @@ class MovieList(GUIComponent):
 				if not this_tags.issuperset(filter_tags) and not this_tags_fullname.issuperset(filter_tags):
 # 					print "Skipping", name, "tags=", this_tags, " filter=", filter_tags
 					continue
-
-#GML:1
 			if begin2 != 0:
 				self.list.append((serviceref, info, begin, -1, begin2))
 			else:
@@ -662,10 +658,21 @@ class MovieList(GUIComponent):
 		self.parentDirectory = 0
 
 		self.list.sort(key=self.buildGroupwiseSortkey)
-#GML:1
+
+# Have we had a temporary sort method override set in MovieSelectiom.py?
+# If so use it, remove it (it's a one-off) and remember the method so
+# that the "Sort by" menu can highlight it.
+#
+		try:
+			self.current_sort = self.temp_sort
+			del self.temp_sort
+		except:
+			self.current_sort = self.sort_type
+
 		if MovieList.UsingTrashSort:      # Same as SORT_RECORDED, but must come first...
 			self.list = sorted(self.list[:numberOfDirs], key=self.buildBeginTimeSortKey) + sorted(self.list[numberOfDirs:], key=self.buildBeginTimeSortKey)
-# Having sorted on deletion times, re-instate any record times for display.
+# Having sorted on *deletion* times, re-instate any record times for
+# *display* if that option is set.
 # self.list is a list of tuples, so we can't just assign to elements...
 #
 			if config.usage.trashsort_deltime.value == "show record time":
@@ -673,32 +680,32 @@ class MovieList(GUIComponent):
 					if len(self.list[i]) == 5:
 						x = self.list[i]
 						self.list[i] = (x[0], x[1], x[4], x[3])
-		elif self.sort_type == MovieList.SORT_ALPHANUMERIC:
+		elif self.current_sort == MovieList.SORT_ALPHANUMERIC:
 			self.list = sorted(self.list[:numberOfDirs], key=self.buildAlphaNumericSortKey) + sorted(self.list[numberOfDirs:], key=self.buildAlphaNumericSortKey)
-		elif self.sort_type == MovieList.SORT_ALPHANUMERIC_REVERSE:
+		elif self.current_sort == MovieList.SORT_ALPHANUMERIC_REVERSE:
 			self.list = sorted(self.list[:numberOfDirs], key=self.buildAlphaNumericSortKey, reverse = True) + sorted(self.list[numberOfDirs:], key=self.buildAlphaNumericSortKey, reverse = True)
-		elif self.sort_type == MovieList.SORT_ALPHANUMERIC_FLAT:
+		elif self.current_sort == MovieList.SORT_ALPHANUMERIC_FLAT:
 			self.list.sort(key=self.buildAlphaNumericFlatSortKey)
-		elif self.sort_type == MovieList.SORT_ALPHANUMERIC_FLAT_REVERSE:
+		elif self.current_sort == MovieList.SORT_ALPHANUMERIC_FLAT_REVERSE:
 			self.list.sort(key=self.buildAlphaNumericFlatSortKey, reverse = True)
-		elif self.sort_type == MovieList.SORT_RECORDED:
+		elif self.current_sort == MovieList.SORT_RECORDED:
 			self.list = sorted(self.list[:numberOfDirs], key=self.buildBeginTimeSortKey) + sorted(self.list[numberOfDirs:], key=self.buildBeginTimeSortKey)
-		elif self.sort_type == MovieList.SORT_RECORDED_REVERSE:
+		elif self.current_sort == MovieList.SORT_RECORDED_REVERSE:
 			self.list = sorted(self.list[:numberOfDirs], key=self.buildBeginTimeSortKey, reverse = True) + sorted(self.list[numberOfDirs:], key=self.buildBeginTimeSortKey, reverse = True)
-		elif self.sort_type == MovieList.SHUFFLE:
+		elif self.current_sort == MovieList.SHUFFLE:
 			dirlist = self.list[:numberOfDirs]
 			shufflelist = self.list[numberOfDirs:]
 			random.shuffle(shufflelist)
 			self.list = dirlist + shufflelist
-		elif self.sort_type == MovieList.SORT_ALPHA_DATE_OLDEST_FIRST:
+		elif self.current_sort == MovieList.SORT_ALPHA_DATE_OLDEST_FIRST:
 			self.list = sorted(self.list[:numberOfDirs], key=self.buildAlphaDateSortKey) + sorted(self.list[numberOfDirs:], key=self.buildAlphaDateSortKey)
-		elif self.sort_type == MovieList.SORT_ALPHAREV_DATE_NEWEST_FIRST:
+		elif self.current_sort == MovieList.SORT_ALPHAREV_DATE_NEWEST_FIRST:
 			self.list = sorted(self.list[:numberOfDirs], key=self.buildAlphaDateSortKey, reverse = True) + sorted(self.list[numberOfDirs:], key=self.buildAlphaDateSortKey, reverse = True)
-		elif self.sort_type == MovieList.SORT_LONGEST:
+		elif self.current_sort == MovieList.SORT_LONGEST:
 			self.list = sorted(self.list[:numberOfDirs], key=self.buildAlphaNumericSortKey) + sorted(self.list[numberOfDirs:], key=self.buildLengthSortKey, reverse = True)
-		elif self.sort_type == MovieList.SORT_SHORTEST:
+		elif self.current_sort == MovieList.SORT_SHORTEST:
 			self.list = sorted(self.list[:numberOfDirs], key=self.buildAlphaNumericSortKey) + sorted(self.list[numberOfDirs:], key=self.buildLengthSortKey)
-		
+
 		for x in self.list:
 			if x[1]:
 				tmppath = x[1].getName(x[0])[:-1] if x[1].getName(x[0]).endswith('/') else x[1].getName(x[0])

--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -76,7 +76,6 @@ l_moviesort = [
 	(str(MovieList.SORT_ALPHANUMERIC_REVERSE), _("alphabetic reverse"), 'Z-A'),
 	(str(MovieList.SORT_ALPHAREV_DATE_NEWEST_FIRST), _("alpharev then newest"),  'Z1 A2 A1')]
 
-#GML:1
 # 4th item is the textual value set in UsageConfig.py
 l_trashsort = [
 	(str(MovieList.TRASHSORT_SHOWRECORD), _("delete time - show record time (Trash ONLY)"), '03/02/01', "show record time"),
@@ -245,8 +244,7 @@ class MovieBrowserConfiguration(ConfigListScreen,Screen):
 		self.cfg = cfg
 		cfg.moviesort = ConfigSelection(default=str(config.movielist.moviesort.value), choices = l_moviesort)
 		cfg.description = ConfigYesNo(default=(config.movielist.description.value != MovieList.HIDE_DESCRIPTION))
-#GML:2 - movielist_trashcan_days
-#GML:1 - trashsort_deltime
+#
 		configList = [getConfigListEntry(_("Use trash can in movie list"), config.usage.movielist_trashcan, _("When enabled, deleted recordings are moved to the trash can, instead of being deleted immediately.")),
 					  getConfigListEntry(_("Remove items from trash can after (days)"), config.usage.movielist_trashcan_days, _("Configure the number of days after which items are automatically removed from the trash can.\nA setting of 0 disables this.")),
 					  getConfigListEntry(_("Clean network trash cans"), config.usage.movielist_trashcan_network_clean, _("When enabled, network trash cans are probed for cleaning.")),
@@ -1359,7 +1357,6 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 			action()
 
 	def saveLocalSettings(self):
-#GML:4
 		if not config.movielist.settings_per_directory.value:
 			return
 		try:
@@ -1373,8 +1370,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		config.movielist.moviesort.value = self.settings["moviesort"]
 		config.movielist.description.value = self.settings["description"]
 		config.usage.on_movie_eof.value = self.settings["movieoff"]
-		# save moviesort and movieeof values for using by hotkeys
-#		config.movielist.moviesort.save()
+		# save movieeof values for using by hotkeys
 		config.usage.on_movie_eof.save()
 
 	def loadLocalSettings(self):
@@ -1422,11 +1418,15 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		return needUpdate
 
 	def sortBy(self, newType):
-#GML:1
 		print '[MovieSelection] SORTBY:',newType
 		if newType < MovieList.TRASHSORT_SHOWRECORD:
 			self.settings["moviesort"] = newType
-			self.saveLocalSettings()
+# If we are using per-directory sort methods then set it now,
+# otherwise indicate to MovieList.py to use a temporary sort override.
+			if config.movielist.settings_per_directory.value:
+				self.saveLocalSettings()
+			else:
+				self["list"].temp_sort = newType
 			self.setSortType(newType)
 # Unset specific trash-sorting if other sort chosen while in Trash
 			if MovieList.InTrashFolder:
@@ -1496,19 +1496,33 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		menu = []
 		index = 0
 		used = 0
+# Determine the current sorting method so that it may be highlighted...
+#
 		for x in l_moviesort:
-			if int(x[0]) == int(config.movielist.moviesort.value):
+			if int(x[0]) == self["list"].current_sort:
 				used = index
 			menu.append((_(x[1]), x[0], "%d" % index))
 			index += 1
-#GML:1
 		if MovieList.InTrashFolder:
 			for x in l_trashsort:
 				if x[3] == config.usage.trashsort_deltime.value:
 					used = index
 				menu.append((_(x[1]), x[0], "%d" % index))
 				index += 1
-		self.session.openWithCallback(self.sortbyMenuCallback, ChoiceBox, title=_("Sort list:"), list=menu, selection = used)
+
+# Add a message to remind the user whether this will set a per-directory
+# method or just a temporary override.
+# Done by using the way that ChoiceBox handles a multi-line title:
+# it makes line1 the title and all succeeding lines go into the "text"
+# display.
+		title=_("Sort list:")
+		if config.movielist.settings_per_directory.value:
+			title = title + "\n\n" + "Set the sort method for this directory"
+		else:
+			title = title + "\n\n" + "Set a temporary sort method for this directory"
+			if self["list"].current_sort != self["list"].sort_type:
+				title = title + "\n" + "(You are currently using a temporary sort method)"
+		self.session.openWithCallback(self.sortbyMenuCallback, ChoiceBox, title=title, list=menu, selection = used)
 
 	def getPixmapSortIndex(self, which):
 		index = int(which)
@@ -1516,7 +1530,6 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 			index = MovieList.SORT_ALPHANUMERIC
 		elif index == MovieList.SORT_ALPHAREV_DATE_NEWEST_FIRST:
 			index = MovieList.SORT_ALPHANUMERIC_REVERSE
-#GML:1
 		elif (index == MovieList.TRASHSORT_SHOWRECORD) or (index == MovieList.TRASHSORT_SHOWDELETE):
 			index = MovieList.SORT_RECORDED
 		return index - 1


### PR DESCRIPTION
in "global sort method" mode. Without this the blue "Sort by" options
do nothing (not even say they will do nothing).

Removed some old, irrelevant, GML* comments.