### PR TITLE
Provide additional updates ET8500 & SF8008

### DIFF
--- a/lib/gdi/gfbdc.cpp
+++ b/lib/gdi/gfbdc.cpp
@@ -251,7 +251,11 @@ void gFBDC::setGamma(int g)
 
 void gFBDC::setResolution(int xres, int yres, int bpp)
 {
-	if (m_pixmap && (surface.x == xres) && (surface.y == yres) && (surface.bpp == bpp))
+	if (m_pixmap && (surface.x == xres) && (surface.y == yres) && (surface.bpp == bpp)
+	#if defined(CONFIG_HISILICON_FB)
+		&& islocked()==0
+	#endif
+		)
 		return;
 
 	if (gAccel::getInstance())

--- a/lib/gdi/gpixmap.cpp
+++ b/lib/gdi/gpixmap.cpp
@@ -546,7 +546,9 @@ void gPixmap::blit(const gPixmap &src, const eRect &_pos, const gRegion &clip, i
 
 //		eDebug("[gPixmap] srcarea after scale: %d %d %d %d",
 //			srcarea.x(), srcarea.y(), srcarea.width(), srcarea.height());
-
+#ifdef FORCE_NO_ACCELNEVER
+		accel = false;
+#else
 		if (accel)
 		{
 			if (srcarea.surface() * src.surface->bypp < accelerationthreshold)
@@ -562,10 +564,13 @@ void gPixmap::blit(const gPixmap &src, const eRect &_pos, const gRegion &clip, i
 				/* alpha blending is requested */
 				if (gAccel::getInstance()->hasAlphaBlendingSupport())
 				{
-#ifndef FORCE_ALPHABLENDING_ACCELERATION
+#ifdef FORCE_ALPHABLENDING_ACCELERATION
 					/* Hardware alpha blending is broken on the few
 					 * boxes that support it, so only use it
 					 * when scaling */
+
+					accel = true;
+#else
 					if (flag & blitScale)
 						accel = true;
 					else if (flag & blitAlphaTest) /* Alpha test only on 8-bit */
@@ -584,6 +589,7 @@ void gPixmap::blit(const gPixmap &src, const eRect &_pos, const gRegion &clip, i
 
 #ifdef GPIXMAP_CHECK_THRESHOLD
 		accel = (surface->data_phys && src.surface->data_phys);
+#endif
 #endif
 
 #ifdef GPIXMAP_DEBUG

--- a/lib/network/serversocket.cpp
+++ b/lib/network/serversocket.cpp
@@ -167,8 +167,11 @@ int eServerSocket::startListening(struct addrinfo *addr)
 	{
 		return -1;
 	}
-
+#if HAVE_HISILICON
+	if (listen(getDescriptor(), 10) < 0)
+#else
 	if (listen(getDescriptor(), 0) < 0)
+#endif
 	{
 		close();
 		return -1;

--- a/lib/python/Screens/About.py
+++ b/lib/python/Screens/About.py
@@ -179,6 +179,22 @@ class About(Screen):
 
 		self["AboutScrollLabel"] = ScrollLabel(AboutText)
 
+	def dualBoot(self):
+		rootfs2 = False
+		kernel2 = False
+		f = open("/proc/mtd")
+		self.dualbootL = f.readlines()
+		for x in self.dualbootL:
+			if 'rootfs2' in x:
+				rootfs2 = True
+			if 'kernel2' in x:
+				kernel2 = True
+		f.close()
+		if rootfs2 and kernel2:
+			return True
+		else:
+			return False
+
 	def showTranslationInfo(self):
 		self.session.open(TranslationInfo, self.menu_path)
 


### PR DESCRIPTION
.ET8500 - provide missing sub routine to find bootloader used
.SF8008/HiSilicon receivers
add additional code to handle accel changes for HiSilicon devices and increase backlog buffer count in Network/serversocket.
These last changes were extracted from the original OpenATV HiSilicon commits and have been in builds for all my receivers for the last 3 weeks, not just the sf8008.   