### PR TITLE
[skin.py] Correct scope definition

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -67,6 +67,7 @@ runCallbacks = False
 # E.g. "MySkin/skin_display.xml"
 #
 def InitSkins():
+	global currentPrimarySkin, currentDisplaySkin
 	runCallbacks = False
 	# Add the emergency skin.  This skin should provide enough functionality
 	# to enable basic GUI functions to work.


### PR DESCRIPTION
Add global scope definition for currentPrimarySkin and currentDisplaySkin to allow the global variables to be correctly set from inside InitSkin().
