### PR TITLE
Fix subtitle runahead on recordings

### DIFF
--- a/lib/gui/esubtitle.cpp
+++ b/lib/gui/esubtitle.cpp
@@ -119,7 +119,7 @@ void eSubtitleWidget::setPage(const eDVBTeletextSubtitlePage &p)
 
 void eSubtitleWidget::setPage(const eDVBSubtitlePage &p)
 {
-	eDebug("[eSubtitleWidget] setPage");
+	//eDebug("[eSubtitleWidget] setPage");
 	m_dvb_page = p;
 	invalidate(m_visible_region); // invalidate old visible regions
 	m_visible_region.rects.clear();
@@ -141,7 +141,7 @@ void eSubtitleWidget::setPage(const eDVBSubtitlePage &p)
 			line++;
 		}
 		eDebug("[eSubtitleWidget] add %d %d %d %d", it->m_position.x(), it->m_position.y(), it->m_pixmap->size().width(), it->m_pixmap->size().height());
-		eDebug("[eSubtitleWidget] disp width %d, disp height %d", p.m_display_size.width(), p.m_display_size.height());
+		//eDebug("[eSubtitleWidget] disp width %d, disp height %d", p.m_display_size.width(), p.m_display_size.height());
 		eRect r = eRect(it->m_position, it->m_pixmap->size());
 		r.scale(size().width(), p.m_display_size.width(), size().height(), p.m_display_size.height());
 		m_visible_region |= r;


### PR DESCRIPTION
Some receivers have a bug in the file drivers that deliver subtitles on playback of records completely out of sync with the video, making them unusable. This PR slightly adjusts the bad timing handler to treat subtitles that have been delivered too early by the filesystem as valid and to queue them up for showing later at the appropriate time. The handling of subtitles that arrive too late remains unchanged.

The original fixes for timing issues can be seen in these commits:
- https://github.com/OpenViX/enigma2/commit/f784155
- https://github.com/OpenViX/enigma2/commit/99473c5

If anyone with access to the Travel Channel can test, that'd be appreciated; the first commit states that the changes were added for problems on that channel.