### PR TITLE
Fix crash when installing picon packs

### DIFF
--- a/lib/python/Components/Renderer/LcdPicon.py
+++ b/lib/python/Components/Renderer/LcdPicon.py
@@ -10,13 +10,14 @@ from Components.config import config
 from Picon import PiconLocator
 
 def useLcdPicons():
-	return getDisplayType() in ('bwlcd255','bwlcd140','bwlcd128') or config.lcd.picon_pack.value
+	return getDisplayType() in ('bwlcd255', 'bwlcd140', 'bwlcd128') or config.lcd.picon_pack.value
 
 lcdPiconLocator = None
-def createLcdPiconLocator(_):
+
+def initPiconPaths(_ = None):
 	global lcdPiconLocator
 	lcdPiconLocator = PiconLocator(['lcd_picon', 'piconlcd']) if useLcdPicons() else PiconLocator()
-config.lcd.picon_pack.addNotifier(createLcdPiconLocator)
+config.lcd.picon_pack.addNotifier(initPiconPaths)
 
 class LcdPicon(Renderer):
 	def __init__(self):

--- a/lib/python/Components/Renderer/Picon.py
+++ b/lib/python/Components/Renderer/Picon.py
@@ -96,7 +96,12 @@ class PiconLocator:
 					pngname = self.findPicon(series)
 		return pngname
 
-piconLocator = PiconLocator()
+piconLocator = None
+
+def initPiconPaths():
+	global piconLocator
+	piconLocator = PiconLocator()
+initPiconPaths()
 
 def getPiconName(serviceName):
 	return piconLocator.getPiconName(serviceName)


### PR DESCRIPTION
One of the removed functions in the Picon and LcdPicon modules is required when installing picon packs to refresh the picon loader.