### PR TITLE
[Directories.py] Refactor and enhance the code

### DIFF
--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -7,9 +7,6 @@ from re import compile
 pathExists = os.path.exists
 isMount = os.path.ismount  # Only used in OpenATV /lib/python/Plugins/SystemPlugins/NFIFlash/downloader.py.
 
-screenResolution = getDesktop(0).size().height()
-lcdResolution = getDesktop(1).size().height()
-
 SCOPE_TRANSPONDERDATA = 0
 SCOPE_SYSETC = 1
 SCOPE_FONTS = 2
@@ -102,15 +99,15 @@ def resolveFilename(scope, base="", path_prefix=None):
 	elif scope in (SCOPE_CURRENT_SKIN, SCOPE_ACTIVE_SKIN):
 		# This import must be here as this module finds the config file as part of the config initialisation.
 		from Components.config import config
-		pos = config.skin.primary_skin.value.rfind("/")
-		if pos == -1:
-			skin = ""
-		else:
-			skin = config.skin.primary_skin.value[:pos + 1]
+		skin = ""
+		if hasattr(config.skin, "primary_skin"):
+			pos = config.skin.primary_skin.value.rfind("/")
+			if pos != -1:
+				skin = config.skin.primary_skin.value[:pos + 1]
 		resolveList = [
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], skin),
 			os.path.join(defaultPaths[SCOPE_SKIN][0], skin),
-			os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_%d" % screenResolution),
+			os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_%d" % getDesktop(0).size().height()),
 			os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_default"),
 			defaultPaths[SCOPE_CONFIG][0],  # Deprecated top level of SCOPE_CONFIG directory.
 			defaultPaths[SCOPE_SKIN][0]  # Deprecated top level of SCOPE_SKIN directory.
@@ -123,15 +120,15 @@ def resolveFilename(scope, base="", path_prefix=None):
 	elif scope == SCOPE_CURRENT_LCDSKIN:
 		# This import must be here as this module finds the config file as part of the config initialisation.
 		from Components.config import config
-		pos = config.skin.display_skin.value.rfind("/")
-		if pos == -1:
-			skin = ""
-		else:
-			skin = config.skin.display_skin.value[:pos + 1]
+		skin = ""
+		if hasattr(config.skin, "display_skin"):
+			pos = config.skin.display_skin.value.rfind("/")
+			if pos != -1:
+				skin = config.skin.display_skin.value[:pos + 1]
 		resolveList = [
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], "display", skin),
 			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], skin),
-			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_%s" % lcdResolution),
+			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_%s" % getDesktop(1).size().height()),
 			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_default"),
 			defaultPaths[SCOPE_CONFIG][0],  # Deprecated top level of SCOPE_CONFIG directory.
 			defaultPaths[SCOPE_LCDSKIN][0]  # Deprecated top level of SCOPE_LCDSKIN directory.
@@ -144,16 +141,16 @@ def resolveFilename(scope, base="", path_prefix=None):
 	elif scope == SCOPE_FONTS:
 		# This import must be here as this module finds the config file as part of the config initialisation.
 		from Components.config import config
-		pos = config.skin.primary_skin.value.rfind("/")
-		if pos == -1:
-			skin = ""
-		else:
-			skin = config.skin.primary_skin.value[:pos + 1]
-		pos = config.skin.display_skin.value.rfind("/")
-		if pos == -1:
-			display = ""
-		else:
-			display = config.skin.display_skin.value[:pos + 1]
+		skin = ""
+		display = ""
+		if hasattr(config.skin, "primary_skin"):
+			pos = config.skin.primary_skin.value.rfind("/")
+			if pos != -1:
+				skin = config.skin.primary_skin.value[:pos + 1]
+		if hasattr(config.skin, "display_skin"):
+			pos = config.skin.display_skin.value.rfind("/")
+			if pos != -1:
+				display = config.skin.display_skin.value[:pos + 1]
 		resolveList = [
 			os.path.join(defaultPaths[SCOPE_CONFIG][0], "fonts"),
 			os.path.join(defaultPaths[SCOPE_SKIN][0], skin),

--- a/lib/python/Tools/Directories.py
+++ b/lib/python/Tools/Directories.py
@@ -1,26 +1,21 @@
 # -*- coding: utf-8 -*-
 import os
+
+from enigma import eEnv, getDesktop
 from re import compile
-from enigma import eEnv
 
-try:
-	from os import chmod
-	have_chmod = True
-except:
-	have_chmod = False
+pathExists = os.path.exists
+isMount = os.path.ismount  # Only used in OpenATV /lib/python/Plugins/SystemPlugins/NFIFlash/downloader.py.
 
-try:
-	from os import utime
-	have_utime = True
-except:
-	have_utime = False
+screenResolution = getDesktop(0).size().height()
+lcdResolution = getDesktop(1).size().height()
 
 SCOPE_TRANSPONDERDATA = 0
 SCOPE_SYSETC = 1
 SCOPE_FONTS = 2
 SCOPE_SKIN = 3
-SCOPE_SKIN_IMAGE = 4
-SCOPE_USERETC = 5
+SCOPE_SKIN_IMAGE = 4  # DEBUG: How is this different from SCOPE_SKIN?
+SCOPE_USERETC = 5  # DEBUG: Not used in Enigma2.
 SCOPE_CONFIG = 6
 SCOPE_LANGUAGE = 7
 SCOPE_HDD = 8
@@ -28,320 +23,288 @@ SCOPE_PLUGINS = 9
 SCOPE_MEDIA = 10
 SCOPE_PLAYLIST = 11
 SCOPE_CURRENT_SKIN = 12
+
 SCOPE_METADIR = 16
 SCOPE_CURRENT_PLUGIN = 17
 SCOPE_TIMESHIFT = 18
-SCOPE_ACTIVE_SKIN = 19
+SCOPE_ACTIVE_SKIN = 19  # DEBUG: Deprecated scope function - use SCOPE_CURRENT_SKIN instead.
 SCOPE_LCDSKIN = 20
-SCOPE_ACTIVE_LCDSKIN = 21
+SCOPE_CURRENT_LCDSKIN = 21
+SCOPE_ACTIVE_LCDSKIN = 21  # DEBUG: Deprecated scope function name - use SCOPE_CURRENT_LCDSKIN instead.
+SCOPE_AUTORECORD = 22
+SCOPE_DEFAULTDIR = 23
+SCOPE_DEFAULTPARTITION = 24
+SCOPE_DEFAULTPARTITIONMOUNTDIR = 25
 
 PATH_CREATE = 0
 PATH_DONTCREATE = 1
-PATH_FALLBACK = 2
+
 defaultPaths = {
-		SCOPE_TRANSPONDERDATA: (eEnv.resolve("${sysconfdir}/"), PATH_DONTCREATE),
-		SCOPE_SYSETC: (eEnv.resolve("${sysconfdir}/"), PATH_DONTCREATE),
-		SCOPE_FONTS: (eEnv.resolve("${datadir}/fonts/"), PATH_DONTCREATE),
-		SCOPE_CONFIG: (eEnv.resolve("${sysconfdir}/enigma2/"), PATH_CREATE),
-		SCOPE_PLUGINS: (eEnv.resolve("${libdir}/enigma2/python/Plugins/"), PATH_CREATE),
+	SCOPE_TRANSPONDERDATA: (eEnv.resolve("${sysconfdir}/"), PATH_DONTCREATE),
+	SCOPE_SYSETC: (eEnv.resolve("${sysconfdir}/"), PATH_DONTCREATE),
+	SCOPE_FONTS: (eEnv.resolve("${datadir}/fonts/"), PATH_DONTCREATE),
+	SCOPE_SKIN: (eEnv.resolve("${datadir}/enigma2/"), PATH_DONTCREATE),
+	SCOPE_SKIN_IMAGE: (eEnv.resolve("${datadir}/enigma2/"), PATH_DONTCREATE),
+	SCOPE_USERETC: ("", PATH_DONTCREATE),  # User home directory
+	SCOPE_CONFIG: (eEnv.resolve("${sysconfdir}/enigma2/"), PATH_CREATE),
+	SCOPE_LANGUAGE: (eEnv.resolve("${datadir}/enigma2/po/"), PATH_DONTCREATE),
+	SCOPE_HDD: ("/media/hdd/movie/", PATH_DONTCREATE),
+	SCOPE_PLUGINS: (eEnv.resolve("${libdir}/enigma2/python/Plugins/"), PATH_CREATE),
+	SCOPE_MEDIA: ("/media/", PATH_DONTCREATE),
+	SCOPE_PLAYLIST: (eEnv.resolve("${sysconfdir}/enigma2/playlist/"), PATH_CREATE),
+	SCOPE_CURRENT_SKIN: (eEnv.resolve("${datadir}/enigma2/"), PATH_DONTCREATE),
+	SCOPE_METADIR: (eEnv.resolve("${datadir}/meta"), PATH_CREATE),
+	SCOPE_CURRENT_PLUGIN: (eEnv.resolve("${libdir}/enigma2/python/Plugins/"), PATH_CREATE),
+	SCOPE_TIMESHIFT: ("/media/hdd/timeshift/", PATH_DONTCREATE),
+	SCOPE_ACTIVE_SKIN: (eEnv.resolve("${datadir}/enigma2/"), PATH_DONTCREATE),
+	SCOPE_LCDSKIN: (eEnv.resolve("${datadir}/enigma2/display/"), PATH_DONTCREATE),
+	SCOPE_CURRENT_LCDSKIN: ("${datadir}/enigma2/display/", PATH_DONTCREATE),
+	SCOPE_AUTORECORD: ("/media/hdd/movie/", PATH_DONTCREATE),
+	SCOPE_DEFAULTDIR: (eEnv.resolve("${datadir}/enigma2/defaults/"), PATH_CREATE),
+	SCOPE_DEFAULTPARTITION: ("/dev/mtdblock6", PATH_DONTCREATE),
+	SCOPE_DEFAULTPARTITIONMOUNTDIR: (eEnv.resolve("${datadir}/enigma2/dealer"), PATH_CREATE)
+}
 
-		SCOPE_LANGUAGE: (eEnv.resolve("${datadir}/enigma2/po/"), PATH_DONTCREATE),
-
-		SCOPE_SKIN: (eEnv.resolve("${datadir}/enigma2/"), PATH_DONTCREATE),
-		SCOPE_LCDSKIN: (eEnv.resolve("${datadir}/enigma2/display/"), PATH_DONTCREATE),
-		SCOPE_SKIN_IMAGE: (eEnv.resolve("${datadir}/enigma2/"), PATH_DONTCREATE),
-		SCOPE_HDD: ("/media/hdd/movie/", PATH_DONTCREATE),
-		SCOPE_TIMESHIFT: ("/media/hdd/timeshift/", PATH_DONTCREATE),
-		SCOPE_MEDIA: ("/media/", PATH_DONTCREATE),
-		SCOPE_PLAYLIST: (eEnv.resolve("${sysconfdir}/enigma2/playlist/"), PATH_CREATE),
-
-		SCOPE_USERETC: ("", PATH_DONTCREATE), # user home directory
-
-		SCOPE_METADIR: (eEnv.resolve("${datadir}/meta"), PATH_CREATE),
-	}
-
-FILE_COPY = 0 # copy files from fallback dir to the basedir
-FILE_MOVE = 1 # move files
-PATH_COPY = 2 # copy the complete fallback dir to the basedir
-PATH_MOVE = 3 # move the fallback dir to the basedir (can be used for changes in paths)
-fallbackPaths = {
-		SCOPE_CONFIG: [("/home/root/", FILE_MOVE),
-					   (eEnv.resolve("${datadir}/enigma2/defaults/"), FILE_COPY)],
-		SCOPE_HDD: [("/media/hdd/movies", PATH_MOVE)],
-		SCOPE_TIMESHIFT: [("/media/hdd/timeshift", PATH_MOVE)]
-	}
-
-def resolveFilename(scope, base = "", path_prefix = None):
+def resolveFilename(scope, base="", path_prefix=None):
+	# You can only use the ~/ if we have a prefix directory.
 	if base.startswith("~/"):
-		# you can only use the ~/ if we have a prefix directory
-		assert path_prefix is not None
-		base = os.path.join(path_prefix, base[2:])
-
-	# don't resolve absolute paths
-	if base.startswith('/'):
+		assert path_prefix is not None  # Assert only works in debug mode!
+		if path_prefix:
+			base = os.path.join(path_prefix, base[2:])
+		else:
+			print "[Directories] Warning: resolveFilename called with base starting with '~/' but 'path_prefix' is None!"
+	# Don't further resolve absolute paths.
+	if base.startswith("/"):
 		return base
-
-	if scope == SCOPE_CURRENT_SKIN:
+	# If an invalid scope is specified log an error and return None.
+	if scope not in defaultPaths:
+		print "[Directories] Error: Invalid scope=%d provided to resolveFilename!" % scope
+		return None
+	# Ensure that the defaultPaths directories that should exist do exist.
+	path, flag = defaultPaths.get(scope)
+	if flag == PATH_CREATE and not pathExists(path):
+		try:
+			os.makedirs(path)
+		except OSError, e:
+			print "[Directories] Error %d: Couldn't create directory '%s' (%s)" % (e.errno, path, os.strerror(e.error))
+			return None
+	# Remove any suffix data and restore it at the end.
+	suffix = None
+	data = base.split(":", 1)
+	if len(data) > 1:
+		base = data[0]
+		suffix = data[1]
+	path = base
+	# If base is "" then set path to the scope.  Otherwise use the scope to resolve the base filename.
+	if base is "":
+		path, flags = defaultPaths.get(scope)
+		path = os.path.normpath(path)
+	elif scope in (SCOPE_CURRENT_SKIN, SCOPE_ACTIVE_SKIN):
+		# This import must be here as this module finds the config file as part of the config initialisation.
 		from Components.config import config
-		# allow files in the config directory to replace skin files
-		tmp = defaultPaths[SCOPE_CONFIG][0]
-		if base and pathExists(tmp + base):
-			path = tmp
+		pos = config.skin.primary_skin.value.rfind("/")
+		if pos == -1:
+			skin = ""
 		else:
-			tmp = defaultPaths[SCOPE_SKIN][0]
-			pos = config.skin.primary_skin.value.rfind('/')
-			if pos != -1:
-				#if basefile is not available use default skin path as fallback
-				tmpfile = tmp+config.skin.primary_skin.value[:pos+1] + base
-				if pathExists(tmpfile):
-					path = tmp+config.skin.primary_skin.value[:pos+1]
-				else:
-					path = tmp
-			else:
-				path = tmp
-
-	elif scope == SCOPE_ACTIVE_SKIN:
+			skin = config.skin.primary_skin.value[:pos + 1]
+		resolveList = [
+			os.path.join(defaultPaths[SCOPE_CONFIG][0], skin),
+			os.path.join(defaultPaths[SCOPE_SKIN][0], skin),
+			os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_%d" % screenResolution),
+			os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_default"),
+			defaultPaths[SCOPE_CONFIG][0],  # Deprecated top level of SCOPE_CONFIG directory.
+			defaultPaths[SCOPE_SKIN][0]  # Deprecated top level of SCOPE_SKIN directory.
+		]
+		for item in resolveList:
+			file = os.path.normpath(os.path.join(item, base))
+			if pathExists(file):
+				path = file
+				break
+	elif scope == SCOPE_CURRENT_LCDSKIN:
+		# This import must be here as this module finds the config file as part of the config initialisation.
 		from Components.config import config
-		# allow files in the config directory to replace skin files
-		tmp = defaultPaths[SCOPE_CONFIG][0]
-		if base and pathExists(tmp + base):
-			path = tmp
+		pos = config.skin.display_skin.value.rfind("/")
+		if pos == -1:
+			skin = ""
 		else:
-			tmp = defaultPaths[SCOPE_SKIN][0]
-			pos = config.skin.primary_skin.value.rfind('/')
-			if pos != -1:
-				tmpfile = tmp+config.skin.primary_skin.value[:pos+1] + base
-				if pathExists(tmpfile) or (':' in tmpfile and pathExists(tmpfile.split(':')[0])):
-					path = tmp+config.skin.primary_skin.value[:pos+1]
-				elif pathExists(tmp + base) or (':' in base and pathExists(tmp + base.split(':')[0])):
-					path = tmp
-				else:
-					if 'skin_default' not in tmp:
-						path = tmp + 'skin_default/'
-					else:
-						path = tmp
-			else:
-				if pathExists(tmp + base):
-					path = tmp
-				elif 'skin_default' not in tmp:
-					path = tmp + 'skin_default/'
-				else:
-					path = tmp
-
-	elif scope == SCOPE_ACTIVE_LCDSKIN:
+			skin = config.skin.display_skin.value[:pos + 1]
+		resolveList = [
+			os.path.join(defaultPaths[SCOPE_CONFIG][0], "display", skin),
+			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], skin),
+			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_%s" % lcdResolution),
+			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_default"),
+			defaultPaths[SCOPE_CONFIG][0],  # Deprecated top level of SCOPE_CONFIG directory.
+			defaultPaths[SCOPE_LCDSKIN][0]  # Deprecated top level of SCOPE_LCDSKIN directory.
+		]
+		for item in resolveList:
+			file = os.path.normpath(os.path.join(item, base))
+			if pathExists(file):
+				path = file
+				break
+	elif scope == SCOPE_FONTS:
+		# This import must be here as this module finds the config file as part of the config initialisation.
 		from Components.config import config
-		# allow files in the config directory to replace skin files
-		tmp = defaultPaths[SCOPE_CONFIG][0]
-		if base and pathExists(tmp + base):
-			path = tmp
-		elif base and pathExists(defaultPaths[SCOPE_LCDSKIN][0] + base):
-			path = defaultPaths[SCOPE_LCDSKIN][0]
+		pos = config.skin.primary_skin.value.rfind("/")
+		if pos == -1:
+			skin = ""
 		else:
-			tmp = defaultPaths[SCOPE_LCDSKIN][0]
-			pos = config.skin.display_skin.value.rfind('/')
-			if pos != -1:
-				tmpfile = tmp+config.skin.display_skin.value[:pos+1] + base
-				if pathExists(tmpfile):
-					path = tmp+config.skin.display_skin.value[:pos+1]
-				else:
-					if 'skin_default' not in tmp:
-						path = tmp + 'skin_default/'
-					else:
-						path = tmp
-			else:
-				if 'skin_default' not in tmp:
-					path = tmp + 'skin_default/'
-				else:
-					path = tmp
-
+			skin = config.skin.primary_skin.value[:pos + 1]
+		pos = config.skin.display_skin.value.rfind("/")
+		if pos == -1:
+			display = ""
+		else:
+			display = config.skin.display_skin.value[:pos + 1]
+		resolveList = [
+			os.path.join(defaultPaths[SCOPE_CONFIG][0], "fonts"),
+			os.path.join(defaultPaths[SCOPE_SKIN][0], skin),
+			os.path.join(defaultPaths[SCOPE_SKIN][0], "skin_default"),
+			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], display),
+			os.path.join(defaultPaths[SCOPE_LCDSKIN][0], "skin_default"),
+			defaultPaths[SCOPE_FONTS][0],
+			os.path.join(defaultPaths[SCOPE_CONFIG][0], skin),  # Deprecated skin in SCOPE_CONFIG directory.
+			os.path.join(defaultPaths[SCOPE_CONFIG][0], display)  # Deprecated display in SCOPE_CONFIG directory.
+		]
+		for item in resolveList:
+			file = os.path.normpath(os.path.join(item, base))
+			if pathExists(file):
+				path = file
+				break
 	elif scope == SCOPE_CURRENT_PLUGIN:
-		tmp = defaultPaths[SCOPE_PLUGINS]
-		from Components.config import config
-		skintmp = defaultPaths[SCOPE_SKIN]
-		pos = config.skin.primary_skin.value.rfind('/')
-		if pos != -1:
-			#if basefile is not available inside current skin path, use the original provided file as fallback
-			skintmpfile = skintmp[0]+config.skin.primary_skin.value[:pos+1] + base
-			if fileExists(skintmpfile):
-				path = skintmp[0]+config.skin.primary_skin.value[:pos+1]
-			else:
-				path = tmp[0]
-		else:
-			path = tmp[0]
+		file = os.path.normpath(os.path.join(defaultPaths[SCOPE_PLUGINS][0], base))
+		if pathExists(file):
+			path = file
 	else:
-		tmp = defaultPaths[scope]
-		path = tmp[0]
-
-	flags = tmp[1]
-
-	if flags == PATH_CREATE:
-		if not pathExists(path):
-			try:
-				os.mkdir(path)
-			except OSError:
-				print "resolveFilename: Couldn't create %s" % path
-				return None
-
-	fallbackPath = fallbackPaths.get(scope)
-
-	if fallbackPath and not fileExists(path + base):
-		for x in fallbackPath:
-			try:
-				if x[1] == FILE_COPY:
-					if fileExists(x[0] + base):
-						try:
-							os.link(x[0] + base, path + base)
-						except:
-							os.system("cp " + x[0] + base + " " + path + base)
-						break
-				elif x[1] == FILE_MOVE:
-					if fileExists(x[0] + base):
-						os.rename(x[0] + base, path + base)
-						break
-				elif x[1] == PATH_COPY:
-					if pathExists(x[0]):
-						if not pathExists(defaultPaths[scope][0]):
-							os.mkdir(path)
-						os.system("cp -a " + x[0] + "* " + path)
-						break
-				elif x[1] == PATH_MOVE:
-					if pathExists(x[0]):
-						os.rename(x[0], path + base)
-						break
-			except Exception, e:
-				print "[D] Failed to recover %s:" % (path+base), e
-
-	# FIXME: we also have to handle DATADIR etc. here.
-	return path + base
-	# this is only the BASE - an extension must be added later.
-
-pathExists = os.path.exists
-isMount = os.path.ismount
+		path, flags = defaultPaths.get(scope)
+		path = os.path.normpath(os.path.join(path, base))
+	# If the path is a directory then ensure that it ends with a "/".
+	if os.path.isdir(path) and not path.endswith("/"):
+		path += "/"
+	# If a suffix was supplier restore it.
+	if suffix is not None:
+		path = "%s:%s" % (path, suffix)
+	return path
 
 def bestRecordingLocation(candidates):
-	path = ''
+	path = ""
 	biggest = 0
 	for candidate in candidates:
 		try:
+			# Must have some free space (i.e. not read-only).
 			stat = os.statvfs(candidate[1])
-			# must have some free space (i.e. not read-only)
 			if stat.f_bavail:
-				# Free space counts double
+				# Free space counts double.
 				size = (stat.f_blocks + stat.f_bavail) * stat.f_bsize
 				if size > biggest:
-					path = candidate[1]
 					biggest = size
+					path = candidate[1]
 		except Exception, e:
-			print "[DRL]", e
+			print "[Directories] Error %d: Couldn't get free space for '%s' (%s)" % (e.errno, candidate[1], os.strerror(e.error))
 	return path
 
 def defaultRecordingLocation(candidate=None):
-	if candidate and os.path.exists(candidate):
+	if candidate and pathExists(candidate):
 		return candidate
-	# First, try whatever /hdd points to, or /media/hdd
+	# First, try whatever /hdd points to, or /media/hdd.
 	try:
-		path = os.readlink('/hdd')
-	except:
-		path = '/media/hdd'
-	if not os.path.exists(path):
-		path = ''
-		# Find the largest local disk
+		path = os.readlink("/hdd")
+	except OSError:
+		path = "/media/hdd"
+	if not pathExists(path):
+		# Find the largest local disk.
 		from Components import Harddisk
-		mounts = [m for m in Harddisk.getProcMounts() if m[1].startswith('/media/')]
+		mounts = [m for m in Harddisk.getProcMounts() if m[1].startswith("/media/")]
 		# Search local devices first, use the larger one
-		path = bestRecordingLocation([m for m in mounts if m[0].startswith('/dev/')])
-		# If we haven't found a viable candidate yet, try remote mounts
+		path = bestRecordingLocation([m for m in mounts if m[0].startswith("/dev/")])
+		# If we haven't found a viable candidate yet, try remote mounts.
 		if not path:
-			path = bestRecordingLocation(mounts)
+			path = bestRecordingLocation([m for m in mounts if not m[0].startswith("/dev/")])
 	if path:
 		# If there's a movie subdir, we'd probably want to use that.
-		movie = os.path.join(path, 'movie')
+		movie = os.path.join(path, "movie")
 		if os.path.isdir(movie):
 			path = movie
-		if not path.endswith('/'):
-			path += '/' # Bad habits die hard, old code relies on this
+		if not path.endswith("/"):
+			path += "/"  # Bad habits die hard, old code relies on this.
 	return path
 
-
-def createDir(path, makeParents = False):
+def createDir(path, makeParents=False):
 	try:
 		if makeParents:
 			os.makedirs(path)
 		else:
 			os.mkdir(path)
-	except:
-		return 0
-	else:
 		return 1
+	except OSError:
+		return 0
 
 def removeDir(path):
 	try:
 		os.rmdir(path)
-	except:
-		return 0
-	else:
 		return 1
+	except OSError:
+		return 0
 
-def fileExists(f, mode='r'):
-	if mode == 'r':
+def fileExists(f, mode="r"):
+	if mode == "r":
 		acc_mode = os.R_OK
-	elif mode == 'w':
+	elif mode == "w":
 		acc_mode = os.W_OK
 	else:
 		acc_mode = os.F_OK
 	return os.access(f, acc_mode)
 
-def fileCheck(f, mode='r'):
+def fileCheck(f, mode="r"):
 	return fileExists(f, mode) and f
 
-def fileHas(f, content, mode='r'):
-        return fileExists(f, mode) and content in open(f, mode).read()
+def fileHas(f, content, mode="r"):
+	result = False
+	if fileExists(f, mode):
+		file = open(f, mode)
+		text = file.read()
+		file.close()
+		if content in text:
+			result = True
+	return result
 
-def getRecordingFilename(basename, dirname = None):
-	# filter out non-allowed characters
+def getRecordingFilename(basename, dirname=None):
+	# Filter out non-allowed characters.
 	non_allowed_characters = "/.\\:*?<>|\""
+	basename = basename.replace("\xc2\x86", "").replace("\xc2\x87", "")
 	filename = ""
-
-	basename = basename.replace('\xc2\x86', '').replace('\xc2\x87', '')
-
 	for c in basename:
 		if c in non_allowed_characters or ord(c) < 32:
 			c = "_"
 		filename += c
-
-	# max filename length for ext4 is 255 (minus 8 characters for .ts.meta)
-	# But must not truncate in the middle of a multi-byte utf8 character!
-	# So convert the truncation to unicode and back, ignoring errors.
-	# The result will be valid utf8 and so xml parsing will be OK.
-        filename = unicode(filename[:247], 'utf8', 'ignore').encode('utf8', 'ignore')
-
+	# Max filename length for ext4 is 255 (minus 8 characters for .ts.meta)
+	# but must not truncate in the middle of a multi-byte utf8 character!
+	# So convert the truncation to unicode and back, ignoring errors, the
+	# result will be valid utf8 and so xml parsing will be OK.
+	filename = unicode(filename[:247], "utf8", "ignore").encode("utf8", "ignore")
 	if dirname is not None:
-		if not dirname.startswith('/'):
+		if not dirname.startswith("/"):
 			dirname = os.path.join(defaultRecordingLocation(), dirname)
 	else:
 		dirname = defaultRecordingLocation()
 	filename = os.path.join(dirname, filename)
-
-	i = 0
+	path = filename
+	i = 1
 	while True:
-		path = filename
-		if i > 0:
-			path += "_%03d" % i
-		try:
-			open(path + ".ts")
-			i += 1
-		except IOError:
+		if not os.path.isfile(path + ".ts"):
 			return path
+		path += "_%03d" % i
+		i += 1
 
-# this is clearly a hack:
+# This is clearly a hack:
+#
 def InitFallbackFiles():
 	resolveFilename(SCOPE_CONFIG, "userbouquet.favourites.tv")
 	resolveFilename(SCOPE_CONFIG, "bouquets.tv")
 	resolveFilename(SCOPE_CONFIG, "userbouquet.favourites.radio")
 	resolveFilename(SCOPE_CONFIG, "bouquets.radio")
 
-# returns a list of tuples containing pathname and filename matching the given pattern
-# example-pattern: match all txt-files: ".*\.txt$"
+# Returns a list of tuples containing pathname and filename matching the given pattern
+# Example-pattern: match all txt-files: ".*\.txt$"
+#
 def crawlDirectory(directory, pattern):
 	list = []
 	if directory:
@@ -353,26 +316,34 @@ def crawlDirectory(directory, pattern):
 	return list
 
 def copyfile(src, dst):
+	f1 = None
+	f2 = None
+	status = 0
 	try:
 		f1 = open(src, "rb")
 		if os.path.isdir(dst):
 			dst = os.path.join(dst, os.path.basename(src))
 		f2 = open(dst, "w+b")
 		while True:
-			buf = f1.read(16*1024)
+			buf = f1.read(16 * 1024)
 			if not buf:
 				break
 			f2.write(buf)
+	except OSError, e:
+		print "[Directories] Error %d: Copying file '%s' to '%s'! (%s)" % (e.errno, src, dst, os.strerror(e.error))
+		status = -1
+	if f1 is not None:
+		f1.close()
+	if f2 is not None:
+		f2.close()
+	try:
 		st = os.stat(src)
 		mode = os.stat.S_IMODE(st.st_mode)
-		if have_chmod:
-			chmod(dst, mode)
-		if have_utime:
-			utime(dst, (st.st_atime, st.st_mtime))
-	except:
-		print "copy", src, "to", dst, "failed!"
-		return -1
-	return 0
+		os.chmod(dst, mode)
+		os.utime(dst, (st.st_atime, st.st_mtime))
+	except OSError, e:
+		print "[Directories] Error %d: Copying stats from '%s' to '%s'! (%s)" % (e.errno, src, dst, os.strerror(e.error))
+	return status
 
 def copytree(src, dst, symlinks=False):
 	names = os.listdir(src)
@@ -393,43 +364,44 @@ def copytree(src, dst, symlinks=False):
 				copytree(srcname, dstname, symlinks)
 			else:
 				copyfile(srcname, dstname)
-		except:
-			print "dont copy srcname (no file or link or folder)"
+		except OSError, e:
+			print "[Directories] Error %d: Copying tree '%s' to '%s'! (%s)" % (e.errno, srcname, dstname, os.strerror(e.error))
 	try:
 		st = os.stat(src)
 		mode = os.stat.S_IMODE(st.st_mode)
-		if have_chmod:
-			chmod(dst, mode)
-		if have_utime:
-			utime(dst, (st.st_atime, st.st_mtime))
-	except:
-		print "copy stats for", src, "failed!"
+		os.chmod(dst, mode)
+		os.utime(dst, (st.st_atime, st.st_mtime))
+	except OSError, e:
+		print "[Directories] Error %d: Copying stats from '%s' to '%s'! (%s)" % (e.errno, src, dst, os.strerror(e.error))
 
 # Renames files or if source and destination are on different devices moves them in background
 # input list of (source, destination)
+#
 def moveFiles(fileList):
+	errorFlag = False
 	movedList = []
 	try:
-		try:
-			for item in fileList:
-				os.rename(item[0], item[1])
-				movedList.append(item)
-		except OSError, e:
-			if e.errno == 18:
-				print "[Directories] cannot rename across devices, trying slow move"
-				import Tools.CopyFiles
-				Tools.CopyFiles.moveFiles(fileList, item[0])
-				print "[Directories] Moving in background..."
-			else:
-				raise
-	except Exception, e:
-		print "[Directories] Failed move:", e
+		for item in fileList:
+			os.rename(item[0], item[1])
+			movedList.append(item)
+	except OSError, e:
+		if e.errno == 18:  # errno.EXDEV - Invalid cross-device link
+			print "[Directories] Warning: Cannot rename across devices, trying slower move."
+			from Tools.CopyFiles import moveFiles as extMoveFiles  # OpenViX, OpenATV, Beyonwiz
+			# from Screens.CopyFiles import moveFiles as extMoveFiles  # OpenPLi
+			extMoveFiles(fileList, item[0])
+			print "[Directories] Moving files in background."
+		else:
+			print "[Directories] Error %d: Moving file '%s' to '%s'! (%s)" % (e.errno, item[0], item[1], os.strerror(e.error))
+			errorFlag = True
+	if errorFlag:
+		print "[Directories] Reversing renamed files due to error."
 		for item in movedList:
 			try:
 				os.rename(item[1], item[0])
-			except:
+			except OSError, e:
+				print "[Directories] Error %d: Renaming '%s' to '%s'! (%s)" % (e.errno, item[1], item[0], os.strerror(e.error))
 				print "[Directories] Failed to undo move:", item
-				raise
 
 def getSize(path, pattern=".*"):
 	path_size = 0
@@ -441,3 +413,36 @@ def getSize(path, pattern=".*"):
 	elif os.path.isfile(path):
 		path_size = os.path.getsize(path)
 	return path_size
+
+def lsof():
+	lsof = []
+	for pid in os.listdir("/proc"):
+		if pid.isdigit():
+			try:
+				prog = os.readlink(os.path.join("/proc", pid, "exe"))
+				dir = os.path.join("/proc", pid, "fd")
+				for file in [os.path.join(dir, file) for file in os.listdir(dir)]:
+					lsof.append((pid, prog, os.readlink(file)))
+			except OSError:
+				pass
+	return lsof
+
+def getExtension(file):
+	filename, extension = os.path.splitext(file)
+	return extension
+
+def mediafilesInUse(session):
+	from Components.MovieList import KNOWN_EXTENSIONS
+	files = [x[2] for x in lsof() if getExtension(x[2]) in KNOWN_EXTENSIONS]
+	service = session.nav.getCurrentlyPlayingServiceOrGroup()
+	filename = service and service.getPath()
+	if filename and "://" in filename:  # When path is a stream ignore it.
+		filename = None
+	return set([file for file in files if not(filename and file.startswith(filename) and files.count(filename) < 2)])
+
+# Prepare filenames for use in external shell processing. Filenames may
+# contain spaces or other special characters.  This method adjusts the
+# filename to be a safe and single entity for passing to a shell.
+#
+def shellquote(s):
+	return "'%s'" % s.replace("'", "'\\''")


### PR DESCRIPTION
The bulk of the changes are in the "resolveFilename" method.  Some of the changes are to clean up the code, some to correct bugs, some to generate consistent results and others to add new functionality.

- This code has undergone a PEP8 clean up.

- The original code was difficult to read.  The refactor should make the code more self explanatory.  More comments have been added to aid readability.

- The previous code tested if the system paths existed and, if not, tried created them at the end of the process.  Moving this logic earlier avoids wasting processing if the required paths can't be created.

- The code to create the system paths now tries to create the entire path tree and not just the lowest level directory.

- One of the uses for the "resolveFilenames" method is to return the default path for a scope.  This is done by calling the method with no arguments other than the scope.  Previously not all scopes had a default path.  Using this form of the method would thus return inconsistent results.  Now all scope only calls return reasonable values.

- The scopes in the "defaultPaths" dictionary has been expanded to encompass all common scopes used in the popular Enigma2 images.  It is important that all scopes remain unique so that plugins don't have unexpected behaviours when they are run on different images.  Having them all defined should eliminate, or at least reduce, the chances of scope number conflicts.  The expansion of this small and simple dictionary should have little cost, impact or burden for any image.

  Note: Some scopes have have been commented either because I couldn't find any use for the scope or the scope appears to replicate another scope with no apparent purpose for the duplication.  Because this is a refactor the scopes can't be changes yet.  Once the new code change has settled it should be possible to investigate removal of the questionable scopes.

- The code now checks if the scope provided is a valid scope.  Previously this could cause unexpected results and even index error crashes.  Now if the scope is not valid an error is logged and None is returned.

- The "defaultPaths" dictionary is now accessed via a .get() method to avoid any unexpected index error failures if the scope isn't valid.  (This should no longer be possible but the code won't crash if it does happen.)

- The SCOPE_PLUGINS code spent time evaluating the primary skin.  This appears to be copy and paste code rot issue that served no purpose.  This has been cleaned up.

- The SCOPE_FONTS code was not correctly finding fonts stored elsewhere, like fonts provided with skins.  This has now been addressed.  (The code that simulates this function in skin.py can now be removed.  This can happen in a later update as the existing code still works but will not be executed as this updated method should find the font on the first call.)

- The SCOPE_CURRENT_SKIN now performs all the duties it previously did but has a few new tricks.  The code can now find images in a list of locations.  The locations include:
  * User defined skin overrides in "/etc/enigma2/\<skinname\>/"
  * The standard skin location in "/usr/share/enigma2/\<skinname\>/"
  * A new location that offers current resolution skins components in /usr/share/enigma2/skin_\<resolution\>  (e.g. "/usr/share/enigma2/skin_1080/")
  * The default skin location in "/usr/share/enigma2/skin_default/"
  * Because this is a refactor the other locations commonly used are still supported but should be removed:
    - User defined skin override in "/etc/enigma2/"
    - Enigma2 work directory in "/usr/share/enigma2/"
    These two locations have been used by some skinners.  These locations shouldn't be used as they place clutter in Enigma2 working locations.  These location have not yet been removed as that would not be appropriate for a code refactor.

- With the improved and smarter SCOPE_CURRENT_SKIN the SCOPE_ACTIVE_SKIN used by some images is now redundant.  To maintain transparent functionality the SCOPE_ACTIVE_SKIN is simply redirected to the SCOPE_CURRENT_SKIN code.  This change will allow all coder and plugin developers to simply use SCOPE_CURRENT_SKIN and it will now work without code modification in all images.

- The SCOPE_CURRENT_LCDSKIN supports coders do want to maintain skins and features for front panel displays in a standardised way.  The code can now find images in a list of locations.  The locations include:
  * User defined skin overrides in "/etc/enigma2/display/"
  * The standard skin location in "/usr/share/enigma2/display/\<skinname\>"
  * A new location that offers current resolution skins components in /usr/share/enigma2/skin_\<resolution\>  (e.g. "/usr/share/enigma2/display/skin_1080/")
  * The default skin location in "/usr/share/enigma2/display/skin_default/"
  * Because this is a refactor the other locations commonly used are still supported but should be removed ASAP:
    - User defined skin override in "/etc/enigma2/"
    - Enigma2 work directory in "/usr/share/enigma2/display/"
    These two locations have been used by some skinners.  These locations shouldn't be used as they place clutter in Enigma2 working locations.  These location have not yet been removed as that would not be appropriate for a code refactor.

  This scope is new for OpenPLi.

- Some calls to resolveFilenames provide extra data, appended to the file name separated with a colon ":".  This extra information is now consistently stripped while the file name is resolved and then restore for return to the calling code.

- If the resolved filename is a path then, in line with Enigma2 convention, ensure that the path ends with a "/".

- The "defaultRecordingLocation" method wasted time retrying locations that had already been rejected.  This has been optimised.
