### PR TITLE
Add debug output to listbox python buildfunc calls

### DIFF
--- a/lib/gui/elistboxcontent.cpp
+++ b/lib/gui/elistboxcontent.cpp
@@ -799,6 +799,7 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 
 		if (!items)
 		{
+			PyErr_Print();
 			eDebug("[eListboxPythonMultiContent] error getting item %d", m_cursor);
 			goto error_out;
 		}

--- a/lib/python/Screens/ButtonSetup.py
+++ b/lib/python/Screens/ButtonSetup.py
@@ -521,8 +521,10 @@ class InfoBarButtonSetup():
 				try:
 					exec "from " + selected[1] + " import *"
 					exec "self.session.open(" + ",".join(selected[2:]) + ")"
-				except:
-					print "[ButtonSetup] error during executing module %s, screen %s" % (selected[1], selected[2])
+				except Exception as e:
+					print "[ButtonSetup] error during executing module %s, screen %s, %s" % (selected[1], selected[2], e)
+					import traceback
+					traceback.print_exc()
 			elif selected[0] == "Setup":
 				exec "from Screens.Setup import *"
 				exec "self.session.open(Setup, \"" + selected[1] + "\")"


### PR DESCRIPTION
This change adds exception stack output
- when a Python buildfunc throws an exception
- when a button press that opens a screen throws an exception
