### PR TITLE
InputDevice/InputDeviceSetup

### DIFF
--- a/lib/python/Components/InputDevice.py
+++ b/lib/python/Components/InputDevice.py
@@ -1,15 +1,12 @@
-from config import config, ConfigSlider, ConfigSubsection, ConfigYesNo, ConfigText, ConfigInteger
-from SystemInfo import SystemInfo
-from fcntl import ioctl
 import os
+from fcntl import ioctl
+import platform
 import struct
 from boxbranding import getBrandOEM
-import platform
+from config import config, ConfigInteger, ConfigSlider, ConfigSubsection, ConfigText, ConfigYesNo
+from SystemInfo import SystemInfo
 
-from Tools.Directories import pathExists
-
-
-# asm-generic/ioctl.h
+# include/uapi/asm-generic/ioctl.h
 IOC_NRBITS = 8L
 IOC_TYPEBITS = 8L
 IOC_SIZEBITS = 13L if "mips" in platform.machine() else 14L

--- a/lib/python/Components/InputDevice.py
+++ b/lib/python/Components/InputDevice.py
@@ -3,8 +3,8 @@ from fcntl import ioctl
 import platform
 import struct
 from boxbranding import getBrandOEM
-from config import config, ConfigInteger, ConfigSlider, ConfigSubsection, ConfigText, ConfigYesNo
-from SystemInfo import SystemInfo
+from .config import config, ConfigInteger, ConfigSlider, ConfigSubsection, ConfigText, ConfigYesNo
+from .SystemInfo import SystemInfo
 
 # include/uapi/asm-generic/ioctl.h
 IOC_NRBITS = 8L
@@ -40,13 +40,13 @@ class inputDevices:
 				self.name = ioctl(self.fd, EVIOCGNAME(256), buffer)
 				self.name = self.name[:self.name.find("\0")]
 				os.close(self.fd)
-			except (IOError,OSError), err:
-				print "[InputDevice] Error: evdev='%s' getInputDevices <ERROR: ioctl(EVIOCGNAME): '%s'>" % (evdev, str(err))
+			except (IOError,OSError) as err:
+				print("[InputDevice] Error: evdev='%s' getInputDevices <ERROR: ioctl(EVIOCGNAME): '%s'>" % (evdev, str(err)))
 				self.name = None
 
 			if self.name:
 				devtype = self.getInputDeviceType(self.name)
-				print "[InputDevice] Found: evdev='%s', name='%s', type='%s'" % (evdev, self.name, devtype)
+				print("[InputDevice] Found: evdev='%s', name='%s', type='%s'" % (evdev, self.name, devtype))
 				self.Devices[evdev] = {'name': self.name, 'type': devtype, 'enabled': False, 'configuredName': None }
 
 
@@ -62,13 +62,13 @@ class inputDevices:
 			return None
 
 	def getDeviceName(self, x):
-		if x in self.Devices.keys():
+		if x in list(self.Devices.keys()):
 			return self.Devices[x].get("name", x)
 		else:
 			return "Unknown device name"
 
 	def getDeviceList(self):
-		return sorted(self.Devices.iterkeys())
+		return sorted(self.Devices.keys())
 
 	def setDeviceAttribute(self, device, attribute, value):
 		#print "[InputDevice] setting for device", device, "attribute", attribute, " to value", value
@@ -100,7 +100,7 @@ class inputDevices:
 	#}; -> size = 16
 
 	def setDefaults(self, device):
-		print "[InputDevice] setDefaults for device '%s'" % device
+		print("[InputDevice] setDefaults for device %s" % device)
 		self.setDeviceAttribute(device, 'configuredName', None)
 		event_repeat = struct.pack('LLHHi', 0, 0, 0x14, 0x01, 100)
 		event_delay = struct.pack('LLHHi', 0, 0, 0x14, 0x00, 700)
@@ -111,16 +111,16 @@ class inputDevices:
 
 	def setRepeat(self, device, value): #REP_PERIOD
 		if self.getDeviceAttribute(device, 'enabled'):
-			print "[InputDevice] setRepeat for device '%s' to %d ms" % (device,value)
-			event = struct.pack('LLhhi', 0, 0, 0x14, 0x01, int(value))
+			print("[InputDevice] setRepeat for device %s to %d ms" % (device,value))
+			event = struct.pack('LLHHi', 0, 0, 0x14, 0x01, int(value))
 			fd = os.open("/dev/input/" + device, os.O_RDWR)
 			os.write(fd, event)
 			os.close(fd)
 
 	def setDelay(self, device, value): #REP_DELAY
 		if self.getDeviceAttribute(device, 'enabled'):
-			print "[InputDevice] setDelay for device '%s' to %d ms" % (device,value)
-			event = struct.pack('LLhhi', 0, 0, 0x14, 0x00, int(value))
+			print("[InputDevice] setDelay for device %s to %d ms" % (device,value))
+			event = struct.pack('LLHHi', 0, 0, 0x14, 0x00, int(value))
 			fd = os.open("/dev/input/" + device, os.O_RDWR)
 			os.write(fd, event)
 			os.close(fd)
@@ -134,7 +134,7 @@ class InitInputDevices:
 
 	def createConfig(self, *args):
 		config.inputDevices = ConfigSubsection()
-		for device in sorted(iInputDevices.Devices.iterkeys()):
+		for device in sorted(iInputDevices.Devices.keys()):
 			self.currentDevice = device
 			#print "[InputDevice] creating config entry for device: %s -> %s  " % (self.currentDevice, iInputDevices.Devices[device]["name"])
 			self.setupConfigEntries(self.currentDevice)
@@ -153,9 +153,9 @@ class InitInputDevices:
 				devname = iInputDevices.getDeviceAttribute(self.currentDevice, 'name')
 				if devname != configElement.value:
 					cmd = "config.inputDevices." + self.currentDevice + ".enabled.value = False"
-					exec cmd
+					exec(cmd)
 					cmd = "config.inputDevices." + self.currentDevice + ".enabled.save()"
-					exec cmd
+					exec(cmd)
 		elif iInputDevices.currentDevice != "":
 			iInputDevices.setName(iInputDevices.currentDevice, configElement.value)
 
@@ -173,23 +173,23 @@ class InitInputDevices:
 
 	def setupConfigEntries(self,device):
 		cmd = "config.inputDevices." + device + " = ConfigSubsection()"
-		exec cmd
+		exec(cmd)
 		cmd = "config.inputDevices." + device + ".enabled = ConfigYesNo(default = False)"
-		exec cmd
+		exec(cmd)
 		cmd = "config.inputDevices." + device + ".enabled.addNotifier(self.inputDevicesEnabledChanged,config.inputDevices." + device + ".enabled)"
-		exec cmd
+		exec(cmd)
 		cmd = "config.inputDevices." + device + '.name = ConfigText(default="")'
-		exec cmd
+		exec(cmd)
 		cmd = "config.inputDevices." + device + ".name.addNotifier(self.inputDevicesNameChanged,config.inputDevices." + device + ".name)"
-		exec cmd
+		exec(cmd)
 		cmd = "config.inputDevices." + device + ".repeat = ConfigSlider(default=100, increment = 10, limits=(0, 500))"
-		exec cmd
+		exec(cmd)
 		cmd = "config.inputDevices." + device + ".repeat.addNotifier(self.inputDevicesRepeatChanged,config.inputDevices." + device + ".repeat)"
-		exec cmd
+		exec(cmd)
 		cmd = "config.inputDevices." + device + ".delay = ConfigSlider(default=700, increment = 100, limits=(0, 5000))"
-		exec cmd
+		exec(cmd)
 		cmd = "config.inputDevices." + device + ".delay.addNotifier(self.inputDevicesDelayChanged,config.inputDevices." + device + ".delay)"
-		exec cmd
+		exec(cmd)
 
 
 iInputDevices = inputDevices()

--- a/lib/python/Components/InputDevice.py
+++ b/lib/python/Components/InputDevice.py
@@ -152,9 +152,9 @@ class InitInputDevices:
 			if configElement.value != "":
 				devname = iInputDevices.getDeviceAttribute(self.currentDevice, 'name')
 				if devname != configElement.value:
-					cmd = "config.inputDevices." + self.currentDevice + ".enabled.value = False"
+					cmd = "config.inputDevices.%s.enabled.value = False" % self.currentDevice
 					exec(cmd)
-					cmd = "config.inputDevices." + self.currentDevice + ".enabled.save()"
+					cmd = "config.inputDevices.%s.enabled.save()" % self.currentDevice
 					exec(cmd)
 		elif iInputDevices.currentDevice != "":
 			iInputDevices.setName(iInputDevices.currentDevice, configElement.value)
@@ -172,23 +172,23 @@ class InitInputDevices:
 			iInputDevices.setDelay(iInputDevices.currentDevice, configElement.value)
 
 	def setupConfigEntries(self,device):
-		cmd = "config.inputDevices." + device + " = ConfigSubsection()"
+		cmd = "config.inputDevices.%s = ConfigSubsection()" % device
 		exec(cmd)
-		cmd = "config.inputDevices." + device + ".enabled = ConfigYesNo(default = False)"
+		cmd = "config.inputDevices.%s.enabled = ConfigYesNo(default = False)" % device
 		exec(cmd)
-		cmd = "config.inputDevices." + device + ".enabled.addNotifier(self.inputDevicesEnabledChanged,config.inputDevices." + device + ".enabled)"
+		cmd = "config.inputDevices.%s.enabled.addNotifier(self.inputDevicesEnabledChanged,config.inputDevices.%s.enabled)" % (device, device)
 		exec(cmd)
-		cmd = "config.inputDevices." + device + '.name = ConfigText(default="")'
+		cmd = "config.inputDevices.%s.name = ConfigText(default='')" % device
 		exec(cmd)
-		cmd = "config.inputDevices." + device + ".name.addNotifier(self.inputDevicesNameChanged,config.inputDevices." + device + ".name)"
+		cmd = "config.inputDevices.%s.name.addNotifier(self.inputDevicesNameChanged,config.inputDevices.%s.name)" % (device, device)
 		exec(cmd)
-		cmd = "config.inputDevices." + device + ".repeat = ConfigSlider(default=100, increment = 10, limits=(0, 500))"
+		cmd = "config.inputDevices.%s.repeat = ConfigSlider(default=100, increment = 10, limits=(0, 500))" % device
 		exec(cmd)
-		cmd = "config.inputDevices." + device + ".repeat.addNotifier(self.inputDevicesRepeatChanged,config.inputDevices." + device + ".repeat)"
+		cmd = "config.inputDevices.%s.repeat.addNotifier(self.inputDevicesRepeatChanged,config.inputDevices.%s.repeat)" % (device, device)
 		exec(cmd)
-		cmd = "config.inputDevices." + device + ".delay = ConfigSlider(default=700, increment = 100, limits=(0, 5000))"
+		cmd = "config.inputDevices.%s.delay = ConfigSlider(default=700, increment = 100, limits=(0, 5000))" % device
 		exec(cmd)
-		cmd = "config.inputDevices." + device + ".delay.addNotifier(self.inputDevicesDelayChanged,config.inputDevices." + device + ".delay)"
+		cmd = "config.inputDevices.%s.delay.addNotifier(self.inputDevicesDelayChanged,config.inputDevices.%s.delay)" % (device, device)
 		exec(cmd)
 
 
@@ -200,14 +200,11 @@ config.plugins.remotecontroltype.rctype = ConfigInteger(default = 0)
 
 class RcTypeControl():
 	def __init__(self):
-		self.boxType = ""
-		if pathExists('/proc/stb/ir/rc/type') and pathExists('/proc/stb/info/boxtype') and getBrandOEM() != 'gigablue':
+		self.boxType = "Default"
+		if os.path.exists('/proc/stb/ir/rc/type') and os.path.exists('/proc/stb/info/boxtype') and getBrandOEM() != 'gigablue':
 			self.isSupported = True
-
-			fd = open('/proc/stb/info/boxtype', 'r')
-			self.boxType = fd.read().strip()
-			fd.close()
-
+			with open("/proc/stb/info/boxtype", "r") as fd:
+				self.boxType = fd.read().strip()
 			if config.plugins.remotecontroltype.rctype.value != 0:
 				self.writeRcType(config.plugins.remotecontroltype.rctype.value)
 		else:
@@ -221,17 +218,14 @@ class RcTypeControl():
 
 	def writeRcType(self, rctype):
 		if self.isSupported and rctype > 0:
-			fd = open('/proc/stb/ir/rc/type', 'w')
-			fd.write('%d' % rctype)
-			fd.close()
+			with open("/proc/stb/ir/rc/type", "w") as fd:
+				fd.write('%d' % rctype)
 
 	def readRcType(self):
+		rc = 0
 		if self.isSupported:
-			fd = open('/proc/stb/ir/rc/type', 'r')
-			rc = fd.read().strip()
-			fd.close()
-		else:
-			rc = 0
+			with open("/proc/stb/ir/rc/type", "r") as fd:
+				rc = fd.read().strip()
 		return int(rc)
 
 iRcTypeControl = RcTypeControl()

--- a/lib/python/Screens/InputDeviceSetup.py
+++ b/lib/python/Screens/InputDeviceSetup.py
@@ -9,7 +9,7 @@ from Components.ConfigList import ConfigListScreen
 from Components.ActionMap import ActionMap, HelpableActionMap
 from Tools.Directories import resolveFilename, SCOPE_ACTIVE_SKIN
 from Tools.LoadPixmap import LoadPixmap
-from boxbranding import getBoxType, getMachineBrand, getMachineName
+from boxbranding import getBoxType, getMachineBrand, getMachineName, getMachineBuild
 
 class InputDeviceSelection(Screen, HelpableScreen):
 	def __init__(self, session, menu_path=""):
@@ -65,7 +65,10 @@ class InputDeviceSelection(Screen, HelpableScreen):
 		activepng = None
 		devicepng = None
 		enabled = iInputDevices.getDeviceAttribute(device, 'enabled')
-		if type == 'remote':
+		# print("[InputDevice] device = %s, description = %s, type = %s, isinputdevice = %s, enabled = %s" % (device, description, type, isinputdevice, enabled))
+		if type == None:
+			devicepng = LoadPixmap(resolveFilename(SCOPE_ACTIVE_SKIN, "icons/input_rcold-configured.png"))
+		elif type == 'remote':
 			if config.misc.rcused.value == 0:
 				if enabled:
 					devicepng = LoadPixmap(resolveFilename(SCOPE_ACTIVE_SKIN, "icons/input_rcnew-configured.png"))
@@ -93,7 +96,7 @@ class InputDeviceSelection(Screen, HelpableScreen):
 	def updateList(self):
 		self.list = []
 		if iRcTypeControl.multipleRcSupported():
-			self.list.append(self.buildInterfaceList('rctype', _('Configure remote control type'), None, False))
+			self.list.append(self.buildInterfaceList('rctype', _('Select to configure remote control type'), None, False))
 
 		for x in self.devices:
 			dev_type = iInputDevices.getDeviceAttribute(x[1], 'type')
@@ -173,16 +176,16 @@ class InputDeviceSetup(Screen, ConfigListScreen):
 	def createSetup(self):
 		self.list = [ ]
 		label = _("Change repeat and delay settings?")
-		cmd = "self.enableEntry = getConfigListEntry(label, config.inputDevices." + self.inputDevice + ".enabled)"
+		cmd = "self.enableEntry = getConfigListEntry(label, config.inputDevices.%s.enabled)" % self.inputDevice
 		exec(cmd)
 		label = _("Interval between keys when repeating:")
-		cmd = "self.repeatEntry = getConfigListEntry(label, config.inputDevices." + self.inputDevice + ".repeat)"
+		cmd = "self.repeatEntry = getConfigListEntry(label, config.inputDevices.%s.repeat)" % self.inputDevice
 		exec(cmd)
 		label = _("Delay before key repeat starts:")
-		cmd = "self.delayEntry = getConfigListEntry(label, config.inputDevices." + self.inputDevice + ".delay)"
+		cmd = "self.delayEntry = getConfigListEntry(label, config.inputDevices.%s.delay)" % self.inputDevice
 		exec(cmd)
 		label = _("Devicename:")
-		cmd = "self.nameEntry = getConfigListEntry(label, config.inputDevices." + self.inputDevice + ".name)"
+		cmd = "self.nameEntry = getConfigListEntry(label, config.inputDevices.%s.name)" % self.inputDevice
 		exec(cmd)
 		if self.enableEntry:
 			if isinstance(self.enableEntry[1], ConfigYesNo):
@@ -233,7 +236,7 @@ class InputDeviceSetup(Screen, ConfigListScreen):
 			return
 		else:
 			self.nameEntry[1].setValue(iInputDevices.getDeviceAttribute(self.inputDevice, 'name'))
-			cmd = "config.inputDevices." + self.inputDevice + ".name.save()"
+			cmd = "config.inputDevices.%s.name.save()" % self.inputDevice
 			exec(cmd)
 			self.keySave()
 
@@ -286,17 +289,30 @@ class RemoteControlType(Screen, ConfigListScreen):
 			("11", _("et9200/9500/6500")),
 			("13", _("et4000")),
 			("14", _("XP1000")),
-			("16", _("HD1100/et7x00/et8500")),
-			("18", _("F1/F3")),
+			("16", _("HD11/HD51/HD1100/HD1200/HD1265/HD1500/HD500C/HD530C/et7x00/et8500")),
+			("17", _("XP3000")),
+			("18", _("F1/F3/F4/F4-TURBO/TRIPLEX")),
 			("19", _("HD2400")),
+			("20", _("Zgemma Star S/2S/H1/H2")),
+			("21", _("Zgemma H.S/H.2S/H.2H/H5")),
+			("22", _("Zgemma i55")),
+			("23", _("WWIO 4K")),
+			("24", _("Axas E4HD Ultra")),
+			("25", _("Zgemma H9/I55Plus old Model")),
+			("26", _("Protek 4K UHD/HD61")),
+			("27", _("HD60")),
+			("28", _("H7/H9/H9COMBO/H10 new Model"))
 			]
 
 	defaultRcList = [
+			("default", 0),
 			("et4000", 13),
 			("et5000", 7),
 			("et6000", 7),
 			("et6500", 11),
+			("et7x00",16),
 			("et8000", 9),
+			("et8500", 16),
 			("et9000", 5),
 			("et9100", 5),
 			("et9200", 11),
@@ -304,13 +320,30 @@ class RemoteControlType(Screen, ConfigListScreen):
 			("et10000", 9),
 			("formuler1", 18),
 			("formuler3", 18),
-			("xp1000", 14),
-			("hd1100", 16),
+			("hd11",16),
+			("hd51",16),
+			("hd52",16),
+			("hd1100",16),
+			("hd1200",16),
+			("hd1265",16),
+			("hd500c",16),
+			("hd530c",16),
 			("hd2400", 19),
-			("et7000", 16),
-			("et7500", 16),
-			("et8500", 16),
-			("hd51", 16),
+			("h3", 21),
+			("h5", 21),
+			#("h7", 21),# old model
+			("i55", 22),
+			("bre2ze4k", 23),
+			("e4hd", 24),
+			#("h9", 25),# old model
+			("i55plus", 25),
+			("protek4k", 26),
+			("hd61", 26),
+			("hd60", 27),
+			("h7", 28), # new model
+			("h9", 28), # new model
+			("h9combo", 28),
+			("h10", 28)
 		]
 
 	def __init__(self, session, menu_path=""):
@@ -338,9 +371,11 @@ class RemoteControlType(Screen, ConfigListScreen):
 		self.getDefaultRcType()
 
 	def getDefaultRcType(self):
-		data = iRcTypeControl.getBoxType()
+		boxtype = getMachineBuild()
+		procBoxtype = iRcTypeControl.getBoxType()
+		print("[InputDevice] procBoxtype = %s, self.boxType = %s" % (procBoxtype, boxtype))
 		for x in self.defaultRcList:
-			if x[0] in data:
+			if x[0] in boxtype or x[0] in procBoxtype:
 				self.defaultRcType = x[1]
 				break
 # If there is none in the list, use the current value...

--- a/lib/python/Screens/InputDeviceSetup.py
+++ b/lib/python/Screens/InputDeviceSetup.py
@@ -37,7 +37,7 @@ class InputDeviceSelection(Screen, HelpableScreen):
 		self["introduction"] = StaticText(self.edittext)
 
 		self.devices = [(iInputDevices.getDeviceName(x),x) for x in iInputDevices.getDeviceList()]
-		print "[InputDeviceSetup] found devices :->", len(self.devices),self.devices
+		print("[InputDeviceSetup] found devices :->", len(self.devices),self.devices)
 
 		self["OkCancelActions"] = HelpableActionMap(self, "OkCancelActions",
 			{
@@ -65,7 +65,6 @@ class InputDeviceSelection(Screen, HelpableScreen):
 		activepng = None
 		devicepng = None
 		enabled = iInputDevices.getDeviceAttribute(device, 'enabled')
-
 		if type == 'remote':
 			if config.misc.rcused.value == 0:
 				if enabled:
@@ -93,14 +92,12 @@ class InputDeviceSelection(Screen, HelpableScreen):
 
 	def updateList(self):
 		self.list = []
-
 		if iRcTypeControl.multipleRcSupported():
 			self.list.append(self.buildInterfaceList('rctype', _('Configure remote control type'), None, False))
 
 		for x in self.devices:
 			dev_type = iInputDevices.getDeviceAttribute(x[1], 'type')
 			self.list.append(self.buildInterfaceList(x[1],_(x[0]), dev_type))
-
 		self["list"].setList(self.list)
 		self["list"].setIndex(self.currentIndex)
 
@@ -177,16 +174,16 @@ class InputDeviceSetup(Screen, ConfigListScreen):
 		self.list = [ ]
 		label = _("Change repeat and delay settings?")
 		cmd = "self.enableEntry = getConfigListEntry(label, config.inputDevices." + self.inputDevice + ".enabled)"
-		exec cmd
+		exec(cmd)
 		label = _("Interval between keys when repeating:")
 		cmd = "self.repeatEntry = getConfigListEntry(label, config.inputDevices." + self.inputDevice + ".repeat)"
-		exec cmd
+		exec(cmd)
 		label = _("Delay before key repeat starts:")
 		cmd = "self.delayEntry = getConfigListEntry(label, config.inputDevices." + self.inputDevice + ".delay)"
-		exec cmd
+		exec(cmd)
 		label = _("Devicename:")
 		cmd = "self.nameEntry = getConfigListEntry(label, config.inputDevices." + self.inputDevice + ".name)"
-		exec cmd
+		exec(cmd)
 		if self.enableEntry:
 			if isinstance(self.enableEntry[1], ConfigYesNo):
 				self.enableConfigEntry = self.enableEntry[1]
@@ -232,12 +229,12 @@ class InputDeviceSetup(Screen, ConfigListScreen):
 
 	def confirm(self, confirmed):
 		if not confirmed:
-			print "[InputDeviceSetup] not confirmed"
+			print("[InputDeviceSetup] not confirmed")
 			return
 		else:
 			self.nameEntry[1].setValue(iInputDevices.getDeviceAttribute(self.inputDevice, 'name'))
 			cmd = "config.inputDevices." + self.inputDevice + ".name.save()"
-			exec cmd
+			exec(cmd)
 			self.keySave()
 
 	def apply(self):


### PR DESCRIPTION
 - add python 3 compatibility, simplify config command statements
- update rctype tables
- if remote reconfigurable - make reconfig line obviously actionable and add picon. Also improve line statement so that user understands its actionable! 
- use both MachineBuild & Receiver Proc to find rctype match 