### PR TITLE
LCD improvements for ET8500

### DIFF
--- a/data/display720/skin_display_templates.xml
+++ b/data/display720/skin_display_templates.xml
@@ -500,4 +500,12 @@
 		<widget source="Name" render="Label" position="10,200" size="700,160" foregroundColor="white" font="FdLcDLight;65" halign="center" valign="top" zPosition="2" />
 		<panel name="LCDTime" />
 	</screen>
+
+	<!-- TIMEREDITLIST -->
+	<screen name="TimerEditListSummary" position="0,0" size="720,576"> 
+		<widget source="service" render="Label" position="10,40" size="700,90" font="FdLcD;75" foregroundColor="yellow" halign="center" valign="center" />
+		<widget source="name" render="Label" position="10,150" size="700,150" font="FdLcDLight;60" foregroundColor="white" halign="center" valign="top" />
+		<widget source="time" render="Label" position="10,340" size="700,70" font="FdLcD;60" foregroundColor="green" halign="center" valign="center" />
+		<widget source="duration" render="Label" position="10,430" size="700,70" font="FdLcD;60" foregroundColor="white" halign="center" valign="center" />
+	</screen>
 </skin>

--- a/data/display720/skin_display_templates.xml
+++ b/data/display720/skin_display_templates.xml
@@ -493,4 +493,11 @@
 		<widget source="parent.Title" render="Label" position="10,20" size="670,250" font="FdLcD;80" halign="center" valign="center" foregroundColor="#e5b243" />
 		<panel name="LCDTime" />
 	</screen> 
+
+	<!-- SKINSELECTOR -->
+	<screen name="SkinSelectorSummary" position="0,0" size="720,576">
+		<widget source="parent.Title" render="Label" position="10,50" size="700,110" foregroundColor="yellow" font="FdLcD;85" halign="center" valign="center" zPosition="2" />
+		<widget source="Name" render="Label" position="10,200" size="700,160" foregroundColor="white" font="FdLcDLight;65" halign="center" valign="top" zPosition="2" />
+		<panel name="LCDTime" />
+	</screen>
 </skin>

--- a/lib/python/Components/Lcd.py
+++ b/lib/python/Components/Lcd.py
@@ -500,12 +500,11 @@ def setLCDLiveTv(value):
 		open(SystemInfo["LcdLiveTV"], "w").write(value and "enable" or "disable")
 	else:
 		open(SystemInfo["LcdLiveTV"], "w").write(value and "0" or "1")
-	if not value:
-		try:
-			InfoBarInstance = InfoBar.instance
-			InfoBarInstance and InfoBarInstance.session.open(dummyScreen)
-		except:
-			pass
+	try:
+		InfoBarInstance = InfoBar.instance
+		InfoBarInstance and InfoBarInstance.session.open(dummyScreen)
+	except:
+		pass
 
 def leaveStandbyLCDLiveTV():
 	if config.lcd.showTv.value:

--- a/lib/python/Screens/TimerEntry.py
+++ b/lib/python/Screens/TimerEntry.py
@@ -26,7 +26,7 @@ from Screens.VirtualKeyBoard import VirtualKeyBoard
 from RecordTimer import AFTEREVENT
 
 
-class TimerEntry(Screen, ConfigListScreen):
+class TimerEntry(ConfigListScreen, Screen):
 	def __init__(self, session, timer, menu_path=""):
 		Screen.__init__(self, session)
 		screentitle = _("Timer entry")


### PR DESCRIPTION
A few adjustments for the ET8500 LCD screen
1. Fixes a failure to switch from info screen to live TV on the LCD when using a long press of the HDMI button
2. Adds a Skin Selector summary screen
3. Adds the missing TimerEditList summary screen
4. Tweaks TimerEntry inheritance order to get rudimentary info onto the summary screen