### PR TITLE
NetworkSetup - reinstate MAC changeability

### DIFF
--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -1156,9 +1156,7 @@ class AdapterSetupConfiguration(Screen, HelpableScreen):
 
 		if os_path.exists(resolveFilename(SCOPE_PLUGINS, "SystemPlugins/NetworkWizard/networkwizard.xml")):
 			menu.append((_("Network wizard"), "openwizard"))
-		kernel_ver = about.getKernelVersionString()
-		if kernel_ver >= "3.5.0":
-			menu.append((_("Network MAC settings"), "mac"))
+		menu.append((_("Network MAC settings"), "mac"))
 
 		return menu
 

--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -1157,7 +1157,7 @@ class AdapterSetupConfiguration(Screen, HelpableScreen):
 		if os_path.exists(resolveFilename(SCOPE_PLUGINS, "SystemPlugins/NetworkWizard/networkwizard.xml")):
 			menu.append((_("Network wizard"), "openwizard"))
 		kernel_ver = about.getKernelVersionString()
-		if kernel_ver <= "3.5.0":
+		if kernel_ver >= "3.5.0":
 			menu.append((_("Network MAC settings"), "mac"))
 
 		return menu


### PR DESCRIPTION
The ability to change the MAC address in NetworkSetup was merged from OpenATV by Andy on Jan 3rd 2014 with some modifications for OpenViX - one of which was to insert a kernel check, which I guess was valid at the time - but has never been changed.
This small change re-enables the code - checked out on my SF8008 and appears fine. 