### PR TITLE
Action: Ignore keyBreak after a keyLong

### DIFF
--- a/lib/actions/action.cpp
+++ b/lib/actions/action.cpp
@@ -170,10 +170,16 @@ void eActionMap::keyPressed(const std::string &device, int key, int flags)
 	for (std::multimap<int64_t,eActionBinding>::iterator c(m_bindings.begin()); c != m_bindings.end(); ++c)
 	{
 		if (flags == eRCKey::flagMake)
+		{
 			c->second.m_prev_seen_make_key = key;
+			c->second.m_long_key_pressed = false;
+		}
 		else if (c->second.m_prev_seen_make_key != key)  // ignore repeat or break when the make code for this key was not visible
 			continue;
-
+		if (flags == eRCKey::flagLong)
+			c->second.m_long_key_pressed = true;
+		else if (flags == eRCKey::flagBreak && c->second.m_long_key_pressed)
+			continue;
 		// is this a native context?
 		if (c->second.m_widget)
 		{

--- a/lib/actions/action.h
+++ b/lib/actions/action.h
@@ -41,7 +41,7 @@ private:
 	struct eActionBinding
 	{
 		eActionBinding()
-			:m_prev_seen_make_key(-1)
+			:m_prev_seen_make_key(-1), m_long_key_pressed(false)
 		{}
 //		eActionContext *m_context;
 		std::string m_context; // FIXME
@@ -52,6 +52,7 @@ private:
 		eWidget *m_widget;
 		int m_id;
 		int m_prev_seen_make_key;
+		bool m_long_key_pressed;
 	};
 
 	std::multimap<int64_t, eActionBinding> m_bindings;


### PR DESCRIPTION
After this commit we can remove all these longkeypressed stuff in python

Cherry picked from the reverted PR. This change has been running on my XTrend for the last 3 or 4 weeks with no issues.