### PR TITLE
U53 - fix accel compile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -459,6 +459,17 @@ if test "$BOXTYPE" == "sf8008"; then
 	AC_DEFINE(FORCE_ALPHABLENDING_ACCELERATION, 1,[define when the framebuffer acceleration has alphablending support, but detection slow down all])
 fi
 
+if test "$BOXTYPE" == "u5" -o "$BOXTYPE" == "u5pvr" -o "$BOXTYPE" == "u51" -o "$BOXTYPE" == "u52" -o "$BOXTYPE" == "u53"; then
+	AC_DEFINE(HAVE_HISILICON, 1,[define add HISILICON chip])
+fi
+
+if test "$BOXTYPE" == "u53"; then
+	AC_DEFINE(KEY_F6_TO_KEY_FAVORITES, 1,[define when rc FAV key sends a KEY_F6 event for its KEY_FAVORITES key])
+	AC_DEFINE(KEY_CONTEXT_MENU_TO_KEY_BACK, 1,[define when rc MOUSE key sends a KEY_CONTEXT_MENU event for its KEY_BACK key])
+	AC_DEFINE(KEY_WWW_TO_KEY_FILE, 1,[define when rc HOME key sends a KEY_WWW event for its KEY_FILE key])
+	AC_DEFINE(KEY_HELP_TO_KEY_AUDIO, 1,[define when rc SETTINGS key sends a KEY_HELP event for its KEY_AUDIO key])
+fi
+
 if test "$BOXTYPE" == "7000s"; then
 	AC_DEFINE(FORCE_NO_BLENDING_ACCELERATION, 1,[define when the framebuffer acceleration has alphablending support, but detection slow down all])
 	AC_DEFINE(KEY_PLAY_ACTUALLY_IS_KEY_PLAYPAUSE, 1,[define when rc sends a KEY_PLAY event for its KEY_PLAYPAUSE key])

--- a/lib/gdi/accel.cpp
+++ b/lib/gdi/accel.cpp
@@ -17,9 +17,11 @@
 gAccel *gAccel::instance;
 
 #if not defined(HAVE_HISILICON_ACCEL)
+#if not defined(__sh__)
 #define BCM_ACCEL
 #else
 #define STMFB_ACCEL
+#endif
 #endif
 
 #ifdef HAVE_HISILICON_ACCEL 
@@ -64,6 +66,7 @@ extern void ati_accel_fill(
 		int x, int y, int width, int height,
 		unsigned long color);
 #endif
+
 #ifdef BCM_ACCEL
 extern int bcm_accel_init(void);
 extern void bcm_accel_close(void);


### PR DESCRIPTION
this fixes the compile so that the Dinobot (U53) U5 Mini can build