### PR TITLE
MultiBootSelector - fix potential crash, improve code consistency, Screen name = module name 

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -244,7 +244,7 @@ self.session.open(HdmiCECSetupScreen)
 			<item text="Standby" entryID="standby"><screen module="Standby" screen="Standby"/></item>
 			<item text="Restart GUI" entryID="restart_enigma"><screen module="Standby" screen="TryQuitMainloop">3</screen></item>
 			<item text="Reboot" entryID="restart"><screen module="Standby" screen="TryQuitMainloop">2</screen></item>
-			<item text="Multiboot Image Selector" entryID="multiboot" requires="canMultiBoot"><screen module="MultiBootSelector" screen="MultiBoot">1</screen></item>
+			<item text="Multiboot Image Selector" entryID="multiboot" requires="canMultiBoot"><screen module="MultiBootSelector" screen="MultiBootSelector">1</screen></item>
 			<item text="H9SDroot" entryID="H9SDswap" requires="HasH9SD"><screen module="H9SDswap" screen="H9SDswap">1</screen></item>
 			<item text="Deep standby" requires="DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
 			<item text="Shut down" requires="!DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>


### PR DESCRIPTION
1. fix potential crash where have boot directory but boot device not mounted
2. Screen name now consistent with module name (also in Menu.xml)
3. imports now ordered and some unused removed
4. provide consistent code across module e.g. " and debug print identifier

Thanks to IanSav for comments, improvements, skin advice