### PR TITLE
Fix crash when creating directory from file with no metadata

### DIFF
--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -1870,7 +1870,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 			dirname = info.getName(item[0])
 			full_name = os.path.split(item[0].getPath())[1]
 			if full_name == dirname: # split extensions for files without metafile
-				dirname, self.extension = os.path.splitext(name)
+				dirname, self.extension = os.path.splitext(dirname)
 		self.session.openWithCallback(self.createDirCallback, VirtualKeyBoard,
 			title = _("Please enter the name of the new directory"),
 			text = dirname)


### PR DESCRIPTION
In movieselection there would be a crash if creating a new directory when a file with no metadata is selected. This fixes that problem (thanks @original-birdman for pointing it out)