### PR TITLE
Bugfix for only save timers.xml once when recordings start and stop

### DIFF
--- a/RecordTimer.py
+++ b/RecordTimer.py
@@ -1394,7 +1394,7 @@ class RecordTimer(timer.Timer):
 		self.saveTimer()
 
 	def shutdown(self):
-		self.saveTimer(True)
+		self.saveTimer()
 
 	def cleanup(self):
 		timer.Timer.cleanup(self)


### PR DESCRIPTION
Fixed crash on shutdown introduced by b57f7753