### PR TITLE
Fix recording deadlock

### DIFF
--- a/lib/dvb/filepush.cpp
+++ b/lib/dvb/filepush.cpp
@@ -329,19 +329,13 @@ eFilePushThreadRecorder::eFilePushThreadRecorder(unsigned char* buffer, size_t b
 
 void eFilePushThreadRecorder::thread()
 {
+	ignore_but_report_signals();
+	hasStarted(); /* "start()" blocks until we get here */
 	setIoPrio(IOPRIO_CLASS_RT, 7);
-
 	eDebug("[eFilePushThreadRecorder] THREAD START");
 
-	/* we set the signal to not restart syscalls, so we can detect our signal. */
-	struct sigaction act;
-	act.sa_handler = signal_handler; // no, SIG_IGN doesn't do it. we want to receive the -EINTR
-	act.sa_flags = 0;
-	sigaction(SIGUSR1, &act, 0);
-
-	hasStarted();
-
-	/* m_stop must be evaluated after each syscall. */
+	/* m_stop must be evaluated after each syscall */
+	/* if it isn't, there's a chance of the thread becoming deadlocked when recordings are finishing */
 	while (!m_stop)
 	{
 		/* this works around the buggy Broadcom encoder that always returns even if there is no data */
@@ -350,20 +344,25 @@ void eFilePushThreadRecorder::thread()
 
 		struct pollfd pfd = { m_fd_source, POLLIN, 0 };
 		poll(&pfd, 1, 100);
+		/* Reminder: m_stop *must* be evaluated after each syscall. */
+		if (m_stop)
+			break;
 
 		ssize_t bytes = ::read(m_fd_source, m_buffer, m_buffersize);
+		/* And again: Check m_stop regardless of read success. */
+		if (m_stop)
+			break;
+
 		if (bytes < 0)
 		{
 			bytes = 0;
-			/* Check m_stop after interrupted syscall. */
-			if (m_stop) {
-				break;
-			}
 			if (errno == EINTR || errno == EBUSY || errno == EAGAIN)
+			{
 #if HAVE_HISILICON
 				usleep(100000);
 #endif
-			continue;
+				continue;
+			}
 			if (errno == EOVERFLOW)
 			{
 				eWarning("[eFilePushThreadRecorder] OVERFLOW while recording");


### PR DESCRIPTION
Fixes for a threading deadlock when a recording is finalised and the recording thread is requested to be shut down.