### PR TITLE
Bugfix: Fix PiP state when using infobar grid EPG

### DIFF
--- a/lib/python/Screens/EpgSelectionInfobarGrid.py
+++ b/lib/python/Screens/EpgSelectionInfobarGrid.py
@@ -1,14 +1,25 @@
 from Components.config import config
-from Screens.EpgSelectionBase import epgActions, infoActions, okActions
+from Screens.EpgSelectionBase import EPGServiceZap
 from Screens.EpgSelectionGrid import EPGSelectionGrid
 from Screens.EventView import EventViewSimple
+from Screens.PictureInPicture import openPip, closePip
 from Screens.Setup import Setup
+
+
+# PiPServiceRelation installed?
+try:
+	from Plugins.SystemPlugins.PiPServiceRelation.plugin import getRelationDict
+	plugin_PiPServiceRelation_installed = True
+except ImportError:
+	plugin_PiPServiceRelation_installed = False
 
 
 class EPGSelectionInfobarGrid(EPGSelectionGrid):
 	def __init__(self, session, zapFunc, startBouquet, startRef, bouquets):
 		EPGSelectionGrid.__init__(self, session, zapFunc, startBouquet, startRef, bouquets, None, True)
 		self.skinName = ["InfoBarGridEPG", "GraphicalInfoBarEPG"]
+		self.__openedPip = False
+		self.pipServiceRelation = getRelationDict() if plugin_PiPServiceRelation_installed else {}
 
 	def createSetup(self):
 		def onClose(test=None):
@@ -40,3 +51,31 @@ class EPGSelectionInfobarGrid(EPGSelectionGrid):
 
 	def toggleNumberOfRows(self):
 		pass
+
+	def closeScreen(self):
+		EPGServiceZap.closeScreen(self)
+		# be nice and only close the PiP if we actually opened a preview PiP 
+		if self.__openedPip:
+			closePip()
+
+	def zapSelectedService(self, preview=False):
+		if self.epgConfig.preview_mode.value != "2" or not preview:
+			EPGServiceZap.zapSelectedService(self)
+			return
+		# Preview mode is set to PiP
+		currentService = self.session.nav.getCurrentlyPlayingServiceReference() and self.session.nav.getCurrentlyPlayingServiceReference().toString() or None
+		selectedService = self["list"].getCurrent()[1]
+		if selectedService is None:
+			return
+		if self.session.pipshown:
+			self.prevch = self.session.pip.getCurrentService() and self.session.pip.getCurrentService().toString() or None
+		pipPluginService = self.pipServiceRelation.get(selectedService.toString(), None)
+		serviceRef = pipPluginService or selectedService
+		if self.currch == serviceRef.toString():
+			closePip()
+			self.zapFunc(selectedService, bouquet=self.getCurrentBouquet(), preview=False)
+			return
+		if self.prevch != serviceRef.toString() and currentService != serviceRef.toString():
+			if openPip(serviceRef):
+				self.__openedPip = True
+			self.currch = self.session.pip.getCurrentService() and self.session.pip.getCurrentService().toString()

--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -2018,7 +2018,7 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 						index = self.list.findService(newItemRef)
 						self.list.invalidateItem(index)
 					else:
-						failedList.append(_("'%s' already exists") % os.path.basename(path))
+						failedList.append(_("'%s' already exists") % newname)
 				else:
 					metafile = open(meta, "r+")
 					sid = metafile.readline()

--- a/lib/python/Screens/PictureInPicture.py
+++ b/lib/python/Screens/PictureInPicture.py
@@ -14,6 +14,29 @@ pip_config_initialized = False
 PipPigModeEnabled = False
 PipPigModeTimer = eTimer()
 
+def openPip(serviceRef=None):
+	pipOpened = False
+	from Screens.InfoBar import InfoBar
+	session = InfoBar.instance and InfoBar.instance.session
+	if session:
+		if not session.pipshown:
+			session.pip = session.instantiateDialog(PictureInPicture)
+			session.pip.show()
+			session.pipshown = True
+			pipOpened = True
+		if serviceRef:
+			session.pip.playService(serviceRef)
+	return pipOpened
+
+def closePip():
+	from Screens.InfoBar import InfoBar
+	session = InfoBar.instance and InfoBar.instance.session
+	if session and session.pipshown and session.pip:
+		session.pipshown = False
+		del session.pip
+		return True
+	return False
+
 def timedStopPipPigMode():
 	from Screens.InfoBar import InfoBar
 	if InfoBar.instance and InfoBar.instance.session:
@@ -44,6 +67,7 @@ def PipPigMode(value):
 				PipPigModeEnabled = True
 		else:
 			PipPigModeTimer.start(100, True)
+
 
 class PictureInPictureZapping(Screen):
 	skin = """<screen name="PictureInPictureZapping" flags="wfNoBorder" position="50,50" size="90,26" title="PiPZap" zPosition="-1">
@@ -150,6 +174,12 @@ class PictureInPicture(Screen):
 	def setExternalPiP(self, onoff):
 		if SystemInfo["HasExternalPIP"]:
 			open(SystemInfo["HasExternalPIP"], "w").write(onoff and "on" or "off")
+
+	def show(self):
+		Screen.show(self)
+
+	def hide(self):
+		Screen.hide(self)
 
 	def active(self):
 		self.pipActive.show()


### PR DESCRIPTION
Opening the infobar grid EPG no longer automatically closes the PiP
and manages the PiP state correctly
New functions added to PictureInPicture.py to open and close the PiP
Try to use these instead of splattering the same code all over the place