### PR TITLE
Fix crash when using the default EPG/Info menus

### DIFF
--- a/lib/python/Components/MovieList.py
+++ b/lib/python/Components/MovieList.py
@@ -582,6 +582,8 @@ class MovieList(GUIComponent):
 			if item[0] == service:
 				self.removeMark(item[0])
 				del self.list[index]
+				if index < self.instance.getCurrentIndex():
+					self.moveUp()
 				return True
 		return False
 

--- a/lib/python/Screens/EpgSelectionBase.py
+++ b/lib/python/Screens/EpgSelectionBase.py
@@ -329,14 +329,12 @@ class EPGSelectionBase(Screen, HelpableScreen):
 		self.session.openWithCallback(callback, TimerEntry, timer)
 
 	def removeTimer(self, timer):
-		self.closePopupDialog()
 		timer.afterEvent = AFTEREVENT.NONE
 		self.session.nav.RecordTimer.removeEntry(timer)
 		self.setActionButtonText("addEditTimer", _("Add Timer"))
 		self.refreshList()
 
 	def disableTimer(self, timer):
-		self.closePopupDialog()
 		timer.disable()
 		self.session.nav.RecordTimer.timeChanged(timer)
 		self.setActionButtonText("addEditTimer", _("Add Timer"))
@@ -388,11 +386,6 @@ class EPGSelectionBase(Screen, HelpableScreen):
 		return None, None
 
 	def __popupMenu(self, title, menu):
-		def callback(choice):
-			self.closePopupDialog()
-			choice[0](*choice[1:])
-
-		menu = [(item[0], "CALLFUNC", callback, item[1:]) for item in menu]
 		self.popupDialog = self.session.instantiateDialog(PopupChoiceBox, title=title, list=menu, keys=["green", "blue"], skin_name="RecordTimerQuestion", closeCB=self.closePopupDialog)
 		pos = self["list"].getSelectionPosition()
 		self.popupDialog.instance.move(ePoint(pos[0] - self.popupDialog.instance.size().width(), self.instance.position().y() + pos[1]))
@@ -411,9 +404,7 @@ class EPGSelectionBase(Screen, HelpableScreen):
 		self.popupDialog.show()
 
 	def closePopupDialog(self):
-		if self.popupDialog is not None:
-			self.popupDialog.doClose()
-			self.popupDialog = None
+		self.popupDialog = None
 		self["okactions"].setEnabled(True)
 		if "epgcursoractions" in self:
 			self["epgcursoractions"].setEnabled(True)

--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -2,7 +2,6 @@ from Screen import Screen
 from Components.Button import Button
 from Components.ActionMap import HelpableActionMap, ActionMap, HelpableNumberActionMap
 from Components.ChoiceList import ChoiceList, ChoiceEntryComponent
-from Components.MenuList import MenuList
 from Components.MovieList import MovieList, getItemDisplayName, resetMoviePlayState, AUDIO_EXTENSIONS, DVD_EXTENSIONS, IMAGE_EXTENSIONS, moviePlayState
 from Components.DiskInfo import DiskInfo
 from Tools.Trashcan import TrashInfo
@@ -1295,7 +1294,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 			choices = [
 				(ngettext("Play the marked recording", "Play %d marked recordings" % markedFilesCount, markedFilesCount), self.__addItemsToPlaylist, markedFiles),
 				(_("Play the selected recording"), self.__playCurrentItem)]
-			self.session.open(ChoiceBox, title=title, list=choices)
+			self.session.open(ChoiceBox, title=title, callbackList=choices)
 
 	def __addItemsToPlaylist(self, markedItems):
 		global playlist
@@ -2203,20 +2202,19 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 			title = "Recording in progress: %s" % name if recCount == 1 else "Recordings in progress: %d" % recCount
 			choices = [
 				(_("Cancel"), None),
-				(ngettext("Stop this recording", "Stop these recordings", recCount), "s"),
-				(ngettext("Stop this recording and delete it", "Stop these recordings and delete them", recCount), "d")]
-			self.session.openWithCallback(lambda choice: self.__onTimerChoice(delList, recList, delInfo, choice), ChoiceBox, title=title, list=choices)
+				(ngettext("Stop this recording", "Stop these recordings", recCount), self.__onTimerChoiceStop, recList),
+				(ngettext("Stop this recording and delete it", "Stop these recordings and delete them", recCount), self.__onTimerChoiceDelete, delList, recList, delInfo)]
+			self.session.open(ChoiceBox, title=title, callbackList=choices)
 
-	def __onTimerChoice(self, delList, recList, delInfo, choice):
-		if choice is None or choice[1] is None:
-			return
+	def __onTimerChoiceStop(self, recList):
 		for rec in recList:
 			self.stopTimer(rec[1])
-		# only continue if the delete option was selected, otherwise unmark everything
-		if choice[1] == "d":
-			self.__showDeleteConfirmation(delList, delInfo)
-		else:
-			self.clearMarks()
+		self.clearMarks()
+
+	def __onTimerChoiceDelete(self, delList, recList, delInfo):
+		for rec in recList:
+			self.stopTimer(rec[1])
+		self.__showDeleteConfirmation(delList, delInfo)
 
 	def __showDeleteConfirmation(self, delList, delInfo):
 		dirCount, fileCount, subItemCount, inTrash = delInfo


### PR DESCRIPTION
Crash was introduced by an over optimistic new feature in ChoiceBox. This has been reverted and replaced with something that's more compatible with existing usages of ChoiceBox.