### PR TITLE
Log rather than crash if a widget has no parent

### DIFF
--- a/lib/gui/ewidget.cpp
+++ b/lib/gui/ewidget.cpp
@@ -333,9 +333,13 @@ void eWidget::recalcClipRegionsWhenVisible()
 			t->m_desktop->recalcClipRegions(t);
 			break;
 		}
+		if (!t->m_parent)
+		{
+			eLogNoNewLineStart(lvlError, "[eWidget] RecalcClipRegions for widget at (%d,%d)=>(%d,%d).", this->position().x(), this->position().y(), this->size().width(), this->size().height());
+			eLogNoNewLine(lvlError, "Top level parent at (%d,%d)=>(%d,%d) has no desktop", t->position().x(), t->position().y(), t->size().width(), t->size().height());
+		}
 		t = t->m_parent;
-		ASSERT(t);
-	} while(1);
+	} while(t);
 }
 
 void eWidget::parentRemoved()


### PR DESCRIPTION
This prevents a hard crash when reloading skins. Somewhere
there's a reference being held to the TimeshiftState's PositionGauge