### PR TITLE
Allow length of Service Name to be specified

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -320,6 +320,7 @@
 		<item level="2" text="OK button (long)" description="Set to what you want the button to do.">config.epgselection.multi.btn_oklong</item>
 		<item level="2" text="Number of rows" description="Configure the number of rows shown.">config.epgselection.multi.itemsperpage</item>
 		<item level="2" text="Event font size" description="Configure the font size relative to skin size, so 1 increases by 1 point size, and -1 decreases by 1 point size.">config.epgselection.multi.eventfs</item>
+		<item level="2" text="Service Name Length" description="Configure the length of ServiceName">config.epgselection.multi.servicename_length</item>
 	</setup>
 	<setup key="epgsingle" title="Single EPG">
 		<item level="2" text="Channel selection" description="Choose what channel to select when the EPG opens.">config.epgselection.single.browse_mode</item>

--- a/lib/python/Components/EpgListMulti.py
+++ b/lib/python/Components/EpgListMulti.py
@@ -52,7 +52,7 @@ class EPGListMulti(EPGListBase):
 		width = esize.width()
 		height = esize.height()
 		fontSize = self.eventFontSize + config.epgselection.multi.eventfs.value
-		servScale, timeScale, durScale, wideScale = parameters.get("EPGMultiColumnScales", (6.5, 6.0, 4.5, 1.5))
+		servScale, timeScale, durScale, wideScale = parameters.get("EPGMultiColumnScales", (config.epgselection.multi.servicename_length.value, 6.0, 4.5, 1.5))
 		servW = int(fontSize * servScale)
 		timeW = int(fontSize * timeScale)
 		durW = int(fontSize * durScale)

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -1106,6 +1106,7 @@ def InitUsageConfig():
 	config.epgselection.multi.btn_oklong = ConfigSelection(choices = [("zap",_("Zap")), ("zapExit", _("Zap + Exit"))], default = "zapExit")
 	config.epgselection.multi.eventfs = ConfigSelectionNumber(default = 0, stepwidth = 1, min = -8, max = 10, wraparound = True)
 	config.epgselection.multi.itemsperpage = ConfigSelectionNumber(default = 18, stepwidth = 1, min = 12, max = 40, wraparound = True)
+	config.epgselection.multi.servicename_length = ConfigSelectionNumber(min = 5, max = 20, stepwidth = 1, default = 7, wraparound = True)
 	config.epgselection.grid = ConfigSubsection()
 	config.epgselection.grid.showbouquet = ConfigYesNo(default = False)
 	config.epgselection.grid.browse_mode = ConfigSelection(default = "currentservice", choices = [


### PR DESCRIPTION
Allows length of service name within MultiEPG to be specified depending on layout of skin.  Min of 5, max of 20 and defaults to 7 (matching existing hard-coded length).

This option only applies to MultiEPG because by default, depending on skin, service name may be cut off.  The length of this can't be easily set as it depends on skin in use so this option allows user to set this themselves.

Thanks to @seagen for highlighting this issue. More details mentioned in [this](https://www.world-of-satellite.com/showthread.php?62653-New-EPG-files-User-trial-and-feedback&p=497546&viewfull=1#post497546) thread.