### PR TITLE
Add quick subtitle toggle feature

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -315,7 +315,8 @@
 	</map>
 
 	<map context="InfobarSubtitleSelectionActions">
-		<key id="KEY_SUBTITLE" mapto="subtitleSelection" flags="m"/>
+		<key id="KEY_SUBTITLE" mapto="subtitleSelection" flags="b"/>
+		<key id="KEY_SUBTITLE" mapto="toggleDefaultSubtitles" flags="l"/>
 	</map>
 
 	<map context="InfobarSubserviceSelectionActions">
@@ -966,6 +967,7 @@
 		<key id="KEY_HELP" mapto="displayHelp" flags="b"/>
 		<key id="KEY_HELP" mapto="displayHelp_long" flags="l"/>
 		<key id="KEY_SUBTITLE" mapto="subtitle" flags="b"/>
+		<key id="KEY_SUBTITLE" mapto="subtitle_long" flags="l"/>
 		<key id="KEY_MENU" mapto="mainMenu" flags="b"/>
 		<key id="KEY_INFO" mapto="info" flags="b"/>
 		<key id="KEY_INFO" mapto="info_long" flags="l"/>
@@ -995,6 +997,7 @@
 		<key id="KEY_PREVIOUSSONG" mapto="rewind" flags="b"/>
 		<key id="KEY_NEXTSONG" mapto="fastforward" flags="b"/>
 		<key id="KEY_SCREEN" mapto="activatePiP" flags="b"/>
+		<key id="KEY_SCREEN" mapto="activatePiP_long" flags="l"/>
 		<key id="KEY_PROGRAM" mapto="timer" flags="b"/>
 		<key id="KEY_PLAYPAUSE" mapto="playpause" flags="m"/>
 		<key id="KEY_LIST" mapto="playlist" flags="b"/>

--- a/lib/python/Screens/ButtonSetup.py
+++ b/lib/python/Screens/ButtonSetup.py
@@ -42,6 +42,7 @@ ButtonSetupKeys = [	(_("Red"), "red", "Infobar/openSingleServiceEPG/1"),
 	(_("Help"), "displayHelp", ""),
 	(_("Help long"), "displayHelp_long", ""),
 	(_("Subtitle"), "subtitle", ""),
+	(_("Subtitle Long"), "subtitle_long", ""),
 	(_("Menu"), "mainMenu", ""),
 	(_("List/Fav/PVR"), "list", ""),
 	(_("List/Fav/PVR") + " " + _("long"), "list_long", ""),
@@ -61,6 +62,7 @@ ButtonSetupKeys = [	(_("Red"), "red", "Infobar/openSingleServiceEPG/1"),
 	(_("Skip back"), "skip_back", ""),
 	(_("Skip forward"), "skip_forward", ""),
 	(_("activatePiP"), "activatePiP", ""),
+	(_("activatePiP long"), "activatePiP_long", ""),
 	(_("Timer"), "timer", ""),
 	(_("Playlist"), "playlist", ""),
 	(_("Timeshift"), "timeshift", ""),
@@ -127,6 +129,7 @@ def getButtonSetupFunctions():
 	ButtonSetupFunctions.append((_("Show multi EPG"), "Infobar/openMultiServiceEPG", "EPG"))
 	ButtonSetupFunctions.append((_("Show select audio track"), "Infobar/audioSelection", "InfoBar"))
 	ButtonSetupFunctions.append((_("Show subtitle selection"), "Infobar/subtitleSelection", "InfoBar"))
+	ButtonSetupFunctions.append((_("Toggle default subtitles"), "Infobar/toggleDefaultSubtitles", "InfoBar"))
 	ButtonSetupFunctions.append((_("Switch to radio mode"), "Infobar/showRadio", "InfoBar"))
 	ButtonSetupFunctions.append((_("Switch to TV mode"), "Infobar/showTv", "InfoBar"))
 	ButtonSetupFunctions.append((_("Instant record"), "Infobar/instantRecord", "InfoBar"))

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -4027,6 +4027,7 @@ class InfoBarSubtitleSupport(object):
 		self["SubtitleSelectionAction"] = HelpableActionMap(self, "InfobarSubtitleSelectionActions",
 			{
 				"subtitleSelection": (self.subtitleSelection, _("Subtitle selection...")),
+				"toggleDefaultSubtitles": (self.toggleDefaultSubtitles, _("Toggle the default subtitles"))
 			})
 
 		self.selected_subtitle = None
@@ -4087,17 +4088,31 @@ class InfoBarSubtitleSupport(object):
 				self.enableSubtitle(cachedsubtitle)
 				self.doCenterDVBSubs()
 
-	def enableSubtitle(self, selectedSubtitle):
+	def toggleDefaultSubtitles(self):
 		subtitle = self.getCurrentServiceSubtitle()
-		self.selected_subtitle = selectedSubtitle
-		if subtitle and self.selected_subtitle:
-			subtitle.enableSubtitles(self.subtitle_window.instance, self.selected_subtitle)
-			self.subtitle_window.show()
-			self.doCenterDVBSubs()
+		subtitlelist = subtitle and subtitle.getSubtitleList()
+		if subtitlelist is None or len(subtitlelist) == 0:
+			self.subtitle_window.showMessage(_("No subtitles available"), True)
+		elif self.selected_subtitle:
+			self.enableSubtitle(None)
+			self.subtitle_window.showMessage(_("Subtitles off"), True)
+			self.selected_subtitle = None
 		else:
-			if subtitle:
-				subtitle.disableSubtitles(self.subtitle_window.instance)
-			self.subtitle_window.hide()
+			self.enableSubtitle(subtitlelist[0])
+			self.subtitle_window.showMessage(_("Subtitles on"), False)
+
+	def enableSubtitle(self, newSubtitle):
+		if self.selected_subtitle != newSubtitle:
+			subtitle = self.getCurrentServiceSubtitle()
+			self.selected_subtitle = newSubtitle
+			if subtitle and newSubtitle:
+				subtitle.enableSubtitles(self.subtitle_window.instance, newSubtitle)
+				self.subtitle_window.show()
+				self.doCenterDVBSubs()
+			else:
+				if subtitle:
+					subtitle.disableSubtitles(self.subtitle_window.instance)
+				self.subtitle_window.hide()
 
 	def restartSubtitle(self):
 		if self.selected_subtitle:

--- a/lib/python/Screens/SubtitleDisplay.py
+++ b/lib/python/Screens/SubtitleDisplay.py
@@ -1,6 +1,31 @@
 from Screens.Screen import Screen
+from Components.Label import Label
+from enigma import eTimer, getDesktop
 
 class SubtitleDisplay(Screen):
-	pass
+	def __init__(self, session):
+		Screen.__init__(self, session)
+		self['notification'] = Label("")
+		self['notification'].hide()
 
-	# not really much to do...
+	def showMessage(self, text, hideScreen):
+		label = self['notification']
+		label.instance.setNoWrap(1)
+		label.setText(text)
+		label.instance.setHAlign(1)
+		label.instance.setVAlign(1)
+		size = label.getSize()
+		label.resize(size[0]+40, size[1])
+		label.move((getDesktop(0).size().width()-size[0]-40) // 2, getDesktop(0).size().height() - size[1] - 30)
+		label.show()
+		self.show()
+		self.hideTimer = eTimer()
+		self.hideTimer.callback.append(self.hideScreen if hideScreen else self.hideMessage)
+		self.hideTimer.start(2000, True)
+
+	def hideMessage(self):
+		self['notification'].hide()
+
+	def hideScreen(self):
+		self['notification'].hide()
+		self.hide()

--- a/lib/python/Screens/SubtitleDisplay.py
+++ b/lib/python/Screens/SubtitleDisplay.py
@@ -1,31 +1,62 @@
 from Screens.Screen import Screen
 from Components.Label import Label
-from enigma import eTimer, getDesktop
+from enigma import eTimer, getDesktop, eActionMap, gFont
+from Components.ActionMap import ActionMap
+from sys import maxint
+import skin
 
 class SubtitleDisplay(Screen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
-		self['notification'] = Label("")
-		self['notification'].hide()
+		eActionMap.getInstance().bindAction('', -maxint - 1, self.keypress)
 
-	def showMessage(self, text, hideScreen):
-		label = self['notification']
+		self.messageShown = False
+		self['message'] = Label()
+		self['message'].hide()
+
+		if self.layoutFinished not in self.onLayoutFinish:
+			self.onLayoutFinish.append(self.layoutFinished)
+
+	def __removeAction(self):
+		eActionMap.getInstance().unbindAction('', self.keypress)
+
+	def layoutFinished(self):
+		# Not expecting skins to contain this element
+		label = self['message']
+		label.instance.setFont(gFont("Regular", 50))
+		label.instance.setZPosition(1)
 		label.instance.setNoWrap(1)
-		label.setText(text)
 		label.instance.setHAlign(1)
 		label.instance.setVAlign(1)
+
+	def showMessage(self, message, hideScreen):
+		padding = (40,10)
+		label = self['message']
+		label.setText(message)
 		size = label.getSize()
-		label.resize(size[0]+40, size[1])
-		label.move((getDesktop(0).size().width()-size[0]-40) // 2, getDesktop(0).size().height() - size[1] - 30)
+		label.resize(size[0]+padding[0]*2, size[1]+padding[1]*2)
+		label.move((getDesktop(0).size().width()-size[0]-padding[0]) // 2, getDesktop(0).size().height()-size[1]-padding[1]*2-30)
 		label.show()
+		self.messageShown = True
 		self.show()
 		self.hideTimer = eTimer()
 		self.hideTimer.callback.append(self.hideScreen if hideScreen else self.hideMessage)
 		self.hideTimer.start(2000, True)
 
+	def keypress(self, key, flag):
+		# Releasing the subtitle button after a long press unintentionally pops up the subtitle dialog,
+		# This blocks it without causing issues for anyone that sets the buttons up the other way round
+		if self.messageShown:
+			# whilst the notification is shown any keydown event dismisses the notification
+			if flag == 0:
+				self.hideMessage()
+			else: # any key repeat or keyup event is discarded
+				return 1
+
 	def hideMessage(self):
-		self['notification'].hide()
+		self.messageShown = False
+		self['message'].hide()
 
 	def hideScreen(self):
-		self['notification'].hide()
+		self.hideMessage()
 		self.hide()


### PR DESCRIPTION
This change allows a long press of the subtitles button to toggle subtitles on and off. If there's more than one subtitle track, the first subtitle track is activated. A subtitle style message is shown onscreen when toggling the subtitle to indicate the new status of subtitles - on or off, or if no subtitles are available. The button used is configurable, and on my installation, I'm using a short press for toggle, a long press for the subtitles dialog.