### PR TITLE
[Satfinder] cosmetic ( remove the word "Tuner" )

### DIFF
--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -168,7 +168,7 @@ class Satfinder(ScanSetup, ServiceScan):
 	def createSetup(self):
 		self.list = []
 		indent = "- "
-		self.satfinderTunerEntry = getConfigListEntry(_("Tuner"), self.satfinder_scan_nims)
+		self.satfinderTunerEntry = getConfigListEntry(_(" "), self.satfinder_scan_nims)
 		self.list.append(self.satfinderTunerEntry)
 		self.DVB_type = self.nim_type_dict[int(self.satfinder_scan_nims.value)]["selection"]
 		self.DVB_TypeEntry = getConfigListEntry(_("DVB type"), self.DVB_type) # multitype?


### PR DESCRIPTION
Satfinder skin panel ( Create Setup ), don´t needs to have Tuner as it is repeated from the Info imported from "nimmanger"

The line 171 ... instead of this ( present code ) ( SATFINDER PANEL )

    self.satfinderTunerEntry = getConfigListEntry(_("Tuner "), self.satfinder_scan_nims)

replaced by this :

    self.satfinderTunerEntry = getConfigListEntry(_(" "), self.satfinder_scan_nims)
A space needed between " " ... at getConfigListEntry