### PR TITLE
Fix empty directory bug in movie list

### DIFF
--- a/ServiceReference.py
+++ b/ServiceReference.py
@@ -21,6 +21,16 @@ def resolveAlternate(serviceref):
 	return nref
 
 # Extensions to eServiceReference
+@staticmethod
+def __fromDirectory(path):
+	ref = eServiceReference(eServiceReference.idFile,
+			eServiceReference.flagDirectory |
+			eServiceReference.shouldSort | eServiceReference.sort1, path)
+	ref.setData(0, 1)
+	return ref
+
+eServiceReference.fromDirectory = __fromDirectory
+
 eServiceReference.isPlayback = lambda serviceref: "0:0:0:0:0:0:0:0:0" in serviceref.toCompareString()
 
 # Apply ServiceReference method proxies to the eServiceReference object so the two classes can be used interchangeably

--- a/lib/python/Components/FileList.py
+++ b/lib/python/Components/FileList.py
@@ -181,7 +181,7 @@ class FileList(MenuList):
 			directories = [ ]
 		elif self.useServiceRef:
 			# we should not use the 'eServiceReference(string)' constructor, because it doesn't allow ':' in the directoryname
-			root = eServiceReference(2, 0, directory)
+			root = eServiceReference.fromDirectory(directory)
 			if self.additional_extensions:
 				root.setName(self.additional_extensions)
 			serviceHandler = eServiceCenter.getInstance()
@@ -404,7 +404,7 @@ class MultiFileSelectList(FileList):
 			files = [ ]
 			directories = [ ]
 		elif self.useServiceRef:
-			root = eServiceReference("2:0:1:0:0:0:0:0:0:0:" + directory)
+			root = eServiceReference.fromDirectory(directory)
 			if self.additional_extensions:
 				root.setName(self.additional_extensions)
 			serviceHandler = eServiceCenter.getInstance()

--- a/lib/python/Components/MovieList.py
+++ b/lib/python/Components/MovieList.py
@@ -8,11 +8,9 @@ from Tools.FuzzyDate import FuzzyTime
 from Components.MultiContent import MultiContentEntryText, MultiContentEntryPixmapAlphaTest, MultiContentEntryPixmapAlphaBlend, MultiContentEntryProgress
 from Components.config import config
 from Components.Renderer.Picon import getPiconName
+from Screens.LocationBox import defaultInhibitDirs
 from Tools.LoadPixmap import LoadPixmap
 from Tools.Directories import SCOPE_ACTIVE_SKIN, resolveFilename
-from Screens.LocationBox import defaultInhibitDirs
-from ServiceReference import ServiceReference
-#
 from Tools.Trashcan import getTrashFolder
 import NavigationInstance
 from skin import parseColor, parseFont, parseScale
@@ -599,8 +597,7 @@ class MovieList(GUIComponent):
 				# enigma wants an extra '/' appended
 				if not parent.endswith('/'):
 					parent += '/'
-				ref = eServiceReference("2:0:1:0:0:0:0:0:0:0:" + parent)
-				ref.flags = eServiceReference.flagDirectory
+				ref = eServiceReference.fromDirectory(parent)
 				self.list.append((ref, None, 0, -1))
 				numberOfDirs += 1
 

--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -996,10 +996,9 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 
 	def showEventInformation(self):
 		from Screens.EventView import EventViewSimple
-		from ServiceReference import ServiceReference
 		evt = self["list"].getCurrentEvent()
 		if evt:
-			self.session.open(EventViewSimple, evt, ServiceReference(self.getCurrent()))
+			self.session.open(EventViewSimple, evt, self.getCurrent())
 
 	def saveListsize(self):
 		listsize = self["list"].instance.size()
@@ -1529,7 +1528,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		self["list"].setSortType(type)
 
 	def setCurrentRef(self, path):
-		self.current_ref = eServiceReference("2:0:1:0:0:0:0:0:0:0:" + path)
+		self.current_ref = eServiceReference.fromDirectory(path)
 		# Magic: this sets extra things to show
 		self.current_ref.setName('16384:jpg 16384:png 16384:gif 16384:bmp')
 
@@ -1625,7 +1624,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 				if selItem:
 					self.reloadList(home = True, sel = selItem)
 				else:
-					self.reloadList(home = True, sel = eServiceReference("2:0:1:0:0:0:0:0:0:0:" + currentDir))
+					self.reloadList(home = True, sel = eServiceReference.fromDirectory(currentDir))
 			else:
 				mbox=self.session.open(
 					MessageBox,
@@ -1810,7 +1809,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 			os.mkdir(path)
 			if not path.endswith('/'):
 				path += '/'
-			self.reloadList(sel = eServiceReference("2:0:1:0:0:0:0:0:0:0:" + path))
+			self.reloadList(sel = eServiceReference.fromDirectory(path))
 		except OSError, e:
 			print "[MovieSelection] Error %s:" % e.errno, e
 			if e.errno == 17:
@@ -1847,13 +1846,12 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 			text = name)
 
 	def do_decode(self):
-		from ServiceReference import ServiceReference
 		item = self.getCurrentSelection()
 		info = item[1]
 		filepath = item[0].getPath()
 		if not filepath.endswith('.ts'):
 			return
-		serviceref = ServiceReference(None, reftype = eServiceReference.idDVB, path = filepath)
+		serviceref = eServiceReference(eServiceReference.idDVB, 0, filepath)
 		name = info.getName(item[0]) + ' - decoded'
 		description = info.getInfoString(item[0], iServiceInformation.sDescription)
 		recording = RecordTimer.RecordTimerEntry(serviceref, int(time.time()), int(time.time()) + 3600, name, description, 0, dirname = preferredTimerPath())
@@ -1892,7 +1890,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 				msg = None
 				print "[MovieSelection] rename", path, "to", newpath
 				os.rename(path, newpath)
-				self.reloadList(sel = eServiceReference("2:0:1:0:0:0:0:0:0:0:" + newpath))
+				self.reloadList(sel = eServiceReference.fromDirectory(newpath))
 			except OSError, e:
 				print "[MovieSelection] Error %s:" % e.errno, e
 				if e.errno == 17:


### PR DESCRIPTION
If a directory contained a colon, movielist wouldn't show its contents
Magic strings and numbers were being used to and create
eServiceReference instances and this parses badly when created by string
Switch to a new static helper method on eServiceReference