### PR TITLE
Detect split programs when setting timers

### DIFF
--- a/RecordTimer.py
+++ b/RecordTimer.py
@@ -36,21 +36,35 @@ from sys import maxint
 import threading
 write_lock = threading.Lock()
 
-# parses an event, and gives out a (begin, end, name, duration, eit)-tuple.
-# begin and end will be corrected
-def parseEvent(ev, description = True):
+# Parses an event, and returns a (begin, end, name, duration, eit)-tuple.
+# begin and end include padding (if set in config)
+# If service is supplied, end will also include any split program spanning adjustment (if set in config)
+def parseEvent(event, description=True, service=None):
 	if description:
-		name = ev.getEventName()
-		description = ev.getShortDescription()
+		name = event.getEventName()
+		description = event.getShortDescription()
 		if description == "":
-			description = ev.getExtendedDescription()
+			description = event.getExtendedDescription()
 	else:
 		name = ""
 		description = ""
-	begin = ev.getBeginTime()
-	end = begin + ev.getDuration()
-	eit = ev.getEventId()
+	begin = event.getBeginTime()
+	end = begin + event.getDuration()
+	eit = event.getEventId()
 	begin -= config.recording.margin_before.value * 60
+
+	if service is not None and config.recording.split_programme_minutes.value > 0:
+		# check for events split by, for example, silly 5 minute entertainment news
+		test = ['IX', (service.ref.toString(), 0, event.getBeginTime(), 300)]
+		epgCache =  eEPGCache.getInstance()
+		query = epgCache.lookupEvent(test)
+		additionalEvents = [epgCache.lookupEventId(service.ref, item[0]) for item in query[1:3]]
+		if (len(additionalEvents) == 2 and
+			event.getEventName() == additionalEvents[1].getEventName() and
+			event.getShortDescription() == additionalEvents[1].getShortDescription() and
+			additionalEvents[0].getDuration() <= config.recording.split_programme_minutes.value * 60):
+			end = additionalEvents[1].getBeginTime() + additionalEvents[1].getDuration()
+
 	end += config.recording.margin_after.value * 60
 	return (begin, end, name, description, eit)
 
@@ -1287,6 +1301,16 @@ class RecordTimer(timer.Timer):
 					return 1 if xend < end2 else 3
 		return None
 
+	# given a service and event, returns a timer matching the timespan or 
+	def getTimerForEvent(self, service, event):
+		timer, matchType = self.isInTimer(service, event.getBeginTime(), event.getDuration())
+		if matchType in (2, 3):
+			return timer
+		# found a timer and it's on the same service
+		if timer is not None and timer.eit == event.getEventId():
+			return timer
+		return None
+
 	# matchType values can be:
 	# 0 last part of event
 	# 1 first part of event
@@ -1298,7 +1322,9 @@ class RecordTimer(timer.Timer):
 		end = begin + duration
 		startAt = begin - config.recording.margin_before.value * 60
 		bailAt = end + config.recording.margin_after.value * 60
-		if isinstance(service, ServiceReference):
+		if isinstance(service, eServiceReference):
+			refstr = service.toCompareString()
+		elif isinstance(service, ServiceReference):
 			refstr = service.ref.toCompareString()
 		else:
 			refstr = ':'.join(service.split(':')[:11])

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -178,6 +178,7 @@
 		<item level="1" text="Recordings always have priority" description="When enabled, a recording is allowed to interrupt live TV, when there are no free tuners.">config.recording.asktozap</item>
 		<item level="0" text="Margin before recording (minutes)" description="When nonzero, a recording will start earlier than the starting time indicated by the EPG.">config.recording.margin_before</item>
 		<item level="0" text="Margin after recording (minutes)" description="When nonzero, a recording will stop later than the ending time indicated by the EPG.">config.recording.margin_after</item>
+		<item level="0" text="Split event detection (minutes)" description="Select the maximum duration of the intervening programmes between two halves of the same programme that will result in one combined timer for both halves.">config.recording.split_programme_minutes</item>
 		<item level="2" text="Show message when recording starts" description="When enabled, a popup message will be shown when a recording starts.">config.usage.show_message_when_recording_starts</item>
 		<item level="2" text="Quit Movie Player with EXIT button" description="When enabled, it is possible to leave the Movie Player with exit.">config.usage.leave_movieplayer_onExit</item>
 		<item level="2" text="Behavior when a movie is started" description="Configure the behavior when movie playback is started.">config.usage.on_movie_start</item>

--- a/lib/python/Components/RecordingConfig.py
+++ b/lib/python/Components/RecordingConfig.py
@@ -6,6 +6,7 @@ def InitRecordingConfig():
 	config.recording.asktozap = ConfigYesNo(default=True)
 	config.recording.margin_before = ConfigSelectionNumber(min = 0, max = 120, stepwidth = 1, default = 3, wraparound = True)
 	config.recording.margin_after = ConfigSelectionNumber(min = 0, max = 120, stepwidth = 1, default = 5, wraparound = True)
+	config.recording.split_programme_minutes = ConfigSelectionNumber(min = 0, max = 30, stepwidth = 1, default = 15, wraparound = True)
 	config.recording.ascii_filenames = ConfigYesNo(default = False)
 	config.recording.keep_timers = ConfigSelectionNumber(min = 1, max = 120, stepwidth = 1, default = 7, wraparound = True)
 	config.recording.filename_composition = ConfigSelection(default = "standard", choices = [

--- a/lib/python/Screens/EventView.py
+++ b/lib/python/Screens/EventView.py
@@ -42,10 +42,8 @@ class EventViewContextMenu(Screen):
 	def cancelClick(self):
 		self.close(False)
 
-class EventViewBase:
-	ADD_TIMER = 1
-	REMOVE_TIMER = 2
 
+class EventViewBase:
 	def __init__(self, event, ref, callback=None, similarEPGCB=None):
 		self.similarEPGCB = similarEPGCB
 		self.cbFunc = callback
@@ -100,35 +98,46 @@ class EventViewBase:
 	def removeTimer(self, timer):
 		timer.afterEvent = AFTEREVENT.NONE
 		self.session.nav.RecordTimer.removeEntry(timer)
-		self["key_green"].setText(_("Add timer"))
-		self.key_green_choice = self.ADD_TIMER
-	
+		self.updateButtons()
+
+	def updateButtons(self):
+		event = self.event
+		if self.isRecording or event is None:
+			self["key_green"].setText("")
+			return
+		timer = self.session.nav.RecordTimer.getTimerForEvent(self.currentService, event)
+		if timer is not None:
+			self["key_green"].setText(_("Change Timer"))
+		else:
+			self["key_green"].setText(_("Add Timer"))
+
+	def editTimer(self, timer):
+		def callback(choice):
+			self.updateButtons()
+		self.session.openWithCallback(callback, TimerEntry, timer)
+
 	def timerAdd(self):
+		def callback(choice):
+			if choice:
+				choice(self)
+			self.closeChoiceBoxDialog()
+
 		if self.isRecording:
 			return
 		event = self.event
-		serviceref = self.currentService
 		if event is None:
 			return
-		eventid = event.getEventId()
-		refstr = ':'.join(serviceref.ref.toString().split(':')[:11])
-		for timer in self.session.nav.RecordTimer.timer_list:
-			if timer.eit == eventid and ':'.join(timer.service_ref.ref.toString().split(':')[:11]) == refstr:
-				cb_func1 = lambda ret: self.removeTimer(timer)
-				cb_func2 = lambda ret: self.editTimer(timer)
-				menu = [(_("Delete timer"), 'CALLFUNC', self.ChoiceBoxCB, cb_func1), (_("Edit timer"), 'CALLFUNC', self.ChoiceBoxCB, cb_func2)]
-				self.ChoiceBoxDialog = self.session.instantiateDialog(ChoiceBox, title=_("Select action for timer %s:") % event.getEventName(), list=menu, keys=['green', 'blue'], skin_name="RecordTimerQuestion")
-				self.ChoiceBoxDialog.instance.move(ePoint(self.instance.position().x()+self["key_green"].getPosition()[0],self.instance.position().y()+self["key_green"].getPosition()[1]-self["key_green"].instance.size().height()))
-				self.showChoiceBoxDialog()
-				break
+		timer = self.session.nav.RecordTimer.getTimerForEvent(self.currentService, event)
+		if timer is not None:
+			cb_func1 = lambda ret: self.removeTimer(timer)
+			cb_func2 = lambda ret: self.editTimer(timer)
+			menu = [(_("Delete Timer"), 'CALLFUNC', callback, cb_func1), (_("Edit Timer"), 'CALLFUNC', callback, cb_func2)]
+			self.ChoiceBoxDialog = self.session.instantiateDialog(ChoiceBox, title=_("Select action for timer %s:") % event.getEventName(), list=menu, keys=['green', 'blue'], skin_name="RecordTimerQuestion")
+			self.ChoiceBoxDialog.instance.move(ePoint(self.instance.position().x()+self["key_green"].getPosition()[0], self.instance.position().y()+self["key_green"].getPosition()[1]-self["key_green"].instance.size().height()))
+			self.showChoiceBoxDialog()
 		else:
-			newEntry = RecordTimerEntry(self.currentService, checkOldTimers = True, dirname = preferredTimerPath(), *parseEvent(self.event))
+			newEntry = RecordTimerEntry(self.currentService, checkOldTimers = True, dirname = preferredTimerPath(), *parseEvent(self.event, service=self.currentService))
 			self.session.openWithCallback(self.finishedAdd, TimerEntry, newEntry)
-
-	def ChoiceBoxCB(self, choice):
-		if choice:
-			choice(self)
-		self.closeChoiceBoxDialog()
 
 	def showChoiceBoxDialog(self):
 		self['actions'].setEnabled(False)
@@ -144,7 +153,6 @@ class EventViewBase:
 		self['actions'].setEnabled(True)
 
 	def finishedAdd(self, answer):
-		print "[EventView] finished add"
 		if answer[0]:
 			entry = answer[1]
 			simulTimerList = self.session.nav.RecordTimer.record(entry)
@@ -168,18 +176,13 @@ class EventViewBase:
 							simulTimerList = self.session.nav.RecordTimer.record(entry)
 					if simulTimerList is not None:
 						self.session.openWithCallback(self.finishSanityCorrection, TimerSanityConflict, simulTimerList)
-			self["key_green"].setText(_("Change timer"))
-			self.key_green_choice = self.REMOVE_TIMER
-		else:
-			self["key_green"].setText(_("Add timer"))
-			self.key_green_choice = self.ADD_TIMER
-			print "[EventView] Timeredit aborted"
+		self.updateButtons()
 
 	def finishSanityCorrection(self, answer):
 		self.finishedAdd(answer)
 
 	def setService(self, service):
-		self.currentService=service
+		self.currentService = service
 		self["Service"].newService(service.ref)
 		if self.isRecording:
 			self["channel"].setText(_("Recording"))
@@ -234,22 +237,7 @@ class EventViewBase:
 		self["duration"].setText(_("%d min")%(event.getDuration()/60))
 		if self.SimilarBroadcastTimer is not None:
 			self.SimilarBroadcastTimer.start(400, True)
-
-		serviceref = self.currentService
-		eventid = self.event.getEventId()
-		refstr = ':'.join(serviceref.ref.toString().split(':')[:11])
-		isRecordEvent = False
-		for timer in self.session.nav.RecordTimer.timer_list:
-			if timer.eit == eventid and ':'.join(timer.service_ref.ref.toString().split(':')[:11]) == refstr:
-				isRecordEvent = True
-				break
-		if isRecordEvent and self.key_green_choice and self.key_green_choice != self.REMOVE_TIMER:
-			self["key_green"].setText(_("Change timer"))
-			self.key_green_choice = self.REMOVE_TIMER
-		elif not isRecordEvent and self.key_green_choice and self.key_green_choice != self.ADD_TIMER:
-			self["key_green"].setText(_("Add timer"))
-			self.key_green_choice = self.ADD_TIMER
-
+		self.updateButtons()
 
 	def pageUp(self):
 		self["epg_eventname"].pageUp()
@@ -300,20 +288,20 @@ class EventViewBase:
 	def runPlugin(self, plugin):
 		plugin(session=self.session, service=self.currentService, event=self.event, eventName=self.event.getEventName())
 
+
 class EventViewSimple(Screen, EventViewBase):
 	def __init__(self, session, event, ref, callback=None, singleEPGCB=None, multiEPGCB=None, similarEPGCB=None, skin='EventViewSimple'):
 		Screen.__init__(self, session)
 		self.setTitle(_('Event view'))
 		self.skinName = [skin,"EventView"]
 		EventViewBase.__init__(self, event, ref, callback, similarEPGCB)
-		self.key_green_choice = None
+
 
 class EventViewEPGSelect(Screen, EventViewBase):
 	def __init__(self, session, event, ref, callback=None, singleEPGCB=None, multiEPGCB=None, similarEPGCB=None):
 		Screen.__init__(self, session)
 		self.skinName = "EventView"
 		EventViewBase.__init__(self, event, ref, callback, similarEPGCB)
-		self.key_green_choice = self.ADD_TIMER
 
 		# Background for Buttons
 		self["red"] = Pixmap()
@@ -323,15 +311,10 @@ class EventViewEPGSelect(Screen, EventViewBase):
 
 		self["epgactions1"] = ActionMap(["OkCancelActions", "EventViewActions"],
 			{
-
 				"timerAdd": self.timerAdd,
 				"openSimilarList": self.openSimilarList,
-
 			})
-		if self.isRecording:
-			self["key_green"] = Button("")
-		else:
-			self["key_green"] = Button(_("Add timer"))
+		self["key_green"] = Button("")
 
 		if singleEPGCB:
 			self["key_yellow"] = Button(_("Single EPG"))
@@ -347,9 +330,10 @@ class EventViewEPGSelect(Screen, EventViewBase):
 			self["key_blue"] = Button(_("Multi EPG"))
 			self["epgactions3"] = ActionMap(["EventViewEPGActions"],
 				{
-
 					"openMultiServiceEPG": multiEPGCB,
 				})
 		else:
 			self["key_blue"] = Button("")
 			self["blue"].hide()
+		
+		self.updateButtons()

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -446,7 +446,7 @@ class SecondInfoBar(Screen):
 				self.session.openWithCallback(cb_func, MessageBox, _("Do you really want to delete %s?") % event.getEventName())
 				break
 		else:
-			newEntry = RecordTimerEntry(self.currentService, checkOldTimers = True, dirname = preferredTimerPath(), *parseEvent(self.event))
+			newEntry = RecordTimerEntry(self.currentService, checkOldTimers = True, dirname = preferredTimerPath(), *parseEvent(self.event, service=serviceref))
 			self.session.openWithCallback(self.finishedAdd, TimerEntry, newEntry)
 
 	def finishedAdd(self, answer):
@@ -2990,13 +2990,13 @@ class InfoBarInstantRecord:
 		self.session.openWithCallback(confirm, MessageBox, msg, MessageBox.TYPE_YESNO)
 
 	def getProgramInfoAndEvent(self, info, name):
-		info["serviceref"] = hasattr(self, "SelectedInstantServiceRef") and self.SelectedInstantServiceRef or self.session.nav.getCurrentlyPlayingServiceOrGroup()
+		service = hasattr(self, "SelectedInstantServiceRef") and self.SelectedInstantServiceRef or self.session.nav.getCurrentlyPlayingServiceOrGroup()
 
 		# try to get event info
 		event = None
 		try:
 			epg = eEPGCache.getInstance()
-			event = epg.lookupEventTime(info["serviceref"], -1, 0)
+			event = epg.lookupEventTime(service, -1, 0)
 			if event is None:
 				if hasattr(self, "SelectedInstantServiceRef") and self.SelectedInstantServiceRef:
 					service_info = eServiceCenter.getInstance().info(self.SelectedInstantServiceRef)
@@ -3007,13 +3007,14 @@ class InfoBarInstantRecord:
 		except:
 			pass
 
+		info["serviceref"] = service
 		info["event"] = event
 		info["name"]  = name
 		info["description"] = ""
 		info["eventid"] = None
 
 		if event is not None:
-			curEvent = parseEvent(event)
+			curEvent = parseEvent(event, service=service)
 			info["name"] = curEvent[2]
 			info["description"] = curEvent[3]
 			info["eventid"] = curEvent[4]


### PR DESCRIPTION
Many commercial channels split longer programmes, usually films, with short news bulletins. This change adds an option to detect this and automatically extend the recording across the news so you don't accidentally miss the second half. Most places in the UI support now this:
- 2nd infobar
- Channel List
- EPGs
- Event View

A new setting, `split_programme_minutes` has been added, which defaults to 15 minutes, so should cover both the entertainment style news and the longer bulletins seen on ITV from time to time. We can reduce the default or have it switched off by default if necessary.

The detection is uses the name _and_ short description of the events. This seems to work well on the UK's ITV, 5, Sony and Paramount channels.