### PR TITLE
Fix memory leak in MovieList

### DIFF
--- a/lib/python/Components/MovieList.py
+++ b/lib/python/Components/MovieList.py
@@ -194,8 +194,6 @@ class MovieList(GUIComponent):
 		if root is not None:
 			self.reload(root)
 
-		self.l.setBuildFunc(self.buildMovieListEntry)
-
 		self.onSelectionChanged = [ ]
 		self.iconPart = []
 		for part in range(5):
@@ -549,6 +547,7 @@ class MovieList(GUIComponent):
 			self.load(root, filter_tags)
 		else:
 			self.load(self.root, filter_tags)
+		self.l.setBuildFunc(self.buildMovieListEntry)  # don't move that to __init__ as this will create memory leak when calling MovieList from WebIf
 		self.l.setList(self.list)
 
 	def removeService(self, service):


### PR DESCRIPTION
This memory leak occurs when listing the movies via the WebIf.
There is a cyclic reference between MovieList and eListboxPythonMultiContent
when the list build function is set. This prevents object destruction and so
the complete movie list stays in memory forever.
WebIf does not call reload, so it's save to set the function there.
Using a weakref for the method does not work as c++ cannot call it.