### PR TITLE
[MovieSelection.py] Use new sort settings

### DIFF
--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -1444,6 +1444,8 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 			if config.movielist.settings_per_directory.value:
 				self.saveLocalSettings()
 			else:
+				config.movielist.moviesort.value = newType
+				config.movielist.moviesort.save()
 				self["list"].temp_sort = newType
 			self.setSortType(newType)
 # Unset specific trash-sorting if other sort chosen while in Trash


### PR DESCRIPTION
In the sortBy() method the newly selected sort mode is not set or saved if the config.movielist.settings_per_directory is False.  This change updates config.movielist.moviesort with the newly selected sort mode and then saves that setting for future use.
