### PR TITLE
Add a global scrollbar style

### DIFF
--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -39,12 +39,17 @@ void eListbox::setScrollbarMode(int mode)
 	{
 		m_scrollbar = new eSlider(this);
 		m_scrollbar->hide();
-		m_scrollbar->setBorderWidth(1);
 		m_scrollbar->setOrientation(eSlider::orVertical);
 		m_scrollbar->setRange(0,100);
 		if (m_scrollbarbackgroundpixmap) m_scrollbar->setBackgroundPixmap(m_scrollbarbackgroundpixmap);
 		if (m_scrollbarpixmap) m_scrollbar->setPixmap(m_scrollbarpixmap);
-		if (m_style.m_sliderborder_color_set) m_scrollbar->setSliderBorderColor(m_style.m_sliderborder_color);
+		if (m_style.m_scrollbarforeground_color_set) m_scrollbar->setForegroundColor(m_style.m_scrollbarforeground_color);
+		if (m_style.m_scrollbarbackground_color_set) m_scrollbar->setBackgroundColor(m_style.m_scrollbarbackground_color);
+		if (m_style.m_scrollbarborder_width_set)
+			m_scrollbar->setBorderWidth(m_style.m_scrollbarborder_width);
+		else
+			m_scrollbar->setBorderWidth(1);
+		if (m_style.m_scrollbarborder_color_set) m_scrollbar->setBorderColor(m_style.m_scrollbarborder_color);
 	}
 }
 
@@ -632,18 +637,6 @@ void eListbox::setBorderWidth(int size)
 	if (m_scrollbar) m_scrollbar->setBorderWidth(size);
 }
 
-void eListbox::setScrollbarSliderBorderWidth(int size)
-{
-	m_style.m_scrollbarsliderborder_size = size;
-	m_style.m_scrollbarsliderborder_size_set = 1;
-	if (m_scrollbar) m_scrollbar->setSliderBorderWidth(size);
-}
-
-void eListbox::setScrollbarWidth(int size)
-{
-	m_scrollbar_width = size;
-}
-
 void eListbox::setBackgroundPicture(ePtr<gPixmap> &pm)
 {
 	m_style.m_background = pm;
@@ -654,33 +647,45 @@ void eListbox::setSelectionPicture(ePtr<gPixmap> &pm)
 	m_style.m_selection = pm;
 }
 
-void eListbox::setSliderPicture(ePtr<gPixmap> &pm)
+void eListbox::setScrollbarWidth(int size)
+{
+	m_scrollbar_width = size;
+}
+
+void eListbox::setScrollbarBorderWidth(int size)
+{
+	m_style.m_scrollbarborder_width = size;
+	if (m_scrollbar) m_scrollbar->setBorderWidth(size);
+}
+
+void eListbox::setScrollbarBorderColor(const gRGB &col)
+{
+	m_style.m_scrollbarborder_color = col;
+	m_style.m_scrollbarborder_color_set = 1;
+	if (m_scrollbar) m_scrollbar->setBorderColor(col);
+}
+
+void eListbox::setScrollbarForegroundColor(const gRGB &col)
+{
+	m_style.m_scrollbarforeground_color = col;
+	m_style.m_scrollbarforeground_color_set = 1;
+	if (m_scrollbar) m_scrollbar->setForegroundColor(col);
+}
+
+void eListbox::setScrollbarBackgroundColor(const gRGB &col)
+{
+	m_style.m_scrollbarbackground_color = col;
+	m_style.m_scrollbarbackground_color_set = 1;
+	if (m_scrollbar) m_scrollbar->setBackgroundColor(col);
+}
+
+void eListbox::setScrollbarPixmap(ePtr<gPixmap> &pm)
 {
 	m_scrollbarpixmap = pm;
 	if (m_scrollbar && m_scrollbarpixmap) m_scrollbar->setPixmap(pm);
 }
 
-void eListbox::setSliderForegroundColor(gRGB &col)
-{
-	m_style.m_sliderforeground_color = col;
-	m_style.m_sliderforeground_color_set = 1;
-	if (m_scrollbar) m_scrollbar->setSliderForegroundColor(col);
-}
-
-void eListbox::setSliderBorderColor(const gRGB &col)
-{
-	m_style.m_sliderborder_color = col;
-	m_style.m_sliderborder_color_set = 1;
-	if (m_scrollbar) m_scrollbar->setSliderBorderColor(col);
-}
-
-void eListbox::setSliderBorderWidth(int size)
-{
-	m_style.m_sliderborder_size = size;
-	if (m_scrollbar) m_scrollbar->setSliderBorderWidth(size);
-}
-
-void eListbox::setScrollbarBackgroundPicture(ePtr<gPixmap> &pm)
+void eListbox::setScrollbarBackgroundPixmap(ePtr<gPixmap> &pm)
 {
 	m_scrollbarbackgroundpixmap = pm;
 	if (m_scrollbar && m_scrollbarbackgroundpixmap) m_scrollbar->setBackgroundPixmap(pm);

--- a/lib/gui/elistbox.h
+++ b/lib/gui/elistbox.h
@@ -61,9 +61,10 @@ struct eListboxStyle
 {
 	ePtr<gPixmap> m_background, m_selection;
 	int m_transparent_background;
-	gRGB m_background_color, m_background_color_selected,
-	m_foreground_color, m_foreground_color_selected, m_border_color, m_sliderborder_color, m_sliderforeground_color;
-	int m_background_color_set, m_foreground_color_set, m_background_color_selected_set, m_foreground_color_selected_set, m_sliderforeground_color_set, m_sliderborder_color_set, m_scrollbarsliderborder_size_set;
+	gRGB m_background_color, m_background_color_selected, m_foreground_color, m_foreground_color_selected, m_border_color;
+	int m_background_color_set, m_foreground_color_set, m_background_color_selected_set, m_foreground_color_selected_set;
+	gRGB m_scrollbarborder_color, m_scrollbarforeground_color, m_scrollbarbackground_color;
+	int m_scrollbarforeground_color_set, m_scrollbarbackground_color_set, m_scrollbarborder_color_set, m_scrollbarborder_width_set;
 		/*
 			{m_transparent_background m_background_color_set m_background}
 			{0 0 0} use global background color
@@ -82,7 +83,7 @@ struct eListboxStyle
 		alignBottom=alignRight,
 		alignBlock
 	};
-	int m_valign, m_halign, m_border_size, m_sliderborder_size, m_scrollbarsliderborder_size;
+	int m_valign, m_halign, m_border_size, m_scrollbarborder_width;
 	ePtr<gFont> m_font, m_secondfont;
 	ePoint m_text_offset;
 };
@@ -147,20 +148,19 @@ public:
 	void setBackgroundPicture(ePtr<gPixmap> &pixmap);
 	void setSelectionPicture(ePtr<gPixmap> &pixmap);
 
-	void setSliderPicture(ePtr<gPixmap> &pm);
-	void setScrollbarBackgroundPicture(ePtr<gPixmap> &pm);
-	void setScrollbarSliderBorderWidth(int size);
-	void setScrollbarWidth(int size);
-
 	void setFont(gFont *font);
 	void setSecondFont(gFont *font);
 	void setVAlign(int align);
 	void setHAlign(int align);
 	void setTextOffset(const ePoint &textoffset);
 
-	void setSliderBorderColor(const gRGB &col);
-	void setSliderBorderWidth(int size);
-	void setSliderForegroundColor(gRGB &col);
+	void setScrollbarWidth(int width);
+	void setScrollbarBorderWidth(int width);
+	void setScrollbarBorderColor(const gRGB &col);
+	void setScrollbarForegroundColor(const gRGB &col);
+	void setScrollbarBackgroundColor(const gRGB &col);
+	void setScrollbarPixmap(ePtr<gPixmap> &pm);
+	void setScrollbarBackgroundPixmap(ePtr<gPixmap> &pm);
 
 	int getScrollbarWidth() { return m_scrollbar_width; }
 

--- a/lib/gui/eslider.cpp
+++ b/lib/gui/eslider.cpp
@@ -2,9 +2,8 @@
 
 eSlider::eSlider(eWidget *parent)
 	:eWidget(parent), m_have_border_color(false), m_have_foreground_color(false),
-	m_have_sliderborder_color(false), m_have_sliderforeground_color(false), m_have_sliderborder_width(false),
 	m_min(0), m_max(0), m_value(0), m_start(0), m_orientation(orHorizontal), m_orientation_swapped(0),
-	m_border_width(0), m_sliderborder_width(0)
+	m_border_width(0)
 {
 }
 
@@ -50,27 +49,6 @@ void eSlider::setForegroundColor(const gRGB &color)
 	invalidate();
 }
 
-void eSlider::setSliderBorderWidth(int pixel)
-{
-	m_sliderborder_width = pixel;
-	m_have_sliderborder_width = true;
-	invalidate();
-}
-
-void eSlider::setSliderBorderColor(const gRGB &color)
-{
-	m_sliderborder_color = color;
-	m_have_sliderborder_color = true;
-	invalidate();
-}
-
-void eSlider::setSliderForegroundColor(const gRGB &color)
-{
-	m_sliderforeground_color = color;
-	m_have_sliderforeground_color = true;
-	invalidate();
-}
-
 int eSlider::event(int event, void *data, void *data2)
 {
 	switch (event)
@@ -95,31 +73,20 @@ int eSlider::event(int event, void *data, void *data2)
 
 		if (!m_pixmap)
 		{
-			if (m_have_sliderforeground_color)
-				painter.setForegroundColor(m_sliderforeground_color);
-			else if (m_have_foreground_color)
+			if (m_have_foreground_color)
 				painter.setForegroundColor(m_foreground_color);
 			painter.fill(m_currently_filled);
 		}
 		else
 			painter.blit(m_pixmap, ePoint(0, 0), m_currently_filled.extends, isTransparent() ? gPainter::BT_ALPHATEST : 0);
 
-// border
-
-		if (m_have_sliderborder_color)
-			painter.setForegroundColor(m_sliderborder_color);
-		else if (m_have_border_color)
+		if (m_have_border_color)
 			painter.setForegroundColor(m_border_color);
 
-		int border_width;
-		if(m_have_sliderborder_width)
-			border_width = m_sliderborder_width;
-		else
-			border_width = m_border_width;
-		painter.fill(eRect(0, 0, s.width(), border_width));
-		painter.fill(eRect(0, border_width, border_width, s.height() - border_width));
-		painter.fill(eRect(border_width, s.height() - border_width, s.width() - border_width, border_width));
-		painter.fill(eRect(s.width() - border_width, border_width, border_width, s.height() - border_width));
+		painter.fill(eRect(0, 0, s.width(), m_border_width));
+		painter.fill(eRect(0, m_border_width, m_border_width, s.height() - m_border_width));
+		painter.fill(eRect(m_border_width, s.height() - m_border_width, s.width() - m_border_width, m_border_width));
+		painter.fill(eRect(s.width() - m_border_width, m_border_width, m_border_width, s.height() - m_border_width));
 
 		return 0;
 	}

--- a/lib/gui/eslider.h
+++ b/lib/gui/eslider.h
@@ -19,9 +19,6 @@ public:
 	void setPixmap(ePtr<gPixmap> &pixmap);
 	void setBackgroundPixmap(gPixmap *pixmap);
 	void setBackgroundPixmap(ePtr<gPixmap> &pixmap);
-	void setSliderBorderWidth(int pixel);
-	void setSliderBorderColor(const gRGB &color);
-	void setSliderForegroundColor(const gRGB &color);
 protected:
 	int event(int event, void *data=0, void *data2=0);
 private:
@@ -30,13 +27,11 @@ private:
 		evtChangedSlider = evtUserWidget
 	};
 	bool m_have_border_color, m_have_foreground_color;
-	bool m_have_sliderborder_color, m_have_sliderforeground_color, m_have_sliderborder_width;
-	int m_min, m_max, m_value, m_start, m_orientation, m_orientation_swapped, m_border_width, m_sliderborder_width;
+	int m_min, m_max, m_value, m_start, m_orientation, m_orientation_swapped, m_border_width;
 	ePtr<gPixmap> m_pixmap, m_backgroundpixmap;
 
 	gRegion m_currently_filled;
 	gRGB m_border_color, m_foreground_color;
-	gRGB m_sliderborder_color, m_sliderforeground_color;
 };
 
 #endif

--- a/lib/python/Components/GUIComponent.py
+++ b/lib/python/Components/GUIComponent.py
@@ -1,6 +1,6 @@
 import skin
 
-from enigma import ePoint, eSize
+from enigma import ePoint, eSize, eListbox
 
 class GUIComponent(object):
 	""" GUI component """
@@ -33,6 +33,8 @@ class GUIComponent(object):
 		if not self.visible:
 			self.instance.hide()
 
+		if type(self.instance) == eListbox:
+			skin.applyScrollbar(self.instance)
 		if self.skinAttributes:
 			skin.applyAllAttributes(self.instance, desktop, self.skinAttributes, parent.scale)
 			return True

--- a/lib/python/Components/ScrollLabel.py
+++ b/lib/python/Components/ScrollLabel.py
@@ -19,8 +19,7 @@ class ScrollLabel(GUIComponent):
 		self.splitchar = "|"
 
 	def applySkin(self, desktop, parent):
-		scrollbarWidth = 10
-		scrollbarBorderWidth = 1
+		scrollbarWidth = skin.applySlider(self.scrollbar, 10, 1)
 		ret = False
 		if self.skinAttributes:
 			widget_attribs = []
@@ -42,7 +41,7 @@ class ScrollLabel(GUIComponent):
 					scrollbarWidth = int(value)
 					self.skinAttributes.remove((attrib, value))
 				elif "scrollbarSliderBorderWidth" in attrib:
-					scrollbarBorderWidth = int(value)
+					self.scrollbar.setBorderWidth(int(value))
 					self.skinAttributes.remove((attrib, value))
 				elif "split" in attrib:
 					self.split = 1 if value.lower() in ("1", "enabled", "on", "split", "true", "yes") else 0
@@ -71,7 +70,6 @@ class ScrollLabel(GUIComponent):
 		self.scrollbar.resize(eSize(scrollbarWidth, self.pageHeight + int(lineheight / 6)))
 		self.scrollbar.setOrientation(eSlider.orVertical)
 		self.scrollbar.setRange(0, 100)
-		self.scrollbar.setBorderWidth(scrollbarBorderWidth)
 		self.setText(self.message)
 		return ret
 


### PR DESCRIPTION
You can now optionally set a single global scrollbar style for all
eListbox based widgets and ScrollLabel. Example

<scrollbarstyle width="6" borderWidth="1" borderColor="blue"
    foregroundColor="blue" backgroundColor="black"
    backgroundPixmap="scrollbg.png" sliderPixmap="slider.png"
	mode="showAlways" />

If you miss out any attributes, they'll assume the defaults, which are:

<scrollbarstyle width="10" borderWidth="1" borderColor="white"
    foregroundColor="white" backgroundColor="black"
	mode="showOnDemand" />

You can override the global style with the existing scrollbar attributes

eListbox has been modified to consistently name scrollbar properties
eSlider has been modified to remove the setSlider* methods. These did
nothing more than the corresponding set* methods.