### PR TITLE
Add restart last movie action

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -1020,5 +1020,7 @@
 		<key id="KEY_F3" mapto="f3_long" flags="l"/>
 		<key id="KEY_AUX" mapto="HDMIin" flags="b"/>
 		<key id="KEY_AUX" mapto="HDMIin_long" flags="l"/>
-	</map>
+		<key id="KEY_FILE" mapto="file" flags="b"/>
+		<key id="KEY_FILE" mapto="file_long" flags="l"/>
+</map>
 </keymap>

--- a/lib/python/Screens/ButtonSetup.py
+++ b/lib/python/Screens/ButtonSetup.py
@@ -46,6 +46,8 @@ ButtonSetupKeys = [	(_("Red"), "red", "Infobar/openSingleServiceEPG/1"),
 	(_("Menu"), "mainMenu", ""),
 	(_("List/Fav/PVR"), "list", ""),
 	(_("List/Fav/PVR") + " " + _("long"), "list_long", ""),
+	(_("List/File"), "file", ""),
+	(_("List/File") + " " + _("long"), "file_long", ""),
 	(_("Back/Recall"), "back", ""),
 	(_("Back/Recall") + " " + _("long"), "back_long", ""),
 	(_("Home"), "home", ""),
@@ -120,6 +122,7 @@ def getButtonSetupFunctions():
 	ButtonSetupFunctions.append((_("Show service list"), "Infobar/openServiceList", "InfoBar"))
 	ButtonSetupFunctions.append((_("Show service list or movies"), "Infobar/showServiceListOrMovies", "InfoBar"))
 	ButtonSetupFunctions.append((_("Show movies"), "Infobar/showMovies", "InfoBar"))
+	ButtonSetupFunctions.append((_("Restart last movie"), "Infobar/restartLastMovie", "InfoBar"))
 	ButtonSetupFunctions.append((_("Show favourites list"), "Infobar/openFavouritesList", "InfoBar"))
 	ButtonSetupFunctions.append((_("History back"), "Infobar/historyBack", "InfoBar"))
 	ButtonSetupFunctions.append((_("History next"), "Infobar/historyNext", "InfoBar"))

--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -1,3 +1,4 @@
+import os
 from Tools.Profile import profile
 
 # workaround for required config entry dependencies.
@@ -188,11 +189,19 @@ class InfoBar(InfoBarBase, InfoBarShowHide,
 		self.rds_display.show()  # in InfoBarRdsDecoder
 		self.servicelist.correctChannelNumber()
 
+	def restartLastMovie(self):
+		service = enigma.eServiceReference(config.usage.last_movie_played.value)
+		if service:
+			if os.path.exists(service.getPath()):
+				from Components.ParentalControl import parentalControl
+				if parentalControl.isServicePlayable(service, self.openMoviePlayer):
+					self.openMoviePlayer(service)
+
 	def showMovies(self, defaultRef=None):
 		self.lastservice = self.session.nav.getCurrentlyPlayingServiceOrGroup()
 		if self.lastservice and ':0:/' in self.lastservice.toString():
 			self.lastservice = enigma.eServiceReference(config.movielist.curentlyplayingservice.value)
-		self.session.openWithCallback(self.movieSelected, Screens.MovieSelection.MovieSelection, defaultRef, timeshiftEnabled = self.timeshiftEnabled())
+		self.session.openWithCallback(self.movieSelected, Screens.MovieSelection.MovieSelection, defaultRef or enigma.eServiceReference(config.usage.last_movie_played.value), timeshiftEnabled = self.timeshiftEnabled())
 
 	def movieSelected(self, service):
 		ref = self.lastservice


### PR DESCRIPTION
This PR makes it much easier to find the movie you were playing back after stopping it. The movielist will open with the last played item selected if the screen is opening in the same directory as the item. Otherwise it defaults to the first movie.

Also included is an assignable action to restart the last movie without opening the movielist. You can bind this to a long button press of the list button for example. If there isn't a last played or if it's been deleted then nothing happens.