### PR TITLE
fix globalname 'eDVBFrontendParametersSatellite' not found BSoD

### DIFF
--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -5,7 +5,7 @@ from Components.Label import Label
 from Components.config import config
 from Components.Sources.StaticText import StaticText
 from ServiceReference import ServiceReference
-from enigma import eListboxPythonMultiContent, eListbox, gFont, iServiceInformation, eServiceCenter, RT_HALIGN_LEFT
+from enigma import eListboxPythonMultiContent, eListbox, gFont, iServiceInformation, eServiceCenter, RT_HALIGN_LEFT, eDVBFrontendParametersSatellite
 from Tools.Transponder import ConvertToHumanReadable, getChannelNumber
 import skin
 


### PR DESCRIPTION
Due to recent commits, 'eDVBFrontendParametersSatellite' not referenced.

Reported in: https://www.world-of-satellite.com/showthread.php?61119-Crash-on-Service-Information-Tuner-Setting-Values