### PR TITLE
Use ImportError to detect missing plugins

### DIFF
--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -2660,34 +2660,34 @@ class InfoBarExtensions:
 			self.session.open(MessageBox, _("The AutoTimer plugin is not installed!\nPlease install it."), type = MessageBox.TYPE_INFO,timeout = 10 )
 
 	def showEPGSearch(self):
-		if not os.path.exists("/usr/lib/enigma2/python/Plugins/Extensions/EPGSearch/plugin.pyo"):
-			self.session.open(MessageBox, _("The EPGSearch plugin is not installed!\nPlease install it."), type = MessageBox.TYPE_INFO,timeout = 10 )
-			return
-		from Plugins.Extensions.EPGSearch.EPGSearch import EPGSearch
-		s = self.session.nav.getCurrentService()
-		if s:
-			info = s.info()
-			event = info.getEvent(0) # 0 = now, 1 = next
-			if event:
-				name = event and event.getEventName() or ''
-			else:
-				name = self.session.nav.getCurrentlyPlayingServiceOrGroup().toString()
-				name = name.split('/')
-				name = name[-1]
-				name = name.replace('.',' ')
-				name = name.split('-')
-				name = name[0]
-				if name.endswith(' '):
-					name = name[:-1]
-			if name:
-				self.session.open(EPGSearch, name, False)
+		try:
+			from Plugins.Extensions.EPGSearch.EPGSearch import EPGSearch
+			s = self.session.nav.getCurrentService()
+			if s:
+				info = s.info()
+				event = info.getEvent(0) # 0 = now, 1 = next
+				if event:
+					name = event and event.getEventName() or ''
+				else:
+					name = self.session.nav.getCurrentlyPlayingServiceOrGroup().toString()
+					name = name.split('/')
+					name = name[-1]
+					name = name.replace('.',' ')
+					name = name.split('-')
+					name = name[0]
+					if name.endswith(' '):
+						name = name[:-1]
+				if name:
+					self.session.open(EPGSearch, name, False)
+				else:
+					self.session.open(EPGSearch)
 			else:
 				self.session.open(EPGSearch)
-		else:
-			self.session.open(EPGSearch)
+		except ImportError:
+			self.session.open(MessageBox, _("The EPGSearch plugin is not installed!\nPlease install it."), type=MessageBox.TYPE_INFO, timeout=10)
 
 	def showIMDB(self):
-		if os.path.exists("/usr/lib/enigma2/python/Plugins/Extensions/IMDb/plugin.pyo"):
+		try:
 			from Plugins.Extensions.IMDb.plugin import IMDB
 			s = self.session.nav.getCurrentService()
 			if s:
@@ -2695,14 +2695,14 @@ class InfoBarExtensions:
 				event = info.getEvent(0) # 0 = now, 1 = next
 				name = event and event.getEventName() or ''
 				self.session.open(IMDB, name)
-		else:
+		except ImportError:
 			self.session.open(MessageBox, _("The IMDb plugin is not installed!\nPlease install it."), type = MessageBox.TYPE_INFO,timeout = 10 )
 
 	def showDreamPlex(self):
-		if os.path.exists("/usr/lib/enigma2/python/Plugins/Extensions/DreamPlex/plugin.pyo"):
+		try:
 			from Plugins.Extensions.DreamPlex.plugin import DPS_MainMenu
 			self.session.open(DPS_MainMenu)
-		else:
+		except ImportError:
 			self.session.open(MessageBox, _("The DreamPlex plugin is not installed!\nPlease install it."), type = MessageBox.TYPE_INFO,timeout = 10 )
 
 from Tools.BoundFunction import boundFunction


### PR DESCRIPTION
Switch InfobarGenerics to use _ImportError_ as the indication of a missing plugin rather than relying on the presence of _plugin.pyo_