### PR TITLE
Sf8008

### DIFF
--- a/lib/python/Components/Harddisk.py
+++ b/lib/python/Components/Harddisk.py
@@ -4,7 +4,7 @@ from Tools.CList import CList
 from SystemInfo import SystemInfo
 from Components.Console import Console
 from Tools.HardwareInfo import HardwareInfo
-from boxbranding import getMachineBuild
+from boxbranding import getBoxType, getMachineBuild, getMachineMtdRoot
 import Task
 import re
 
@@ -603,11 +603,8 @@ class HarddiskManager:
 		error = False
 		removable = False
 		BLACKLIST=[]
-		if getMachineBuild() in ('multibox','h9combo','v8plus','hd60','hd61','vuduo4k','ustym4kpro','dags72604','u51','u52','u53','u54','u5','u5pvr','cc1','sf8008','sf8008s','sf8008t','vuzero4k','et1x000','vuuno4k','vuuno4kse','vuultimo4k','vusolo4k','hd51','hd52','sf4008','dm900','dm7080','dm820', 'gb7252', 'dags7252', 'vs1500','h7','8100s','et13000','sf5008'):
-			BLACKLIST=["mmcblk0"]
-		elif getMachineBuild() in ('xc7439','osmio4k'):
-			BLACKLIST=["mmcblk1"]
-
+		if SystemInfo["HasMMC"]:
+			BLACKLIST=["%s" %(getMachineMtdRoot()[0:7])]
 		blacklisted = False
 		if blockdev[:7] in BLACKLIST:
 			blacklisted = True

--- a/lib/python/Screens/About.py
+++ b/lib/python/Screens/About.py
@@ -306,6 +306,8 @@ class Devices(Screen):
 			device = parts[3]
 			if not search('sd[a-z][1-9]', device) and not search('mmcblk[0-9]p[1-9]', device):
 				continue
+			if SystemInfo["HasSDmmc"] and search('sd[a][1-9]', device):
+				continue
 			if device in list2:
 				continue
 

--- a/lib/python/Screens/MBRestart.py
+++ b/lib/python/Screens/MBRestart.py
@@ -1,6 +1,6 @@
 from os import mkdir
 from shutil import copyfile
-from boxbranding import getMachineBuild
+from boxbranding import getMachineBuild, getMachineMtdRoot
 from Components.Sources.StaticText import StaticText
 from Components.ActionMap import ActionMap
 from Components.ChoiceList import ChoiceList, ChoiceEntryComponent
@@ -48,6 +48,9 @@ class MultiBoot(Screen):
 			self["labe15"] = StaticText(_("Mode 1 suppports Kodi, PiP may not work.\nMode 12 supports PiP, Kodi may not work."))
 		self["config"] = ChoiceList(list=[ChoiceEntryComponent('',((_("Retrieving image slots - Please wait...")), "Queued"))])
 		imagedict = []
+		self.mtdboot = "%s1" % SystemInfo["canMultiBoot"][2]
+ 		if SystemInfo["canMultiBoot"][2] == "sda":
+			self.mtdboot = "%s3" %getMachineMtdRoot()[0:8]
 		self.getImageList = None
 		self.title = screentitle
 		if not SystemInfo["HasSDmmc"] or SystemInfo["HasSDmmc"] and pathExists('/dev/%s4' %(SystemInfo["canMultiBoot"][2])):
@@ -106,7 +109,7 @@ class MultiBoot(Screen):
 				self.ContainterFallback()
 			else:
 				mkdir('/tmp/startupmount')
-				self.container.ePopen('mount /dev/%s1 /tmp/startupmount' % SystemInfo["canMultiBoot"][2], self.ContainterFallback)
+				self.container.ePopen('mount /dev/%s /tmp/startupmount' % self.mtdboot, self.ContainterFallback)
 
 	def ContainterFallback(self, data=None, retval=None, extra_args=None):
 		self.container.killAll()


### PR DESCRIPTION
SF8008: 
1) fix multiboot restart to use correct boot partition for SF8008
2) don't lists sdc card used by SF8008 multiboot in About

General:
Generate BLACKLIST for mmc devices using HasMMC and root device name (mmcblkXp where X is 0 or 1 (currently)