### PR TITLE
Infobar EPG open on current channel

### DIFF
--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -439,9 +439,8 @@ class EPGSelection(Screen, HelpableScreen):
 		if self.type == EPG_TYPE_GRAPH or self.type == EPG_TYPE_INFOBARGRAPH:
 			populateBouquetList()
 			self['list'].fillGraphEPGNoRefresh(self.services, self.ask_time)
-			if self.type == EPG_TYPE_GRAPH:
-				if not config.epgselection.graph_channel1.value:
-					self['list'].moveToService(serviceref)
+			if self.type == EPG_TYPE_INFOBARGRAPH or not config.epgselection.graph_channel1.value:
+				self['list'].moveToService(serviceref)
 			self['list'].setCurrentlyPlaying(serviceref)
 			self.moveTimeLines()
 		if self.type == EPG_TYPE_MULTI:


### PR DESCRIPTION
Fixes the infobar EPG to open on the current channel rather than the first channel in the bouquet