### PR TITLE
Zap picons

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -108,6 +108,7 @@
 		<item level="1" text="Service info font size" description="This allows you to change the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size">config.usage.serviceinfo_fontsize</item>
 		<item level="2" text="Load unlinked userbouquets" description="When enabled enigma2 will load unlinked userbouquets. This means that userbouquets that are available, but not included in the bouquets.tv or bouquets.radio files, will still be loaded. This allows you for example to keep your own user bouquet while installed settings are upgraded">config.misc.load_unlinked_userbouquets</item>
 		<item level="1" text="Zap key delay for channel number input" description="In live view wait this many seconds after a numeric key press before assuming the required channel number has been entered. Default: 5 seconds. Setting zero will require confirmation with 'OK'. ">config.misc.zapkey_delay</item>
+		<item level="2" text="Show picons during channel number input" description="Configure whether service picons will be shown in number zap.">config.misc.numzap_picon</item>
 		<item level="1" text="Zap mode" requires="ZapMode" description="Setup how to control the channel changing.">config.misc.zapmode</item>
 	</setup>
 	<setup key="epgsettings" title="EPG settings" titleshort="Settings">

--- a/lib/python/Components/Renderer/LcdPicon.py
+++ b/lib/python/Components/Renderer/LcdPicon.py
@@ -155,12 +155,11 @@ class LcdPicon(Renderer):
 			elif attrib == "size":
 				self.piconsize = value
 		self.skinAttributes = attribs
-		return Renderer.applySkin(self, desktop, parent)
+		rc = Renderer.applySkin(self, desktop, parent)
+		self.changed((self.CHANGED_DEFAULT,))
+		return rc
 
 	GUI_WIDGET = ePixmap
-
-	def postWidgetCreate(self, instance):
-		self.changed((self.CHANGED_DEFAULT,))
 
 	def updatePicon(self, picInfo=None):
 		ptr = self.PicLoad.getData()
@@ -171,7 +170,7 @@ class LcdPicon(Renderer):
 	def changed(self, what):
 		if self.instance:
 			pngname = ""
-			if what[0] == 1 or what[0] == 3:
+			if what[0] in (self.CHANGED_DEFAULT, self.CHANGED_ALL, self.CHANGED_SPECIFIC):
 				pngname = getLcdPiconName(self.source.text)
 				if not pathExists(pngname): # no picon for service found
 					pngname = self.defaultpngname
@@ -182,6 +181,9 @@ class LcdPicon(Renderer):
 					else:
 						self.instance.hide()
 					self.pngname = pngname
+			elif what[0] == self.CHANGED_CLEAR:
+				self.pngname = None
+				self.instance.hide()
 
 harddiskmanager.on_partition_list_change.append(onPartitionChange)
 initLcdPiconPaths()

--- a/lib/python/Components/Renderer/LcdPicon.py
+++ b/lib/python/Components/Renderer/LcdPicon.py
@@ -177,7 +177,13 @@ class LcdPicon(Renderer):
 				if self.pngname != pngname:
 					if pngname:
 						self.PicLoad.setPara((self.piconsize[0], self.piconsize[1], 0, 0, 1, 1, "#FF000000"))
-						self.PicLoad.startDecode(pngname)
+						if self.PicLoad.startDecode(pngname):
+							# if this has failed, then another decode is probably already in progress
+							# throw away the old picload and try again immediately
+							self.PicLoad = ePicLoad()
+							self.PicLoad.PictureData.get().append(self.updatePicon)
+							self.PicLoad.setPara((self.piconsize[0], self.piconsize[1], 0, 0, 1, 1, "#FF000000"))
+							self.PicLoad.startDecode(pngname)
 					else:
 						self.instance.hide()
 					self.pngname = pngname

--- a/lib/python/Components/Renderer/Picon.py
+++ b/lib/python/Components/Renderer/Picon.py
@@ -147,7 +147,7 @@ class Picon(Renderer):
 	def changed(self, what):
 		if self.instance:
 			pngname = ""
-			if what[0] == 1 or what[0] == 3:
+			if what[0] in (self.CHANGED_DEFAULT, self.CHANGED_ALL, self.CHANGED_SPECIFIC):
 				pngname = getPiconName(self.source.text)
 				if not pathExists(pngname): # no picon for service found
 					pngname = self.defaultpngname
@@ -159,6 +159,9 @@ class Picon(Renderer):
 					else:
 						self.instance.hide()
 					self.pngname = pngname
+			elif what[0] == self.CHANGED_CLEAR:
+				self.pngname = None
+				self.instance.hide()
 
 harddiskmanager.on_partition_list_change.append(onPartitionChange)
 initPiconPaths()

--- a/lib/python/Components/Renderer/PiconBg.py
+++ b/lib/python/Components/Renderer/PiconBg.py
@@ -16,7 +16,7 @@ class PiconBg(Renderer):
 	def changed(self, what):
 		if self.instance:
 			pngname = ""
-			if what[0] == 1 or what[0] == 3:
+			if what[0] in (self.CHANGED_ALL, self.CHANGED_SPECIFIC):
 				pngname = resolveFilename(SCOPE_ACTIVE_SKIN, "piconbg/"+config.usage.show_picon_bkgrn.value + ".png")
 				if self.pngname != pngname:
 					if pngname:

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -884,6 +884,7 @@ def InitUsageConfig():
 	config.misc.erase_flags.addNotifier(updateEraseFlags, immediate_feedback = False)
 
 	config.misc.zapkey_delay = ConfigSelectionNumber(default = 5, stepwidth = 1, min = 0, max = 20, wraparound = True)
+	config.misc.numzap_picon = ConfigYesNo(default = False)
 	if SystemInfo["ZapMode"]:
 		def setZapmode(el):
 			file = open(SystemInfo["ZapMode"], "w")

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -942,6 +942,8 @@ class NumberZap(Screen):
 		self["Service"] = ServiceEvent()
 
 		self.onLayoutFinish.append(self.handleServiceName)
+		if config.misc.numzap_picon.value:
+			self.skinName = ["NumberZapPicon", "NumberZap"]
 
 		self["actions"] = NumberActionMap( [ "SetupActions", "ShortcutActions" ],
 			{

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -6,6 +6,7 @@ from Components.Label import Label
 from Components.MovieList import AUDIO_EXTENSIONS, MOVIE_EXTENSIONS, DVD_EXTENSIONS
 from Components.PluginComponent import plugins
 from Components.ServiceEventTracker import ServiceEventTracker
+from Components.Sources.ServiceEvent import ServiceEvent
 from Components.Sources.Boolean import Boolean
 from Components.config import config, configfile, ConfigBoolean, ConfigClock
 from Components.SystemInfo import SystemInfo
@@ -898,17 +899,20 @@ class NumberZap(Screen):
 		if self.searchNumber:
 			self.service, self.bouquet = self.searchNumber(int(self["number"].getText()))
 			self["servicename"].setText(ServiceReference(self.service).getServiceName())
+			self["Service"].newService(self.service)
 			if not self.startBouquet:
 				self.startBouquet = self.bouquet
 
 	def keyBlue(self):
-		self.Timer.start(5000, True)
+		if config.misc.zapkey_delay.value > 0:
+			self.Timer.start(1000*config.misc.zapkey_delay.value, True)
 		if self.searchNumber:
 			if self.startBouquet == self.bouquet:
 				self.service, self.bouquet = self.searchNumber(int(self["number"].getText()), firstBouquetOnly = True)
 			else:
 				self.service, self.bouquet = self.searchNumber(int(self["number"].getText()))
 			self["servicename"].setText(ServiceReference(self.service).getServiceName())
+			self["Service"].newService(self.service)
 
 	def keyNumberGlobal(self, number):
 		if config.misc.zapkey_delay.value > 0:
@@ -935,8 +939,9 @@ class NumberZap(Screen):
 		self["number"] = Label(self.numberString)
 		self["number_summary"] = StaticText(self.numberString)
 		self["servicename"] = Label()
+		self["Service"] = ServiceEvent()
 
-		self.handleServiceName()
+		self.onLayoutFinish.append(self.handleServiceName)
 
 		self["actions"] = NumberActionMap( [ "SetupActions", "ShortcutActions" ],
 			{
@@ -1563,7 +1568,7 @@ class InfoBarEPG:
 	def RedPressed(self):
 		if isStandardInfoBar(self) or isMoviePlayerInfoBar(self):
 			if config.usage.defaultEPGType.value != _("Graphical EPG") and config.usage.defaultEPGType.value != _("None"):
-					self.openGraphEPG()
+				self.openGraphEPG()
 			else:
 				self.openSingleServiceEPG()
 


### PR DESCRIPTION
This PR allows skins to display a picon element in the NumberZap screen by adding a ServiceEvent object named `Service`.

The example below is a number zap in the top left of the screen the number with the picon to the right:
```
	<screen name="NumberZap" position="20,20" size="330,100" backgroundColor="outlinemenubackground" flags="wfNoBorder">
		<eLabel position="175,5" size="150,90" halign="center" backgroundColor="menubackground" zPosition="-1"/>   
		<widget name="number" position="5,5" size="165,75" font="menulist;80" foregroundColor="maincolour" backgroundColor="menubackground" transparent="1" borderColor="menubackground" borderWidth="3" valign="center" halign="center" zPosition="2" />
		<widget source="Service" render="Picon" position="180,10" size="140,80" alphatest="blend" backgroundColor="background" transparent="1">
			<convert type="ServiceName">Reference</convert>
		</widget>
	</screen>
```