### PR TITLE
StartWizard revamp wizard priorities for Restore

### DIFF
--- a/lib/python/Screens/StartWizard.py
+++ b/lib/python/Screens/StartWizard.py
@@ -33,7 +33,7 @@ class StartWizard(WizardLanguage, Rc):
 		config.misc.firstrun.save()
 		configfile.save()
 
-wizardManager.registerWizard(VideoWizard, config.misc.videowizardenabled.value, priority = 0)
-wizardManager.registerWizard(LanguageWizard, config.misc.languageselected.value, priority = 2)
-wizardManager.registerWizard(UserInterfacePositionerWizard, config.misc.firstrun.value, priority = 4)
+wizardManager.registerWizard(VideoWizard, config.misc.videowizardenabled.value, priority = 5)
+wizardManager.registerWizard(LanguageWizard, config.misc.languageselected.value, priority = 10)
+wizardManager.registerWizard(UserInterfacePositionerWizard, config.misc.firstrun.value, priority = 15)
 wizardManager.registerWizard(StartWizard, config.misc.firstrun.value, priority = 20)


### PR DESCRIPTION
This Pull and the change to plugin.py in ViX plugin enables a flashed image to extract the language in use from a ViX backup and go straight to the Restore Wizard in the language in use.
If no backup is detected then the code is as current.