### PR TITLE
Add option to specify Update Interval

### DIFF
--- a/lib/python/Plugins/SystemPlugins/OpentvZapper/opentv_zapper.py
+++ b/lib/python/Plugins/SystemPlugins/OpentvZapper/opentv_zapper.py
@@ -21,7 +21,7 @@ import six
 
 debug_name = "opentv_zapper"
 lamedb_path = "/etc/enigma2"
-download_interval = 6 * 60 * 60 # 6 hours
+download_interval = config.plugins.opentvzapper.update_interval.value * 60 * 60 #  6 hours
 download_duration = 180 # stay tuned for 3 minutes
 start_first_download = 5 * 60 # 5 minutes after booting
 wait_time_on_fail = 15 * 60 # 15 minutes

--- a/lib/python/Plugins/SystemPlugins/OpentvZapper/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/OpentvZapper/plugin.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from Components.config import config, ConfigSelection, ConfigSubsection, ConfigYesNo
+from Components.config import config, ConfigSelection, ConfigSubsection, ConfigYesNo, ConfigSelectionNumber
 from Components.NimManager import nimmanager
 
 from Plugins.Plugin import PluginDescriptor
@@ -12,6 +12,7 @@ from .providers import providers
 config.plugins.opentvzapper = ConfigSubsection()
 config.plugins.opentvzapper.enabled = ConfigYesNo(default = False)
 config.plugins.opentvzapper.providers = ConfigSelection(default="Astra 28.2", choices=list(providers.keys()))
+config.plugins.opentvzapper.update_interval = ConfigSelectionNumber(min = 3, max = 24, stepwidth = 3, default = 6, wraparound = True)
 config.plugins.opentvzapper.extensions = ConfigYesNo(default = True)
 config.plugins.opentvzapper.notifications = ConfigYesNo(default = False)
 

--- a/lib/python/Plugins/SystemPlugins/OpentvZapper/setup.xml
+++ b/lib/python/Plugins/SystemPlugins/OpentvZapper/setup.xml
@@ -3,6 +3,7 @@
 		<item text="Enable OpenTV download" description="Enable automated downloading of OpenTV EPG data. If only one tuner is available the download will be done when the reciever is in standby.">config.plugins.opentvzapper.enabled</item>
 		<if conditional="config.plugins.opentvzapper.enabled.value">
 			<item text="Provider" description=" ">config.plugins.opentvzapper.providers</item>
+			<item text="Update Interval" description="Set update interval (in hours).">config.plugins.opentvzapper.update_interval</item>
 			<item text="Show in extensions" description="When enabled a forced download will be possible from the extensions menu (blue button). Shows after next restart.">config.plugins.opentvzapper.extensions</item>
 			<item text="Show notifications" description="Show on-screen notifications (pop up) to warn the OpenTV download is in progress.">config.plugins.opentvzapper.notifications</item>
 		</if>


### PR DESCRIPTION
Allows option of specifying update interval of EPG (in hours).  Adjustable in multiples of 3 hours.  Default remains 6 hours