### PR TITLE
Multiboot rebuild- Part 1(Part2 in ViX plugin vix-core)

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -244,7 +244,7 @@ self.session.open(HdmiCECSetupScreen)
 			<item text="Standby" entryID="standby"><screen module="Standby" screen="Standby"/></item>
 			<item text="Restart GUI" entryID="restart_enigma"><screen module="Standby" screen="TryQuitMainloop">3</screen></item>
 			<item text="Reboot" entryID="restart"><screen module="Standby" screen="TryQuitMainloop">2</screen></item>
-			<item text="Multiboot" entryID="multiboot" requires="canMultiBoot"><screen module="MBRestart" screen="MultiBoot">1</screen></item>
+			<item text="Multiboot Image Selector" entryID="multiboot" requires="canMultiBoot"><screen module="MultiBootSelector" screen="MultiBootSelector">1</screen></item>
 			<item text="H9SDroot" entryID="H9SDswap" requires="HasH9SD"><screen module="H9SDswap" screen="H9SDswap">1</screen></item>
 			<item text="Deep standby" requires="DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
 			<item text="Shut down" requires="!DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>

--- a/data/menu.xml
+++ b/data/menu.xml
@@ -244,7 +244,7 @@ self.session.open(HdmiCECSetupScreen)
 			<item text="Standby" entryID="standby"><screen module="Standby" screen="Standby"/></item>
 			<item text="Restart GUI" entryID="restart_enigma"><screen module="Standby" screen="TryQuitMainloop">3</screen></item>
 			<item text="Reboot" entryID="restart"><screen module="Standby" screen="TryQuitMainloop">2</screen></item>
-			<item text="Multiboot Image Selector" entryID="multiboot" requires="canMultiBoot"><screen module="MultiBootSelector" screen="MultiBootSelector">1</screen></item>
+			<item text="Multiboot Image Selector" entryID="multiboot" requires="canMultiBoot"><screen module="MultiBootSelector" screen="MultiBoot">1</screen></item>
 			<item text="H9SDroot" entryID="H9SDswap" requires="HasH9SD"><screen module="H9SDswap" screen="H9SDswap">1</screen></item>
 			<item text="Deep standby" requires="DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
 			<item text="Shut down" requires="!DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>

--- a/lib/python/Components/Console.py
+++ b/lib/python/Components/Console.py
@@ -23,6 +23,8 @@ class ConsoleItem:
 		retval = self.container.execute(*cmd)
 		if retval:
 			self.finishedCB(retval)
+		if callback is None:
+			os.waitpid(self.container.getPID(), 0)
 	def dataAvailCB(self, data):
 		self.appResults.append(data)
 	def finishedCB(self, retval):

--- a/lib/python/Components/Console.py
+++ b/lib/python/Components/Console.py
@@ -1,4 +1,4 @@
-import enigma
+import enigma, ctypes, os
 
 class ConsoleItem:
 	def __init__(self, containers, cmd, callback, extra_args):
@@ -24,7 +24,13 @@ class ConsoleItem:
 		if retval:
 			self.finishedCB(retval)
 		if callback is None:
-			os.waitpid(self.container.getPID(), 0)
+			pid = self.container.getPID()
+			print "[Console] pid = %s" %pid
+			try:
+				os.waitpid(pid, 0)
+			except OSError:
+				pass
+
 	def dataAvailCB(self, data):
 		self.appResults.append(data)
 	def finishedCB(self, retval):

--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -10,7 +10,7 @@ SystemInfo = { }
 
 #FIXMEE...
 
-from Tools.Multiboot import getMultibootStartupDevice, getMultibootslots
+from Tools.Multiboot import getMBbootdevice, getMultibootslots
 
 def getNumVideoDecoders():
 	idx = 0
@@ -90,7 +90,7 @@ SystemInfo["Has24hz"] = fileCheck("/proc/stb/video/videomode_24hz")
 SystemInfo["HasRootSubdir"] = fileHas("/proc/cmdline", "rootsubdir=")
 SystemInfo["RecoveryMode"] = SystemInfo["HasRootSubdir"] and getMachineBuild() not in ('hd51','h7') or fileCheck("/proc/stb/fp/boot_mode")
 SystemInfo["AndroidMode"] = SystemInfo["RecoveryMode"] and getMachineBuild() in ('multibox',)
-SystemInfo["MultibootStartupDevice"] = getMultibootStartupDevice()
+SystemInfo["MBbootdevice"] = getMBbootdevice()
 SystemInfo["canMultiBoot"] = getMultibootslots()
 SystemInfo["canBackupEMC"] = getMachineBuild() in ('hd51','h7') and ('disk.img', 'mmcblk0p1') or getMachineBuild() in ('osmio4k', 'osmio4kplus', 'osmini4k') and ('emmc.img', 'mmcblk1p1') or getMachineBuild() in ('viper4k', 'gbmv200','sf8008','beyonwizv2') and ('usb_update.bin','none')
 SystemInfo["HasHiSi"] = pathExists('/proc/hisi')

--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -92,7 +92,7 @@ SystemInfo["RecoveryMode"] = SystemInfo["HasRootSubdir"] and getMachineBuild() n
 SystemInfo["AndroidMode"] = SystemInfo["RecoveryMode"] and getMachineBuild() in ('multibox',)
 SystemInfo["MBbootdevice"] = getMBbootdevice()
 SystemInfo["canMultiBoot"] = getMultibootslots()
-SystemInfo["canBackupEMC"] = getMachineBuild() in ('hd51','h7') and ('disk.img', 'mmcblk0p1') or getMachineBuild() in ('osmio4k', 'osmio4kplus', 'osmini4k') and ('emmc.img', 'mmcblk1p1') or getMachineBuild() in ('viper4k', 'gbmv200','sf8008','beyonwizv2') and ('usb_update.bin','none')
+SystemInfo["canBackupEMC"] = getMachineBuild() in ('hd51','h7') and ('disk.img', '%s' %SystemInfo["MBbootdevice"]) or getMachineBuild() in ('osmio4k', 'osmio4kplus', 'osmini4k') and ('emmc.img', '%s' %SystemInfo["MBbootdevice"]) or getMachineBuild() in ('viper4k', 'gbmv200','sf8008','beyonwizv2') and ('usb_update.bin','none')
 SystemInfo["HasHiSi"] = pathExists('/proc/hisi')
 SystemInfo["canMode12"] = getMachineBuild() in ('hd51', 'h7') and ('brcm_cma=440M@328M brcm_cma=192M@768M', 'brcm_cma=520M@248M brcm_cma=200M@768M')
 SystemInfo["HasMMC"] = fileHas("/proc/cmdline", "root=/dev/mmcblk") or SystemInfo["canMultiBoot"] and fileHas("/proc/cmdline", "root=/dev/sda")

--- a/lib/python/Screens/About.py
+++ b/lib/python/Screens/About.py
@@ -1,25 +1,25 @@
-from Screen import Screen
-from Screens.SoftwareUpdate import UpdatePlugin
-from Screens.GitCommitInfo import CommitInfo
-from Components.ActionMap import ActionMap
-from Components.Button import Button
-from Components.Sources.StaticText import StaticText
-from Components.Harddisk import harddiskmanager
-from Components.NimManager import nimmanager
-from Components.About import about
-from Components.ScrollLabel import ScrollLabel
-from Components.Console import Console
-from Components.config import config
-from enigma import eTimer, getEnigmaVersionString, getDesktop
-from boxbranding import getMachineBrand, getMachineBuild, getMachineName, getImageVersion, getImageType, getImageBuild, getDriverDate, getImageDevBuild
-from Components.Pixmap import MultiPixmap
-from Components.Network import iNetwork
-from Components.SystemInfo import SystemInfo
-from Tools.StbHardware import getFPVersion
-from Tools.Multiboot import GetCurrentImage, GetCurrentImageMode
-from Tools.Directories import fileExists, fileCheck, pathExists
 from os import path
 from re import search
+from enigma import eTimer, getEnigmaVersionString, getDesktop
+from boxbranding import getMachineBrand, getMachineBuild, getMachineName, getImageVersion, getImageType, getImageBuild, getDriverDate, getImageDevBuild
+from Components.About import about
+from Components.ActionMap import ActionMap
+from Components.Button import Button
+from Components.config import config
+from Components.Console import Console
+from Components.Harddisk import harddiskmanager
+from Components.Network import iNetwork
+from Components.NimManager import nimmanager
+from Components.Pixmap import MultiPixmap
+from Components.ScrollLabel import ScrollLabel
+from Components.Sources.StaticText import StaticText
+from Components.SystemInfo import SystemInfo
+from Screen import Screen
+from Screens.GitCommitInfo import CommitInfo
+from Screens.SoftwareUpdate import UpdatePlugin
+from Tools.Directories import fileExists, fileCheck, pathExists
+from Tools.Multiboot import GetCurrentImage, GetCurrentImageMode
+from Tools.StbHardware import getFPVersion
 import skin
 
 class About(Screen):

--- a/lib/python/Screens/About.py
+++ b/lib/python/Screens/About.py
@@ -88,26 +88,24 @@ class About(Screen):
 		AboutText += _("Image:\t%s.%s%s (%s)\n") % (getImageVersion(), getImageBuild(), imageSubBuild, getImageType().title())
 
 		if SystemInfo["HasH9SD"]:
-			f = open('/sys/firmware/devicetree/base/chosen/bootargs', 'r').read()
-			if "rootfstype=ext4" in f:
-				part = "        - SD card in use for Image root \n"
+			if "rootfstype=ext4" in open('/sys/firmware/devicetree/base/chosen/bootargs', 'r').read():
+				part = "        - SD card in use for Image root \n" 
 			else:
 				part = "        - eMMC slot in use for Image root \n"
 			AboutText += _("%s") % part
 
 
 		if SystemInfo["canMultiBoot"]:
-			slot = image = GetCurrentImage()
+			slot = image= GetCurrentImage()
 			part = "eMMC slot %s" %slot
 			bootmode = ""
 			if SystemInfo["canMode12"]:
-				bootmode = "bootmode = %s" %GetCurrentImageMode()
-			if SystemInfo["HasSDmmc"]:
-				slot += 1
-				if image != 0:
-					part = "SDC slot %s (%s%s) " %(image, SystemInfo["canMultiBoot"][2], image*2)
-				else:
-					part = "eMMC slot %s" %slot
+				bootmode = "bootmode = %s" %GetCurrentImageMode()		
+			print "[About] HasHiSi = %s, slot = %s" %(SystemInfo["HasHiSi"], slot)
+			if SystemInfo["HasHiSi"]:
+				if slot != 1:
+					image =-1
+					part = "SDcard slot %s (%s) " %(image, SystemInfo["canMultiBoot"][slot]['device'])
 			AboutText += _("Image Slot:\t%s") % "STARTUP_" + str(slot) + "  " + part + " " + bootmode + "\n"
 
 		if getMachineName() in ('ET8500') and path.exists('/proc/mtd'):

--- a/lib/python/Screens/MultiBootSelector.py
+++ b/lib/python/Screens/MultiBootSelector.py
@@ -1,0 +1,151 @@
+from os import mkdir, path
+from shutil import copyfile
+from boxbranding import getMachineBuild, getMachineMtdRoot
+from Components.ActionMap import ActionMap
+from Components.ChoiceList import ChoiceList, ChoiceEntryComponent
+from Components.Console import Console
+from Components.Label import Label
+from Components.Sources.StaticText import StaticText
+from Components.SystemInfo import SystemInfo
+from Screens.MessageBox import MessageBox
+from Screens.Screen import Screen
+from Screens.Standby import TryQuitMainloop
+from Tools.BoundFunction import boundFunction
+from Tools.Directories import fileExists, fileCheck, pathExists, fileHas
+from Tools.Multiboot import GetImagelist, GetCurrentImage, GetCurrentImageMode
+
+class MultiBootSelector(Screen):
+
+	skin = """
+	<screen name="Multiboot Image Selector" position="center,center" size="750,900" flags="wfNoBorder" backgroundColor="transparent">
+		<eLabel name="b" position="0,0" size="750,700" backgroundColor="#00ffffff" zPosition="-2" />
+		<eLabel name="a" position="1,1" size="748,698" backgroundColor="#00000000" zPosition="-1" />
+		<widget source="Title" render="Label" position="60,10" foregroundColor="#00ffffff" size="480,50" halign="left" font="Regular; 28" backgroundColor="#00000000" />
+		<eLabel name="line" position="1,60" size="748,1" backgroundColor="#00ffffff" zPosition="1" />
+		<eLabel name="line2" position="1,250" size="748,4" backgroundColor="#00ffffff" zPosition="1" />
+		<widget name="config" position="2,280" size="730,380" halign="center" font="Regular; 22" backgroundColor="#00000000" foregroundColor="#00e5b243" />
+		<widget source="description" render="Label" position="2,80" size="730,30" halign="center" font="Regular; 22" backgroundColor="#00000000" foregroundColor="#00ffffff" />
+		<widget source="options" render="Label" position="2,130" size="730,60" halign="center" font="Regular; 22" backgroundColor="#00000000" foregroundColor="#00ffffff" />
+		<widget source="key_red" render="Label" position="30,200" size="150,30" noWrap="1" zPosition="1" valign="center" font="Regular; 20" halign="left" backgroundColor="#00000000" foregroundColor="#00ffffff" />
+		<widget source="key_green" render="Label" position="200,200" size="150,30" noWrap="1" zPosition="1" valign="center" font="Regular; 20" halign="left" backgroundColor="#00000000" foregroundColor="#00ffffff" />
+		<eLabel position="20,200" size="6,40" backgroundColor="#00e61700" /> <!-- Should be a pixmap -->
+		<eLabel position="190,200" size="6,40" backgroundColor="#0061e500" /> <!-- Should be a pixmap -->
+	</screen>
+	"""
+
+	def __init__(self, session, *args):
+		Screen.__init__(self, session)
+		screentitle = _("Multiboot Image Selector")
+		self["key_red"] = StaticText(_("Cancel"))
+		if not SystemInfo["HasHiSi"] or SystemInfo["HasHiSi"] and pathExists('/dev/sda4'):
+			self["description"] = StaticText(_("Use the cursor keys to select an installed image and then Reboot button."))
+		else:
+			self["description"] = StaticText(_("SDcard is not initialised for multiboot - Exit and use ViX MultiBoot Manager to initialise"))			
+		self["options"] = StaticText(_(" "))
+		self["key_green"] = StaticText(_("Reboot"))
+		if SystemInfo["canMode12"]:
+			self["options"] = StaticText(_("Mode 1 suppports Kodi, PiP may not work.\nMode 12 supports PiP, Kodi may not work."))
+		self["config"] = ChoiceList(list=[ChoiceEntryComponent('',((_("Retrieving image slots - Please wait...")), "Queued"))])
+		imagedict = []
+		self.getImageList = None
+		self.title = screentitle
+		self["actions"] = ActionMap(["OkCancelActions", "ColorActions", "DirectionActions", "KeyboardInputActions", "MenuActions"],
+		{
+			"red": boundFunction(self.close, None),
+			"green": self.reboot,
+			"ok": self.reboot,
+			"cancel": boundFunction(self.close, None),
+			"up": self.keyUp,
+			"down": self.keyDown,
+			"left": self.keyLeft,
+			"right": self.keyRight,
+			"upRepeated": self.keyUp,
+			"downRepeated": self.keyDown,
+			"leftRepeated": self.keyLeft,
+			"rightRepeated": self.keyRight,
+			"menu": boundFunction(self.close, True),
+		}, -1)
+		self.callLater(self.getBootOptions)
+
+	def cancel(self, value=None):
+		self.container = Console()
+		self.container.ePopen('umount /tmp/startupmount', boundFunction(self.unmountCallback, value))
+
+	def unmountCallback(self, value, data=None, retval=None, extra_args=None):
+		self.container.killAll()
+		if not path.ismount('/tmp/startupmount'):
+			rmdir('/tmp/startupmount')
+		self.close(value)
+
+	def getBootOptions(self, value=None):
+		self.container = Console()
+		if path.isdir('/tmp/startupmount'):
+			self.getImagesList()
+		else:
+			mkdir('/tmp/startupmount')
+			self.container.ePopen('mount %s /tmp/startupmount' % SystemInfo["MBbootdevice"], self.getImagesList)
+	def getImagesList(self, data=None, retval=None, extra_args=None):
+		self.container.killAll()
+		self.getImageList = GetImagelist(self.getImagelistCallback)
+
+	def getImagelistCallback(self, imagedict):
+		list = []
+		mode = GetCurrentImageMode() or 0
+		currentimageslot = GetCurrentImage()
+		print "[MultiBoot Restart] reboot1 slot:\n", currentimageslot 
+		if imagedict:
+			for index, x in enumerate(sorted(imagedict.keys())):
+				if imagedict[x]["imagename"] != _("Empty slot"):
+					if not SystemInfo["canMode12"]:
+						list.append(ChoiceEntryComponent('',((_("slot%s -%s (current image)") if x == currentimageslot else _("slot%s -%s")) % (x, imagedict[x]['imagename']), x)))
+					else:
+						list.insert(index, ChoiceEntryComponent('',((_("slot%s - %s mode 1 (current image)") if x == currentimageslot and mode != 12 else _("slot%s - %s mode 1")) % (x, imagedict[x]['imagename']), x)))
+						list.append("                                 ")
+						list.append("                                 ")
+						list.append(ChoiceEntryComponent('',((_("slot%s - %s mode 12 (current image)") if x == currentimageslot and mode == 12 else _("slot%s - %s mode 12")) % (x, imagedict[x]['imagename']), x + 12)))
+		else:
+			list.append(ChoiceEntryComponent('',((_("No images found")), "Waiter")))
+		self["config"].setList(list)
+
+	def reboot(self):
+		self.currentSelected = self["config"].l.getCurrentSelection()
+		self.slot = self.currentSelected[0][1]
+		if self.currentSelected[0][1] != "Queued":
+			if self.slot == "Recovery":
+				copyfile("/tmp/startupmount/STARTUP_RECOVERY", "/tmp/startupmount/STARTUP")
+			elif self.slot == "Android":
+				copyfile("/tmp/startupmount/STARTUP_ANDROID", "/tmp/startupmount/STARTUP")
+			else:
+				if self.slot < 12:
+					startupfile = "/tmp/startupmount/%s" % SystemInfo["canMultiBoot"][self.slot]['startupfile'].replace("boxmode=12'", "boxmode=1'")
+					copyfile(startupfile, "/tmp/startupmount/STARTUP")
+				else:
+					self.slot -=12
+					startupfile = "/tmp/startupmount/%s" % SystemInfo["canMultiBoot"][self.slot]['startupfile']
+					if "BOXMODE" not in startupfile:
+						f = open('%s' %startupfile, 'r').read().replace("boxmode=1'", "boxmode=12'").replace("%s" %SystemInfo["canMode12"][0], "%s" %SystemInfo["canMode12"][1])
+						open('/tmp/startupmount/STARTUP', 'w').write(f)
+						self.session.open(TryQuitMainloop, 2)
+					else:
+						copyfile(startupfile, "/tmp/startupmount/STARTUP")
+			self.session.open(TryQuitMainloop, 2)
+
+
+	def selectionChanged(self):
+		currentSelected = self["config"].l.getCurrentSelection()
+
+	def keyLeft(self):
+		self["config"].instance.moveSelection(self["config"].instance.moveUp)
+		self.selectionChanged()
+
+	def keyRight(self):
+		self["config"].instance.moveSelection(self["config"].instance.moveDown)
+		self.selectionChanged()
+
+	def keyUp(self):
+		self["config"].instance.moveSelection(self["config"].instance.moveUp)
+		self.selectionChanged()
+
+	def keyDown(self):
+		self["config"].instance.moveSelection(self["config"].instance.moveDown)
+		self.selectionChanged()

--- a/lib/python/Screens/MultiBootSelector.py
+++ b/lib/python/Screens/MultiBootSelector.py
@@ -14,7 +14,7 @@ from Tools.BoundFunction import boundFunction
 from Tools.Directories import fileExists, fileCheck, pathExists, fileHas
 from Tools.Multiboot import GetImagelist, GetCurrentImage, GetCurrentImageMode
 
-class MultiBootSelector(Screen):
+class MultiBoot(Screen):
 
 	skin = """
 	<screen name="Multiboot Image Selector" position="center,center" size="750,900" flags="wfNoBorder" backgroundColor="transparent">

--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -23,7 +23,6 @@ def getMBbootdevice():
 		if path.exists(device):
 			Console().ePopen('mount %s %s' % (device, Imagemount))
 			if path.isfile(path.join(Imagemount, "STARTUP")):
-				print '[Multiboot] Startupdevice found:', device
 				return device
 			Console().ePopen('umount %s' % Imagemount)
 	if not path.ismount(Imagemount):
@@ -43,7 +42,6 @@ def getMultibootslots():
 			if slotnumber.isdigit() and slotnumber not in bootslots:
 				slot = {}
 				for line in open(file).readlines():
-					print "Multiboot getMultibootslots readlines = %s " %line
 					if 'root=' in line:
 						line = line.rstrip('\n')
 						device = getparam(line, 'root')
@@ -61,7 +59,6 @@ def getMultibootslots():
 						break
 				if slot:
 					bootslots[int(slotnumber)] = slot
-		print "[multiboot1] getMultibootslots bootslots = %s" %bootslots
 		Console().ePopen('umount %s' % Imagemount)
 		if not path.ismount(Imagemount):
 			rmdir(Imagemount)

--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -44,6 +44,7 @@ def getMultibootslots():
 				slot = {}
 				for line in open(file).readlines():
 					if 'root=' in line:
+						line = line.rstrip('\n')
 						device = getparam(line, 'root')
 						if os.path.exists(device):
 							slot['device'] = device

--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -15,10 +15,17 @@ import subprocess
 
 TMP_MOUNT = '/tmp/multibootcheck'
 
-def getMultibootStartupDevice(model):
-	for device in ('/dev/block/by-name/bootoptions', '/dev/block/by-name/bootoptions', "/dev/mmcblk1p1" if model in ('osmio4k', 'osmio4kplus', 'osmini4k') else "/dev/mmcblk0p1"):
+def getMultibootStartupDevice():
+	if not os.path.isdir(TMP_MOUNT):
+		os.mkdir(TMP_MOUNT)
+	for device in ('/dev/block/by-name/bootoptions', '/dev/mmcblk0p1', '/dev/mmcblk1p1', '/dev/mmcblk0p3', '/dev/mmcblk0p4'):
 		if os.path.exists(device):
-			return device
+			Console().ePopen('mount %s %s' % (device, TMP_MOUNT))
+			if os.path.isfile(os.path.join(TMP_MOUNT, "STARTUP")):
+				return device
+			Console().ePopen('umount %s' % TMP_MOUNT)
+	if not os.path.ismount(TMP_MOUNT):
+		os.rmdir(TMP_MOUNT)
 
 def getparam(line, param):
 	return line.rsplit('%s=' % param, 1)[1].split(' ', 1)[0]
@@ -26,9 +33,6 @@ def getparam(line, param):
 def getMultibootslots():
 	bootslots = {}
 	if SystemInfo["MultibootStartupDevice"]:
-		if not os.path.isdir(TMP_MOUNT):
-			os.mkdir(TMP_MOUNT)
-		Console().ePopen('/bin/mount %s %s' % (SystemInfo["MultibootStartupDevice"], TMP_MOUNT))
 		for file in glob.glob('%s/STARTUP_*' % TMP_MOUNT):
 			slotnumber = file.rsplit('_', 3 if 'BOXMODE' in file else 1)[1]
 			if slotnumber.isdigit() and slotnumber not in bootslots:
@@ -44,7 +48,7 @@ def getMultibootslots():
 						break
 				if slot:
 					bootslots[int(slotnumber)] = slot
-		Console().ePopen('/bin/umount %s' % TMP_MOUNT)
+		Console().ePopen('umount %s' % TMP_MOUNT)
 		if not os.path.ismount(TMP_MOUNT):
 			os.rmdir(TMP_MOUNT)
 	return bootslots

--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -1,5 +1,4 @@
 from Components.SystemInfo import SystemInfo
-<<<<<<< HEAD
 from Components.Console import Console
 from boxbranding import getMachineMtdRoot
 from Tools.Directories import pathExists
@@ -92,13 +91,7 @@ class GetImagelist():
 			self.container.ePopen('umount %s' % TMP_MOUNT, self.appClosed)
 		else:
 			self.slot = self.slots.pop(0)
-			if 'rootsubdir' in SystemInfo["canMultiBoot"][self.slot]:
-				if self.slot == 1 and os.path.islink("/dev/block/by-name/linuxrootfs"):
-					self.container.ePopen('mount /dev/block/by-name/linuxrootfs %s' % TMP_MOUNT, self.appClosed)
-				else:
-					self.container.ePopen('mount /dev/block/by-name/userdata %s'% TMP_MOUNT, self.appClosed)
-			else:
-				self.container.ePopen('mount /dev/%s %s' % (SystemInfo["canMultiBoot"][self.slot]['device'], TMP_MOUNT), self.appClosed)
+			self.container.ePopen('mount %s %s' % (SystemInfo["canMultiBoot"][self.slot]['device'], TMP_MOUNT), self.appClosed)
 
 	def appClosed(self, data, retval, extra_args=None):
 		if retval == 0 and self.phase == self.MOUNT:
@@ -137,12 +130,9 @@ class GetImagelist():
 						pass
 					date = max(date, datetime.fromtimestamp(os.stat(os.path.join(target, "usr/bin/enigma2")).st_mtime).strftime('%Y-%m-%d'))
 				return "%s (%s)" % (open(os.path.join(target, "etc/issue")).readlines()[-2].capitalize().strip()[:-6], date)
-			if 'rootsubdir' in SystemInfo["canMultiBoot"][self.slot]:
-				imagedir = "%s/%s/" % (TMP_MOUNT, SystemInfo["canMultiBoot"][self.slot]['rootsubdir'])
-				if os.path.isfile('%s/usr/bin/enigma2' % imagedir):
-					self.imagelist[self.slot] = { 'imagename': getImagename(imagedir) }
-				else:
-					self.imagelist[self.slot] = { 'imagename': _("Empty slot")}
+			imagedir = "/".join(filter(None, [TMP_MOUNT, SystemInfo["canMultiBoot"][self.slot].get('rootsubdir', '')]))
+			if os.path.isfile('%s/usr/bin/enigma2' % imagedir):
+				self.imagelist[self.slot] = { 'imagename': getImagename(imagedir) }
 			else:
 				if os.path.isfile("%s/usr/bin/enigma2" % TMP_MOUNT):
 					self.imagelist[self.slot] = { 'imagename': getImagename(TMP_MOUNT) }
@@ -157,6 +147,7 @@ class GetImagelist():
 						Date = max(Date, datetime.fromtimestamp(os.stat("%s/usr/bin/enigma2" %self.OsPath).st_mtime).strftime("%d-%m-%Y"))
 					BuildVersion = "%s build date %s" % (Creator, Date)
 				self.imagelist[self.slot2] =  { 'imagename': '%s' %BuildVersion, 'part': '%s' %self.part2 }
+				self.imagelist[self.slot] = { 'imagename': _("Empty slot") }
 			self.phase = self.UNMOUNT
 			self.run()
 		elif self.slots:

--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -75,7 +75,7 @@ class GetImagelist():
 
 	def __init__(self, callback):
 		if SystemInfo["canMultiBoot"]:
-			self.slots = SystemInfo["canMultiBoot"].keys()
+			self.slots = sorted(SystemInfo["canMultiBoot"].keys())
 			self.callback = callback
 			self.imagelist = {}
 			if not os.path.isdir(TMP_MOUNT):
@@ -94,7 +94,10 @@ class GetImagelist():
 			self.slot = self.slots.pop(0)
 			self.container.ePopen('mount %s %s' % (SystemInfo["canMultiBoot"][self.slot]['device'], TMP_MOUNT), self.appClosed)
 
-	def appClosed(self, data, retval, extra_args=None):
+
+	def appClosed(self, data="", retval=0, extra_args=None):
+		if retval:
+			self.imagelist[self.slot] = { 'imagename': _("Empty slot") }
 		if retval == 0 and self.phase == self.MOUNT:
 			BuildVersion = "  "	
 			Build = " "	#ViX Build No.#
@@ -149,8 +152,12 @@ class GetImagelist():
 					BuildVersion = "%s build date %s" % (Creator, Date)
 				self.imagelist[self.slot2] =  { 'imagename': '%s' %BuildVersion, 'part': '%s' %self.part2 }
 				self.imagelist[self.slot] = { 'imagename': _("Empty slot") }
-			self.phase = self.UNMOUNT
-			self.run()
+			if self.slots and SystemInfo["canMultiBoot"][self.slot]['device'] == SystemInfo["canMultiBoot"][self.slots[0]]['device']:
+				self.slot = self.slots.pop(0)
+				self.appClosed()
+			else:
+				self.phase = self.UNMOUNT
+				self.run()
 		elif self.slots:
 			self.phase = self.MOUNT
 			self.run()

--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -134,7 +134,7 @@ class GetImagelist():
 					Dev = BuildType != "release" and " %s" % reader.getImageDevBuild() or ''
 					BuildVersion = "%s %s %s %s" % (Creator, BuildType[0:3], Build, Dev)
 				else:
-					def getImagename(target):
+					try:
 						from datetime import datetime
 						date = datetime.fromtimestamp(os.stat(os.path.join(target, "var/lib/opkg/status")).st_mtime).strftime('%Y-%m-%d')
 						if date.startswith("1970"):
@@ -143,8 +143,9 @@ class GetImagelist():
 							except:
 								pass
 							date = max(date, datetime.fromtimestamp(os.stat(os.path.join(target, "usr/bin/enigma2")).st_mtime).strftime('%Y-%m-%d'))
-						return "%s (%s)" % (open(os.path.join(target, "etc/issue")).readlines()[-2].capitalize().strip()[:-6], date)
-					BuildVersion = getImagename(imagedir)
+					except:
+						date = _("Unknown")
+					BuildVersion = "%s (%s)" % (open(os.path.join(target, "etc/issue")).readlines()[-2].capitalize().strip()[:-6], date)
 				self.imagelist[self.slot] =  { 'imagename': '%s' %BuildVersion }
 			if self.slots and SystemInfo["canMultiBoot"][self.slot]['device'] == SystemInfo["canMultiBoot"][self.slots[0]]['device']:
 				self.slot = self.slots.pop(0)

--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -16,7 +16,7 @@ import subprocess
 
 TMP_MOUNT = '/tmp/multibootcheck'
 
-def getMultibootStartupDevice():
+def getMBbootdevice():
 	if not os.path.isdir(TMP_MOUNT):
 		os.mkdir(TMP_MOUNT)
 	for device in ('/dev/block/by-name/bootoptions', '/dev/mmcblk0p1', '/dev/mmcblk1p1', '/dev/mmcblk0p3', '/dev/mmcblk0p4'):
@@ -33,8 +33,12 @@ def getparam(line, param):
 
 def getMultibootslots():
 	bootslots = {}
-	if SystemInfo["MultibootStartupDevice"]:
-		for file in glob.glob('%s/STARTUP_*' % TMP_MOUNT):
+	if SystemInfo["MBbootdevice"]:
+		if not os.path.isdir(TMP_MOUNT):
+			os.mkdir(TMP_MOUNT)
+		Console().ePopen('/bin/mount %s %s' % (SystemInfo["MBbootdevice"], TMP_MOUNT))
+		for file in glob.glob(os.path.join(TMP_MOUNT, 'STARTUP_*')):
+			print "Multiboot getMultibootslots file = %s " %file
 			slotnumber = file.rsplit('_', 3 if 'BOXMODE' in file else 1)[1]
 			if slotnumber.isdigit() and slotnumber not in bootslots:
 				slot = {}

--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -2,11 +2,9 @@ from Components.SystemInfo import SystemInfo
 from Components.Console import Console
 from boxbranding import getMachineMtdRoot
 from Tools.Directories import pathExists
-import os
+import os, glob
 import shutil
 import subprocess
-from Components.Console import Console, PosixSpawn
-import os, glob
 
 #		#default layout for 				Zgemma H7/Mut@nt HD51						 Giga4K						SF8008/trio4K
 # boot								/dev/mmcblk0p1						/dev/mmcblk0p1				/dev/mmcblk0p3
@@ -30,8 +28,7 @@ def getMultibootslots():
 	if SystemInfo["MultibootStartupDevice"]:
 		if not os.path.isdir(TMP_MOUNT):
 			os.mkdir(TMP_MOUNT)
-		postix = PosixSpawn()
-		postix.execute('mount %s %s' % (SystemInfo["MultibootStartupDevice"], TMP_MOUNT))
+		Console().ePopen('/bin/mount %s %s' % (SystemInfo["MultibootStartupDevice"], TMP_MOUNT))
 		for file in glob.glob('%s/STARTUP_*' % TMP_MOUNT):
 			slotnumber = file.rsplit('_', 3 if 'BOXMODE' in file else 1)[1]
 			if slotnumber.isdigit() and slotnumber not in bootslots:
@@ -47,7 +44,7 @@ def getMultibootslots():
 						break
 				if slot:
 					bootslots[int(slotnumber)] = slot
-		postix.execute('umount %s' % TMP_MOUNT)
+		Console().ePopen('/bin/umount %s' % TMP_MOUNT)
 		if not os.path.ismount(TMP_MOUNT):
 			os.rmdir(TMP_MOUNT)
 	return bootslots

--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -47,12 +47,20 @@ def getMultibootslots():
 						device = getparam(line, 'root')
 						if os.path.exists(device):
 							slot['device'] = device
-							slot['startupfile'] = os.path.basename(file).split('_BOXMODE')[0]
+							slot['startupfile'] = os.path.basename(file)
 							if 'rootsubdir' in line:
 								slot['rootsubdir'] = getparam(line, 'rootsubdir')
+								slot['kernel'] = getparam(line, 'kernel')
+							if "sda" in line:
+								slot['kernel'] = "/dev/sda%s" %line.split('sda', 1)[1].split(' ', 1)[0]
+							else:
+								slot['kernel'] = "%sp%s" %(device.split("p")[0], int(device.split("p")[1])-1)
+								
 						break
 				if slot:
 					bootslots[int(slotnumber)] = slot
+					print "Multiboot getMultibootslots slot = %s" %slot
+		print "Multiboot getMultibootslots bootslots = %s" %bootslots
 		Console().ePopen('umount %s' % TMP_MOUNT)
 		if not os.path.ismount(TMP_MOUNT):
 			os.rmdir(TMP_MOUNT)

--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -23,6 +23,7 @@ def getMBbootdevice():
 		if os.path.exists(device):
 			Console().ePopen('mount %s %s' % (device, TMP_MOUNT))
 			if os.path.isfile(os.path.join(TMP_MOUNT, "STARTUP")):
+				print '[Multiboot] Startupdevice found:', device
 				return device
 			Console().ePopen('umount %s' % TMP_MOUNT)
 	if not os.path.ismount(TMP_MOUNT):
@@ -40,9 +41,11 @@ def getMultibootslots():
 		for file in glob.glob(os.path.join(TMP_MOUNT, 'STARTUP_*')):
 			print "Multiboot getMultibootslots file = %s " %file
 			slotnumber = file.rsplit('_', 3 if 'BOXMODE' in file else 1)[1]
+			print "Multiboot getMultibootslots slotnumber = %s " %slotnumber
 			if slotnumber.isdigit() and slotnumber not in bootslots:
 				slot = {}
 				for line in open(file).readlines():
+					print "Multiboot getMultibootslots readlines = %s " %line
 					if 'root=' in line:
 						line = line.rstrip('\n')
 						device = getparam(line, 'root')
@@ -123,9 +126,7 @@ class GetImagelist():
 			self.imagelist[self.slot] = { 'imagename': _("Empty slot") }
 		if retval == 0 and self.phase == self.MOUNT:
 			imagedir = os.sep.join(filter(None, [TMP_MOUNT, SystemInfo["canMultiBoot"][self.slot].get('rootsubdir', '')]))
-			if not fileExists("/tmp/multibootcheck/usr/bin/enigma2"):
-				self.imagelist[self.slot] = { 'imagename': _("Empty slot") }
-			else:
+			if fileExists("/tmp/multibootcheck/usr/bin/enigma2"):
 				Creator = open("%s/etc/issue" %imagedir).readlines()[-2].capitalize().strip()[:-6].replace("-release", " rel")
 				if Creator.startswith("Openvix"):
 					reader = boxbranding_reader(imagedir)
@@ -147,6 +148,8 @@ class GetImagelist():
 						date = _("Unknown")
 					BuildVersion = "%s (%s)" % (open(os.path.join(target, "etc/issue")).readlines()[-2].capitalize().strip()[:-6], date)
 				self.imagelist[self.slot] =  { 'imagename': '%s' %BuildVersion }
+			else:
+				self.imagelist[self.slot] = { 'imagename': _("Empty slot") }
 			if self.slots and SystemInfo["canMultiBoot"][self.slot]['device'] == SystemInfo["canMultiBoot"][self.slots[0]]['device']:
 				self.slot = self.slots.pop(0)
 				self.appClosed()

--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -1,8 +1,9 @@
-from Components.SystemInfo import SystemInfo
+from boxbranding import getMachineMtdRoot, getMachineBuild
 from Components.Console import Console
-from boxbranding import getMachineMtdRoot
-from Tools.Directories import pathExists
-import os, glob
+from Components.SystemInfo import SystemInfo
+from Tools.Directories import fileExists, fileCheck, pathExists, fileHas
+import os
+import glob
 import shutil
 import subprocess
 
@@ -134,9 +135,17 @@ class GetImagelist():
 						pass
 					date = max(date, datetime.fromtimestamp(os.stat(os.path.join(target, "usr/bin/enigma2")).st_mtime).strftime('%Y-%m-%d'))
 				return "%s (%s)" % (open(os.path.join(target, "etc/issue")).readlines()[-2].capitalize().strip()[:-6], date)
-			imagedir = "/".join(filter(None, [TMP_MOUNT, SystemInfo["canMultiBoot"][self.slot].get('rootsubdir', '')]))
+			imagedir = os.sep.join(filter(None, [TMP_MOUNT, SystemInfo["canMultiBoot"][self.slot].get('rootsubdir', '')]))
 			if os.path.isfile('%s/usr/bin/enigma2' % imagedir):
-				self.imagelist[self.slot] = { 'imagename': getImagename(imagedir) }
+				try:
+					from datetime import datetime
+					date = datetime.fromtimestamp(os.stat(os.path.join(imagedir, "var/lib/opkg/status")).st_mtime).strftime('%Y-%m-%d')
+					if date.startswith("1970"):
+						date = datetime.fromtimestamp(os.stat(os.path.join(imagedir, "usr/share/bootlogo.mvi")).st_mtime).strftime('%Y-%m-%d')
+					date = max(date, datetime.fromtimestamp(os.stat(os.path.join(imagedir, "usr/bin/enigma2")).st_mtime).strftime('%Y-%m-%d'))
+				except:
+					date = _("Unknown")
+				self.imagelist[self.slot] = { 'imagename': "%s (%s)" % (open(os.path.join(imagedir, "etc/issue")).readlines()[-2].capitalize().strip()[:-6], date) }
 			else:
 				if os.path.isfile("%s/usr/bin/enigma2" % TMP_MOUNT):
 					self.imagelist[self.slot] = { 'imagename': getImagename(TMP_MOUNT) }


### PR DESCRIPTION
This takes the multiboot changes by Littlesat (OpenPli) and implements them into OpenViX.
Benefits are the removal of most direct hardware code by interrogating the receivers system files and removes the  hacks required by the Octagon sf8008 and equivalent receivers.
Changes are:
Components/SystemInfo : removal of getMachineBuild in multiboot statements
Components/Console: implementation of wait for PID to finish - needed by Multiboot code
Screens/About - use new features for multiboot slot information
Screens/MultiBootSelector - renamed MBRestart, updated for the new multiboot structure
Data/Menu.xml - reflects new MultiBootSelector and names as MultiBoot Image Selector
Tools/Multiboot - reflect new code implementation and extensions to support OpenViX and Image Backup/Flashing   