### PR TITLE
About Devices - correct total freespace on a disk

### DIFF
--- a/lib/python/Components/Harddisk.py
+++ b/lib/python/Components/Harddisk.py
@@ -204,6 +204,20 @@ class Harddisk:
 				pass
 		return -1
 
+	def Totalfree(self):
+		mediapath = [ ]
+		freetot = 0 
+		for parts in getProcMounts():
+			if os.path.realpath(parts[0]).startswith(self.dev_path):
+				mediapath.append(parts[1])
+		for mpath in mediapath:
+			try:
+				stat = os.statvfs(mpath)
+				freetot += (stat.f_bfree/1000) * (stat.f_bsize/1000)
+			except:
+				pass
+		return	freetot 
+
 	def numPartitions(self):
 		numPart = -1
 		if self.devtype == DEVTYPE_UDEV:

--- a/lib/python/Screens/About.py
+++ b/lib/python/Screens/About.py
@@ -315,7 +315,7 @@ class Devices(Screen):
 				if "ATA" in hddp:
 					hddp = hddp.replace('ATA', '')
 					hddp = hddp.replace('Internal', 'ATA Bus ')
-				free = hdd.free()
+				free = hdd.Totalfree()
 				if ((float(free) / 1024) / 1024) >= 1:
 					freeline = _("Free: ") + str(round(((float(free) / 1024) / 1024), 2)) + _("TB")
 				elif (free / 1024) >= 1:


### PR DESCRIPTION
When a disk contains multiple partitions the original code only provided freespace on the 1st partition - this change resolves this situation. 