### PR TITLE
Enable remote key translations for receivers with named remotes e.g. GigaBlue

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -3,6 +3,7 @@ SUBDIRS = fonts keymaps
 dist_pkgdata_DATA = \
 	encoding.conf \
 	keymap.xml \
+	keytranslation.xml \
 	menu.xml \
 	black.mvi \
 	rcpositions.xml \

--- a/data/keytranslation.xml
+++ b/data/keytranslation.xml
@@ -1,0 +1,7 @@
+<keymap>
+      <translate>
+              <device name="gigablue remote control">
+                      <key from="KEY_OPTION" to="KEY_SUBTITLE"/>
+              </device>
+      </translate>
+</keymap>

--- a/data/keytranslation.xml
+++ b/data/keytranslation.xml
@@ -1,7 +1,7 @@
 <keymap>
       <translate>
               <device name="gigablue remote control">
-                      <key from="KEY_OPTION" to="KEY_SUBTITLE"/>
+			<key from="KEY_OPTION" to="KEY_HELP"/>
               </device>
       </translate>
 </keymap>

--- a/keymapparser.py
+++ b/keymapparser.py
@@ -13,6 +13,23 @@ class KeymapError(Exception):
 	def __str__(self):
 		return self.msg
 
+def getKeyId(id):
+	if len(id) == 1:
+		keyid = ord(id) | 0x8000
+	elif id[0] == '\\':
+		if id[1] == 'x':
+			keyid = int(id[2:], 0x10) | 0x8000
+		elif id[1] == 'd':
+			keyid = int(id[2:]) | 0x8000
+		else:
+			raise KeymapError("[keymapparser] key id '" + str(id) + "' is neither hex nor dec")
+	else:
+		try:
+			keyid = KEYIDS[id]
+		except:
+			raise KeymapError("[keymapparser] key id '" + str(id) + "' is illegal")
+	return keyid
+
 def parseKeys(context, filename, actionmap, device, keys):
 	for x in keys.findall("key"):
 		get_attr = x.attrib.get
@@ -24,50 +41,65 @@ def parseKeys(context, filename, actionmap, device, keys):
 
 		flags = sum(map(flag_ascii_to_id, flags))
 
-		assert mapto, "%s: must specify mapto in context %s, id '%s'" % (filename, context, id)
-		assert id, "%s: must specify id in context %s, mapto '%s'" % (filename, context, mapto)
-		assert flags, "%s: must specify at least one flag in context %s, id '%s'" % (filename, context, id)
+		assert mapto, "[keymapparser] %s: must specify mapto in context %s, id '%s'" % (filename, context, id)
+		assert id, "[keymapparser] %s: must specify id in context %s, mapto '%s'" % (filename, context, mapto)
+		assert flags, "[keymapparser] %s: must specify at least one flag in context %s, id '%s'" % (filename, context, id)
 
-		if len(id) == 1:
-			keyid = ord(id) | 0x8000
-		elif id[0] == '\\':
-			if id[1] == 'x':
-				keyid = int(id[2:], 0x10) | 0x8000
-			elif id[1] == 'd':
-				keyid = int(id[2:]) | 0x8000
-			else:
-				raise KeymapError("[Keymapparser] key id '" + str(id) + "' is neither hex nor dec")
-		else:
-			try:
-				keyid = KEYIDS[id]
-			except:
-				raise KeymapError("[Keymapparser] key id '" + str(id) + "' is illegal")
-#				print context + "::" + mapto + " -> " + device + "." + hex(keyid)
+		keyid = getKeyId(id)
+#		print "[keymapparser] " + context + "::" + mapto + " -> " + device + "." + hex(keyid)
 		actionmap.bindKey(filename, device, keyid, flags, context, mapto)
 		addKeyBinding(filename, keyid, context, mapto, flags)
+
+def parseTrans(filename, actionmap, device, keys):
+	for x in keys.findall("toggle"):
+		get_attr = x.attrib.get
+		toggle_key = get_attr("from")
+		toggle_key = getKeyId(toggle_key)
+		actionmap.bindToggle(filename, device, toggle_key)
+
+	for x in keys.findall("key"):
+		get_attr = x.attrib.get
+		keyin = get_attr("from")
+		keyout = get_attr("to")
+		toggle = get_attr("toggle") or "0"
+		assert keyin, "[keymapparser] %s: must specify key to translate from '%s'" % (filename, keyin)
+		assert keyout, "[keymapparser] %s: must specify key to translate to '%s'" % (filename, keyout)
+
+		keyin  = getKeyId(keyin)
+		keyout = getKeyId(keyout)
+		toggle = int(toggle)
+		actionmap.bindTranslation(filename, device, keyin, keyout, toggle)
 
 def readKeymap(filename):
 	p = enigma.eActionMap.getInstance()
 	assert p
 
-	source = open(filename)
+	try:
+		source = open(filename)
+	except:
+		print "[keymapparser] keymap file " + filename + " not found"
+		return
 
 	try:
 		dom = xml.etree.cElementTree.parse(source)
 	except:
-		raise KeymapError("[Keymapparser] keymap %s not well-formed." % filename)
+		raise KeymapError("[keymapparser] keymap %s not well-formed." % filename)
 
 	source.close()
 	keymap = dom.getroot()
 
 	for cmap in keymap.findall("map"):
 		context = cmap.attrib.get("context")
-		assert context, "map must have context"
+		assert context, "[keymapparser] map must have context"
 
 		parseKeys(context, filename, p, "generic", cmap)
 
 		for device in cmap.findall("device"):
 			parseKeys(context, filename, p, device.attrib.get("name"), device)
+
+	for ctrans in keymap.findall("translate"):
+		for device in ctrans.findall("device"):
+			parseTrans(filename, p, device.attrib.get("name"), device)
 
 def removeKeymap(filename):
 	p = enigma.eActionMap.getInstance()

--- a/lib/actions/action.h
+++ b/lib/actions/action.h
@@ -5,7 +5,8 @@
 
 #include <lib/python/python.h>
 #include <string>
-#include <map>
+#include <map>    
+#include <vector>
 
 class eWidget;
 
@@ -29,7 +30,10 @@ public:
 	void unbindAction(const std::string &context, SWIG_PYOBJECT(ePyObject) function);
 
 	void bindKey(const std::string &domain, const std::string &device, int key, int flags, const std::string &context, const std::string &action);
+	void bindTranslation(const std::string &domain, const std::string &device, int keyin, int keyout, int toggle);
+	void bindToggle(const std::string &domain, const std::string &device, int togglekey);
 	void unbindNativeKey(const std::string &context, int action);
+	void unbindPythonKey(const std::string &context, int key, const std::string &action);
 	void unbindKeyDomain(const std::string &domain);
 
 	void keyPressed(const std::string &device, int key, int flags);
@@ -55,6 +59,21 @@ private:
 	};
 
 	std::multimap<int64_t, eActionBinding> m_bindings;
+
+	struct eTranslationBinding
+	{
+		int m_keyin;
+		int m_keyout;
+		int m_toggle;
+		std::string m_domain;
+	};
+	struct eDeviceBinding
+	{
+		int m_togglekey;
+		int m_toggle;
+		std::vector<eTranslationBinding> m_translations;
+	};
+	std::map <std::string, eDeviceBinding> m_rcDevices;
 
 	friend struct compare_string_keybind_native;
 	struct eNativeKeyBinding

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -777,6 +777,7 @@ def InitUsageConfig():
 		config.usage.output_12V.addNotifier(set12VOutput, immediate_feedback=False)
 
 	config.usage.keymap = ConfigText(default = eEnv.resolve("${datadir}/enigma2/keymap.xml"))
+	config.usage.keytrans = ConfigText(default = eEnv.resolve("${datadir}/enigma2/keytranslation.xml"))
 
 	config.network = ConfigSubsection()
 

--- a/mytest.py
+++ b/mytest.py
@@ -649,6 +649,7 @@ Components.NetworkTime.AutoNTPSync()
 profile("keymapparser")
 import keymapparser
 keymapparser.readKeymap(config.usage.keymap.value)
+keymapparser.readKeymap(config.usage.keytrans.value)
 
 profile("Network")
 import Components.Network


### PR DESCRIPTION
Following a question from Abu on providing a Help key on the Giga remote, I tried the usual change in Confugure.ac (which didn't work) and then remembered this old(2015) OpenPli change that was then enhanced by OpenATV and allows a simple process to change  keys.(Its been on my Git since the Giga4K was 1st shipped)
Instructions are in the arn354 commit heading 
Its currently setup to change on the Giga remote, option key -> help key