### PR TITLE
If no resume marker, use first marker as resume point for playback

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -3671,22 +3671,27 @@ class InfoBarCueSheetSupport:
 		force_resume = self.force_next_resume
 		self.force_next_resume = False
 		self.resume_point = None
+		last = start = None
 		if self.ENABLE_RESUME_SUPPORT:
 			for (pts, what) in self.cut_list:
-				if what == self.CUT_TYPE_LAST:
+				if what == self.CUT_TYPE_MARK and start is None:
+					start = pts
+				elif what == self.CUT_TYPE_LAST and last is None:
 					last = pts
+				if start is not None and last is not None:
 					break
-			else:
-				last = getResumePoint(self.session)
-			if last is None:
-				return
-			# only resume if at least 10 seconds ahead, or <10 seconds before the end.
+			last = last or getResumePoint(self.session)
 			seekable = self.__getSeekable()
 			if seekable is None:
 				return # Should not happen?
 			length = seekable.getLength() or (None,0)
-			# Hmm, this implies we don't resume if the length is unknown...
-			if (last > 900000) and (not length[1]  or (last < length[1] - 900000)):
+			# if there's no resume or resume is in the first 10 seconds, use the start marker
+			# if it's within the first 20% or the pre-recording padding
+			if ((last is None or last < 900000) and
+				(start < length[1] / 5 or start < (config.recording.margin_before.value+1) * 5400000)):
+				last = start
+			# only resume if the resume point is more than 10 seconds from the start or the end.
+			if last > 900000 and (not length[1] or last < length[1] - 900000):
 				self.resume_point = last
 				l = last / 90000
 				if force_resume:


### PR DESCRIPTION
When using the resume or ask resume option in the recording settings this change will ask if you want to resume from the first marker if there's no specific resume marker set and one of the following is true:
- start marker is within the first 20% of a recording
- start marker is within pre-recording margin + 1 minute of the start of the recording

Sometimes the marker is missing from the start of recordings, so this automates the OK, check to see if there's a start marker, Exit, Press > when starting playback.

An additional option can be added if necessary.