### PR TITLE
Add thread signal mask to fix recording deadlocks

### DIFF
--- a/lib/dvb/filepush.cpp
+++ b/lib/dvb/filepush.cpp
@@ -37,6 +37,12 @@ static void signal_handler(int x)
 
 static void ignore_but_report_signals()
 {
+	/* we must set a signal mask for the thread otherwise signals don't have any effect */
+	sigset_t sigmask;
+	sigemptyset(&sigmask);
+	sigaddset(&sigmask, SIGUSR1);
+	pthread_sigmask(SIG_UNBLOCK, &sigmask, NULL);
+	
 	/* we set the signal to not restart syscalls, so we can detect our signal. */
 	struct sigaction act;
 	act.sa_handler = signal_handler; // no, SIG_IGN doesn't do it. we want to receive the -EINTR


### PR DESCRIPTION
Signalling wasn't working, so it was possible for ::read to cause a
threading deadlock when the main thread requests a recording
to stop, if the read buffer happened to be empty on entry.
This change makes sure the signal is unblocked on the recording thread
so it can interrupt system calls.