### PR TITLE
Fix Menu to stop crashes:

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -102,7 +102,7 @@ self.session.openWithCallback(msgClosed, EpgDeleteMsg)
 				<menu weight="4" level="0" text="Front panel display" entryID="display_selection" requires="Display">
 					<id val="display"/>
 					<item weight="1" level="0" text="Settings" entryID="display_setup"><setup id="display"/></item>
-					<item weight="2" level="0" text="Skin" entryID="lcd_skin_setup"><screen module="SkinSelector" screen="LcdSkinSelector"/></item>
+					<item weight="2" level="0" text="Skin" entryID="lcd_skin_setup" requires="LCDSKINSetup"><screen module="SkinSelector" screen="LcdSkinSelector"/></item>
 				</menu>
 				<!-- Menu / Setup / User Interface / LED Display -->
 				<menu weight="5" level="0" text="LED display panel" entryID="leddisplay_selection" requires="DisplayLED">

--- a/data/menu.xml
+++ b/data/menu.xml
@@ -147,9 +147,9 @@ self.session.open(SABnzbdSetupScreen)
 				<item level="2" text="Password" entryID="password_setup"><screen module="NetworkSetup" screen="NetworkPassword"/></item>
 			</menu>
 			<!-- Menu / Setup / Common Interface -->
-			<menu weight="7" text="Common interface" entryID="cicam_setup">
+			<menu weight="7" text="Common interface" entryID="cicam_setup" requires="CommonInterface">
 				<id val="cicam"/>
-				<item weight="10" level="1" text="Common interface" entryID="ci_setup" requires="CommonInterface"><screen module="Ci" screen="CiSelection"/></item>
+				<item weight="10" level="1" text="Common interface" entryID="ci_setup"><screen module="Ci" screen="CiSelection"/></item>
 			</menu>
 			<!-- Menu / Setup / Softcam -->
 			<menu weight="8" text="Softcam" entryID="cam_setup">


### PR DESCRIPTION
Remove Common Interface from Menu for boxes with no CI slot.
Fix crash on boxes with no front panel display