### PR TITLE
BUGFIX: Under rare circumstances the timeshift directory can contain …

### DIFF
--- a/lib/python/Components/Timeshift.py
+++ b/lib/python/Components/Timeshift.py
@@ -882,7 +882,7 @@ class InfoBarTimeshift:
 		# print 'ptsCreateHardlink'
 		for filename in os.listdir(config.usage.timeshift_path.value):
 			# if filename.startswith("timeshift") and not os.path.splitext(filename)[1]:
-			if filename.startswith("timeshift") and not filename.endswith(".sc") and not filename.endswith(".del") and not filename.endswith(".copy"):
+			if filename.startswith("timeshift") and not filename.endswith(".sc") and not filename.endswith(".del") and not filename.endswith(".copy") and not filename.endswith(".ap"):
 				if os.path.exists("%spts_livebuffer_%s.eit" % (config.usage.timeshift_path.value,self.pts_eventcount)):
 					self.BgFileEraser.erase("%spts_livebuffer_%s.eit" % (config.usage.timeshift_path.value,self.pts_eventcount))
 				if os.path.exists("%spts_livebuffer_%s.meta" % (config.usage.timeshift_path.value,self.pts_eventcount)):


### PR DESCRIPTION
…an .ap file which is not exception handled correctly.  Processing misleads the user into thinking they've incorrectly setup their disk to a format not supporting hardlinks.  There maybe other extensions to exclude or the block of code may want to process other extensions including .ap but in its current state without this patch it will fail and confuse the user.

More details on this thread:

https://www.world-of-satellite.com/showthread.php?61157-Enigma2-Timeshift-Bug