### PR TITLE
Optionally group recordings by name into collections

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -483,6 +483,7 @@
 		<item level="0" text="Number of rows" description="Number of rows to display">config.movielist.itemsperpage</item>
 		<item level="0" text="Use slim screen" description="Use the alternative screen">config.movielist.useslim</item>
 		<item level="0" text="Use adaptive date display" description="Adaptive date display allows recent dates to be displayed as 'Today' or 'Yesterday'.  It hides the year for recordings made this year.  It hides the day of the week for recordings made in previous years.">config.movielist.use_fuzzy_dates</item>
+		<item level="0" text="Enable automatic collections" description="When enabled, recordings are grouped by name into collections automatically.">config.movielist.enable_collections</item>
 		<item level="0" text="Sort" description="Set the default sorting method.">self.cfg.moviesort</item>
 		<item level="0" text="Sort Trash by deletion time" description="Use the deletion time to sort Trash directories.\nMost recently deleted at the top.">config.usage.trashsort_deltime</item>
 		<item level="0" text="Show extended description" description="Show or hide the extended description, (skin dependant).">self.cfg.description</item>

--- a/lib/python/Components/Converter/MovieInfo.py
+++ b/lib/python/Components/Converter/MovieInfo.py
@@ -96,6 +96,8 @@ class MovieInfo(Converter, object):
 			elif self.type == self.MOVIE_REC_FILESIZE:
 				if (service.flags & eServiceReference.flagDirectory) == eServiceReference.flagDirectory:
 					return _("Directory")
+				if (service.flags & eServiceReference.isGroup) == eServiceReference.isGroup:
+					return _("Collection")
 				filesize = info.getInfoObject(service, iServiceInformation.sFileSize)
 				if filesize is not None:
 					if filesize >= 104857600000: #100000*1024*1024

--- a/lib/python/Components/MovieList.py
+++ b/lib/python/Components/MovieList.py
@@ -24,10 +24,13 @@ KNOWN_EXTENSIONS = MOVIE_EXTENSIONS.union(IMAGE_EXTENSIONS, DVD_EXTENSIONS, AUDI
 
 # Gets the name of a movielist item for display in the UI honouring the hide extensions setting
 def getItemDisplayName(itemRef, info, removeExtension=None):
-	name = info.getName(itemRef)
-	if itemRef.flags & eServiceReference.isDirectory:
+	if itemRef.flags & eServiceReference.isGroup:
+		name = itemRef.getName()
+	elif itemRef.flags & eServiceReference.isDirectory:
+		name = info.getName(itemRef)
 		name = os.path.basename(name.rstrip("/"))
 	else:
+		name = info.getName(itemRef)
 		removeExtension = config.movielist.hide_extensions.value if removeExtension is None else removeExtension
 		if removeExtension:
 			fileName, fileExtension = os.path.splitext(name)
@@ -35,11 +38,20 @@ def getItemDisplayName(itemRef, info, removeExtension=None):
 				name = fileName
 	return name
 
+def expandCollections(items):
+	expanded = []
+	for item in items:
+		if item[0].flags & eServiceReference.isGroup:
+			expanded.extend(item[3].collectionItems)
+		else:
+			expanded.append(item)
+	return expanded
+
 cutsParser = struct.Struct('>QI') # big-endian, 64-bit PTS and 32-bit type
 
 class MovieListData:
 	def __init__(self):
-		pass
+		self.dirty = True
 
 # iStaticServiceInformation
 class StubInfo:
@@ -168,7 +180,7 @@ class MovieList(GUIComponent):
 	UsingTrashSort = False
 	InTrashFolder = False
 
-	def __init__(self, root, sort_type=None, descr_state=None):
+	def __init__(self, root, sort_type=None, descr_state=None, allowCollections=False):
 		GUIComponent.__init__(self)
 		self.list = []
 		self.descr_state = descr_state or self.HIDE_DESCRIPTION
@@ -198,6 +210,7 @@ class MovieList(GUIComponent):
 		self.l = eListboxPythonMultiContent()
 		self.tags = set()
 		self.markList = []
+		self.allowCollections = allowCollections # used to disable collections when loaded by OpenWebIf
 		self.root = None
 		self._playInBackground = None
 		self._playInForeground = None
@@ -216,6 +229,7 @@ class MovieList(GUIComponent):
 		self.iconUnwatched = loadPNG(resolveFilename(SCOPE_ACTIVE_SKIN, "icons/part_unwatched.png"))
 		self.iconFolder = loadPNG(resolveFilename(SCOPE_ACTIVE_SKIN, "icons/folder.png"))
 		self.iconMarked = loadPNG(resolveFilename(SCOPE_ACTIVE_SKIN, "icons/mark_on.png"))
+		self.iconCollection = loadPNG(resolveFilename(SCOPE_ACTIVE_SKIN, "icons/collection.png")) or self.iconFolder
 		self.iconTrash = loadPNG(resolveFilename(SCOPE_ACTIVE_SKIN, "icons/trashcan.png"))
 		self.runningTimers = {}
 		self.updateRecordings()
@@ -344,8 +358,9 @@ class MovieList(GUIComponent):
 		self.l.setFont(1, gFont(self.fontName, (self.fontSize - 3) + config.movielist.fontsize.value))
 
 	def invalidateItem(self, index):
-		x = self.list[index]
-		self.list[index] = (x[0], x[1], x[2], None)
+		data = self.list[index][3]
+		if data:
+			data.dirty = True
 		self.l.invalidateEntry(index)
 
 	def invalidateCurrentItem(self):
@@ -375,6 +390,15 @@ class MovieList(GUIComponent):
 		pathName = serviceref.getPath()
 		res = [ None ]
 
+		if serviceref.flags & eServiceReference.isGroup:
+			# Collections
+			res.append(MultiContentEntryPixmapAlphaBlend(pos=(0, 0), size=(col0iconSize, self.itemHeight), png=self.iconCollection, flags=BT_ALIGN_CENTER))
+			if self.getCurrent() in self.markList:
+				res.append(MultiContentEntryPixmapAlphaBlend(pos=(0, 0), size=(col0iconSize, self.itemHeight), png=self.iconMarked))
+			res.append(MultiContentEntryText(pos=(col0iconSize + space, 0), size=(width-220, self.itemHeight), font=0, flags = RT_HALIGN_LEFT|RT_VALIGN_CENTER, text = data.txt))
+			recordingCount = ngettext("%d Recording", "%d Recordings", data.collectionCount) % data.collectionCount
+			res.append(MultiContentEntryText(pos=(width-220-r, 0), size=(220, self.itemHeight), font=1, flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=recordingCount))
+			return res
 		if serviceref.flags & eServiceReference.mustDescent:
 			# Directory
 			# Name is full path name
@@ -398,8 +422,7 @@ class MovieList(GUIComponent):
 			res.append(MultiContentEntryText(pos=(col0iconSize + space, 0), size=(width-145, self.itemHeight), font=0, flags = RT_HALIGN_LEFT|RT_VALIGN_CENTER, text = txt))
 			res.append(MultiContentEntryText(pos=(width-145-r, 0), size=(145, self.itemHeight), font=1, flags=RT_HALIGN_RIGHT|RT_VALIGN_CENTER, text=_("Directory")))
 			return res
-		if data == -1 or data is None:
-			data = MovieListData()
+		if data.dirty:
 			cur_idx = self.l.getCurrentSelectionIndex()
 			x = self.list[cur_idx] # x = ref,info,begin,...
 			if config.usage.load_length_of_movies_in_moviellist.value:
@@ -564,14 +587,14 @@ class MovieList(GUIComponent):
 		instance.setContent(None)
 		instance.selectionChanged.get().remove(self.selectionChanged)
 
-	def reload(self, root = None, filter_tags = None):
+	def reload(self, root=None, filter_tags=None, collection=None):
 		if self.reloadDelayTimer is not None:
 			self.reloadDelayTimer.stop()
 			self.reloadDelayTimer = None
 		if root is not None:
-			self.load(root, filter_tags)
+			self.load(root, filter_tags, collection)
 		else:
-			self.load(self.root, filter_tags)
+			self.load(self.root, filter_tags, collection)
 		self.l.setBuildFunc(self.buildMovieListEntry)  # don't move that to __init__ as this will create memory leak when calling MovieList from WebIf
 		self.refreshDisplay()
 
@@ -593,6 +616,15 @@ class MovieList(GUIComponent):
 				if index < self.instance.getCurrentIndex():
 					self.moveUp()
 				return True
+			data = item[3]
+			if item[0].flags & eServiceReference.isGroup and data:
+				for colIemIndex, colItem in enumerate(data.collectionItems):
+					if colItem[0] == service:
+						del data.collectionItems[colIemIndex]
+						if len(data.collectionItems) == 0:
+							self.removeMark(item[0])
+							del self.list[index]
+						return True
 		return False
 
 	def findService(self, service):
@@ -612,13 +644,16 @@ class MovieList(GUIComponent):
 	def __iter__(self):
 		return self.list.__iter__()
 
-	def load(self, root, filter_tags):
+	def load(self, root, filter_tags, collectionName=None):
 		# this lists our root service, then building a
 		# nice list
 		del self.list[:]
 		del self.markList[:]
 		serviceHandler = eServiceCenter.getInstance()
 		numberOfDirs = 0
+		collectionMode = config.movielist.enable_collections.value
+		if not collectionMode or not self.allowCollections:
+			collectionName = None
 
 		reflist = root and serviceHandler.list(root)
 		if reflist is None:
@@ -627,17 +662,20 @@ class MovieList(GUIComponent):
 		realtags = set()
 		autotags = {}
 		rootPath = os.path.normpath(root.getPath())
+		split = os.path.split(rootPath)
 		parent = None
 		# Don't navigate above the "root"
 		if len(rootPath) > 1 and (os.path.realpath(rootPath) != os.path.realpath(config.movielist.root.value)):
-			parent = os.path.split(os.path.normpath(rootPath))[0]
-			currentfolder = os.path.normpath(rootPath) + '/'
-			if parent and (parent not in defaultInhibitDirs) and not currentfolder.endswith(config.usage.default_path.value):
+			parent = split[0]
+			currentFolder = os.path.normpath(rootPath) + '/'
+			if collectionName:
+				self.list.append((eServiceReference.fromDirectory(currentFolder), None, 0, MovieListData()))
+			elif parent and (parent not in defaultInhibitDirs) and not currentFolder.endswith(config.usage.default_path.value):
 				# enigma wants an extra '/' appended
 				if not parent.endswith('/'):
 					parent += '/'
 				ref = eServiceReference.fromDirectory(parent)
-				self.list.append((ref, None, 0, -1))
+				self.list.append((ref, None, 0, MovieListData()))
 				numberOfDirs += 1
 		firstDir = numberOfDirs
 
@@ -666,6 +704,10 @@ class MovieList(GUIComponent):
 				info = justStubInfo
 			begin = info.getInfo(serviceref, iServiceInformation.sTimeCreate)
 			begin2 = 0
+			name = info.getName(serviceref)
+			# OSX put a lot of stupid files ._* everywhere... we need to skip them
+			if name[:2] == "._":
+				continue
 			if MovieList.UsingTrashSort:
 				f_path = serviceref.getPath()
 				if os.path.exists(f_path):  # Override with deltime for sorting
@@ -673,20 +715,18 @@ class MovieList(GUIComponent):
 						begin2 = begin      # Save for later re-instatement
 					begin = os.stat(f_path).st_ctime
 
-			if serviceref.flags & eServiceReference.mustDescent:
-				dirname = info.getName(serviceref)
-				if not dirname.endswith('.AppleDouble/') and not dirname.endswith('.AppleDesktop/') and not dirname.endswith('.AppleDB/') and not dirname.endswith('Network Trash Folder/') and not dirname.endswith('Temporary Items/'):
-					self.list.append((serviceref, info, begin, -1))
+			# Filter on a specific collections
+			if collectionName and collectionName != name.strip():
+				continue
+
+			if not collectionName and serviceref.flags & eServiceReference.mustDescent:
+				if not name.endswith('.AppleDouble/') and not name.endswith('.AppleDesktop/') and not name.endswith('.AppleDB/') and not name.endswith('Network Trash Folder/') and not name.endswith('Temporary Items/'):
+					self.list.append((serviceref, info, begin, MovieListData()))
 					numberOfDirs += 1
 				continue
+
 			# convert space-separated list of tags into a set
 			this_tags = info.getInfoString(serviceref, iServiceInformation.sTags).split(' ')
-			name = info.getName(serviceref)
-
-			# OSX put a lot of stupid files ._* everywhere... we need to skip them
-			if name[:2] == "._":
-				continue
-
 			if this_tags == ['']:
 				# No tags? Auto tag!
 				this_tags = name.replace(',',' ').replace('.',' ').replace('_',' ').replace(':',' ').split()
@@ -710,9 +750,39 @@ class MovieList(GUIComponent):
 # 					print "Skipping", name, "tags=", this_tags, " filter=", filter_tags
 					continue
 			if begin2 != 0:
-				self.list.append((serviceref, info, begin, -1, begin2))
+				self.list.append((serviceref, info, begin, MovieListData(), begin2))
 			else:
-				self.list.append((serviceref, info, begin, -1))
+				self.list.append((serviceref, info, begin, MovieListData()))
+
+		if not collectionName and collectionMode and self.allowCollections:
+			# not displaying the contents of a collection, group similar named recordings into collections
+			groupedFiles = {}
+			items = []
+			for item in self.list:
+				if item[0].flags & eServiceReference.mustDescent:
+					items.append(item)
+				else:
+					name = item[1].getName(item[0]).strip()
+					if collectionMode == 1 and name == split[1]:
+						items.append(item)
+					elif groupedFiles.get(name):
+						groupedFiles[name].append(item)
+					else:
+						groupedFiles[name] = [item]
+
+			for key, groupedItems in groupedFiles.items():
+				if len(groupedItems) == 1:
+					# insert single items as normal files
+					items.append(groupedItems[0])
+				else:
+					# more than one item, display a collection
+					data = MovieListData()
+					data.collectionCount = len(groupedItems)
+					data.collectionItems = groupedItems
+					data.txt = key
+					serviceref = eServiceReference(eServiceReference.idFile, eServiceReference.isGroup, key)
+					items.append((serviceref, serviceref.info(), max(groupedItems, key=lambda i: i[2])[2], data))
+			self.list = items
 
 		self.firstFileEntry = numberOfDirs
 		self.parentDirectory = 0
@@ -840,6 +910,11 @@ class MovieList(GUIComponent):
 		# x = ref,info,begin,...
 		ref = x[0]
 		name = x[1] and x[1].getName(ref)
+		# if a collection, use the first item in the collection for the length
+		if ref.flags & eServiceReference.isGroup:
+			firstItem = x[3].collectionItems[0]
+			if firstItem:
+				ref = firstItem[0] or ref
 		len = x[1] and (x[1].getLength(ref) // 60) # we only display minutes, so sort by minutes
 		if ref.flags & eServiceReference.mustDescent:
 			return 0, len or 0, name and name.lower() or "", -x[2]
@@ -853,7 +928,7 @@ class MovieList(GUIComponent):
 			return 0, name and name.lower() or "", -x[2]
 		return 1, name and name.lower() or "", -x[2]
 
-# as for buildAlphaNumericSortKey, but without negating dates
+	# as for buildAlphaNumericSortKey, but without negating dates
 	def buildAlphaDateSortKey(self, x):
 		# x = ref,info,begin,...
 		ref = x[0]
@@ -873,8 +948,6 @@ class MovieList(GUIComponent):
 				# if path ends in '/', p is blank.
 				p = os.path.split(p[0])
 			name = p[1]
-		# print "Sorting for -%s-" % name
-
 		return 1, name and name.lower() or "", -x[2]
 
 	def buildBeginTimeSortKey(self, x):

--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -2,7 +2,7 @@ from Screen import Screen
 from Components.Button import Button
 from Components.ActionMap import HelpableActionMap, ActionMap, HelpableNumberActionMap
 from Components.ChoiceList import ChoiceList, ChoiceEntryComponent
-from Components.MovieList import MovieList, getItemDisplayName, resetMoviePlayState, AUDIO_EXTENSIONS, DVD_EXTENSIONS, IMAGE_EXTENSIONS, moviePlayState
+from Components.MovieList import MovieList, expandCollections, getItemDisplayName, resetMoviePlayState, AUDIO_EXTENSIONS, DVD_EXTENSIONS, IMAGE_EXTENSIONS
 from Components.DiskInfo import DiskInfo
 from Tools.Trashcan import TrashInfo
 from Components.Pixmap import Pixmap, MultiPixmap
@@ -47,6 +47,7 @@ config.movielist.use_fuzzy_dates = ConfigYesNo(default=True)
 config.movielist.moviesort = ConfigInteger(default=MovieList.SORT_GROUPWISE)
 config.movielist.description = ConfigInteger(default=MovieList.SHOW_DESCRIPTION)
 config.movielist.last_videodir = ConfigText(default=resolveFilename(SCOPE_HDD))
+config.movielist.last_videocollection = ConfigText(default="")
 config.movielist.last_timer_videodir = ConfigText(default=resolveFilename(SCOPE_HDD))
 config.movielist.videodirs = ConfigLocations(default=[resolveFilename(SCOPE_HDD)])
 config.movielist.last_selected_tags = ConfigSet([], default=[])
@@ -56,6 +57,7 @@ config.movielist.perm_sort_changes = ConfigYesNo(default=True)
 config.movielist.root = ConfigSelection(default="/media", choices=["/","/media","/media/hdd","/media/hdd/movie","/media/usb","/media/usb/movie"])
 config.movielist.hide_extensions = ConfigYesNo(default=False)
 config.movielist.stop_service = ConfigYesNo(default=True)
+config.movielist.enable_collections = ConfigSelection(default=0, choices=[(0,"Off"), (1, "On except in same named directory"), (2, "On")])
 
 userDefinedButtons = None
 last_selected_dest = []
@@ -124,7 +126,7 @@ def isSimpleFile(item):
 		return False
 	if not item[0] or not item[1]:
 		return False
-	return (item[0].flags & eServiceReference.mustDescent) == 0
+	return (item[0].flags & (eServiceReference.mustDescent | eServiceReference.isGroup)) == 0
 
 def isFolder(item):
 	if not item:
@@ -138,6 +140,8 @@ def canMove(item):
 		return False
 	if not item[0] or not item[1] or isTrashFolder(item[0]):
 		return False
+	#if (item[0].flags & eServiceReference.isGroup) != 0:
+	#	return False
 	return True
 
 def canDelete(item):
@@ -145,6 +149,8 @@ def canDelete(item):
 		return False
 	if not item[0] or not item[1]:
 		return False
+	#if (item[0].flags & eServiceReference.isGroup) != 0:
+	#	return False
 	return True
 
 canCopy = canMove
@@ -543,6 +549,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		else:
 			self.selected_tags = None
 		self.selected_tags_ele = None
+		self.collectionName = config.movielist.last_videocollection.value
 		self.nextInBackground = None
 
 		self.movemode = False
@@ -584,7 +591,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		}
 		self.movieOff = self.settings["movieoff"]
 
-		self["list"] = MovieList(None, sort_type=self.settings["moviesort"], descr_state=self.settings["description"])
+		self["list"] = MovieList(None, sort_type=self.settings["moviesort"], descr_state=self.settings["description"], allowCollections=True)
 
 		self.list = self["list"]
 		self.selectedmovie = selectedmovie
@@ -1341,6 +1348,12 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 					Screens.InfoBar.InfoBar.instance.checkTimeshiftRunning(boundFunction(self.itemSelectedCheckTimeshiftCallback, '.img', path))
 					return
 				self.gotFilename(path)
+			elif current.flags & eServiceReference.isGroup:
+				# moving "into" a collection - select the .. item
+				self.collectionName = path
+				config.movielist.last_videocollection.value = path
+				config.movielist.last_videocollection.save()
+				self.reloadList(sel=eServiceReference.fromDirectory(config.movielist.last_videodir.value))
 			else:
 				ext = os.path.splitext(path)[1].lower()
 				if config.movielist.play_audio_internal.value and (ext in AUDIO_EXTENSIONS):
@@ -1658,13 +1671,15 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		if config.usage.movielist_trashcan.value and os.access(config.movielist.last_videodir.value, os.W_OK):
 			Tools.Trashcan.createTrashFolder(config.movielist.last_videodir.value)
 		self.loadLocalSettings()
-		self["list"].reload(self.current_ref, self.selected_tags)
+		self["list"].reload(self.current_ref, self.selected_tags, self.collectionName)
 		self.updateTags()
 		title = ""
 		if config.usage.setup_level.index >= 2: # expert+
 			title += config.movielist.last_videodir.value
 		if self.selected_tags:
 			title += " - " + ','.join(self.selected_tags)
+		if self.collectionName:
+			title += ": %s" % self.collectionName
 		self.setTitle(title)
 		self.displayMovieOffStatus()
 		self.displaySortStatus()
@@ -1711,7 +1726,13 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		if not res.endswith('/'):
 			res += '/'
 		currentDir = config.movielist.last_videodir.value
-		if res != currentDir:
+		if res != currentDir or self.collectionName:
+			if self.collectionName:
+				# going "up" a level to the current directory - select this collection
+				selItem = eServiceReference(eServiceReference.idFile, eServiceReference.isGroup, self.collectionName)
+				self.collectionName = None
+				config.movielist.last_videocollection.value = ""
+				config.movielist.last_videocollection.save()
 			if os.path.isdir(res):
 				baseName = os.path.basename(res[:-1])
 				if config.ParentalControl.servicepinactive.value and baseName.startswith(".") and not baseName.startswith(".Trash"):
@@ -1945,7 +1966,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		renameList = []
 		itemCount = 0
 		msg = None
-		for item in self.getMarkedOrCurrentSelection():
+		for item in expandCollections(self.getMarkedOrCurrentSelection()):
 			itemRef = item[0]
 		 	if not canRename(item):
 				continue
@@ -2048,7 +2069,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		return False
 
 	def do_reset(self):
-		for item in self.getMarkedOrCurrentSelection():
+		for item in expandCollections(self.getMarkedOrCurrentSelection()):
 			itemRef = item[0]
 			path = itemRef.getPath()
 			if os.path.isfile(path):
@@ -2082,7 +2103,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		movedList = []
 		failedList = []
 		name = ""
-		for item in moveList:
+		for item in expandCollections(moveList):
 			itemRef, info = item[:2]
 			name = getItemDisplayName(itemRef, info)
 			try:
@@ -2123,7 +2144,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 			return
 		dest = os.path.normpath(choice)
 		failedList = []
-		for item in copyList:
+		for item in expandCollections(copyList):
 			itemRef, info = item[:2]
 			name = getItemDisplayName(itemRef, info)
 			try:
@@ -2156,19 +2177,19 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		recList = []
 		dirCount = fileCount = subItemCount = 0
 		inTrash = None
-		markedItems = self.getMarkedOrCurrentSelection()
+		markedList = self.getMarkedOrCurrentSelection()
 		# Check for the items that can only be single selected:
 		#  - Trash can't be marked but can be deleted as a shortcut for deleting all trash
 		#  - Parent directory (..) cannot be deleted
-		if len(markedItems) == 1:
-			item = markedItems[0]
+		if len(markedList) == 1:
+			item = markedList[0]
 			itemRef, info = item[:2]
 			if isTrashFolder(itemRef):
 				self.purgeAll()
 				return
 			elif not info: # parent directory
 				return
-		for item in markedItems:
+		for item in expandCollections(markedList):
 			itemRef = item[0]
 			if inTrash is None:
 				inTrash = isInTrashFolder(itemRef)


### PR DESCRIPTION
Collections are virtual folders, similar to those seen in the Dream EPG
Android app. They automatically group episodes of a programme together
so you don't need to create directories yourself.
The movie list displays and navigates them as if they're directories.
Delete, move and copy on collection acts on all files in the collection
There's also an option to not group if items are already organised in a
same named directory.