### PR TITLE
MultiBoot - handle corrupted/boot

### DIFF
--- a/lib/python/Screens/MBRestart.py
+++ b/lib/python/Screens/MBRestart.py
@@ -101,9 +101,20 @@ class MultiBoot(Screen):
 			slot = self.currentSelected[0][1]
 
 			if slot < 12:
-				import shutil
-				shutil.copyfile("/boot/STARTUP_%s" % slot, "/boot/STARTUP")
-				self.session.open(TryQuitMainloop, 2)
+				if pathExists("/boot/STARTUP_%s" % slot):
+					import shutil
+					shutil.copyfile("/boot/STARTUP_%s" % slot, "/boot/STARTUP")
+					self.session.open(TryQuitMainloop, 2)
+				elif SystemInfo["canMode12"] and pathExists("/boot/STARTUP"):
+					print "[MultiBoot Restart] No boot/Startup_%s - created Startup slot:" %slot
+					model = getMachineBuild()
+					startupFileContents = "boot emmcflash0.kernel%s 'brcm_cma=%s root=/dev/mmcblk0p%s rw rootwait %s_4.boxmode=1'\n" % (slot, SystemInfo["canMode12"][0], slot * 2 + SystemInfo["canMultiBoot"][0], model)
+					open('/boot/STARTUP', 'w').write(startupFileContents)
+					self.session.open(TryQuitMainloop, 2)
+				elif pathExists("/boot/STARTUP"):		
+					self.session.open(MessageBox, _("Multiboot ERROR! - no STARTUP_%s in /boot - Image may need manual restart" % slot), MessageBox.TYPE_INFO, timeout=20)
+				else:
+					self.session.open(MessageBox, _("Multiboot ERROR! - no STARTUP in /boot -Please check /etc/fstab for correct boot partition"), MessageBox.TYPE_INFO, timeout=20)
 			else:
 				slot -= 12
 				model = getMachineBuild()


### PR DESCRIPTION
Part 1: (Part2 is in ImageManager - ViX plugin)
Multiboot depends on the boot partition mounted in fstab and that there is a symlink from /boot to the boot partition which should contain a number of STARTUP files for the receiver(STARTUP, STARTUP_x where x is a number specific to the receiver)
Unfortunately either users appear to dislike setting up their boxes anew and copy Backup settings from any previous box or because they cannot remember which images are in which slots (and OpenATV and their clones don't give any information) the "brighter" users  change the STARTUP file names.

Hopefully this code will help resolve these issues or at least allow a resolution to be quickly applied.