### PR TITLE
[Satfinder] cosmetic ( remove duplicated word "Tuner", imported from …

### DIFF
--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -168,7 +168,7 @@ class Satfinder(ScanSetup, ServiceScan):
 	def createSetup(self):
 		self.list = []
 		indent = "- "
-		self.satfinderTunerEntry = getConfigListEntry(_("Tuner"), self.satfinder_scan_nims)
+		self.satfinderTunerEntry = getConfigListEntry(_(" "), self.satfinder_scan_nims)
 		self.list.append(self.satfinderTunerEntry)
 		self.DVB_type = self.nim_type_dict[int(self.satfinder_scan_nims.value)]["selection"]
 		self.DVB_TypeEntry = getConfigListEntry(_("DVB type"), self.DVB_type) # multitype?


### PR DESCRIPTION
…"NimManager" )

line 171 ... instead of this ( present code ) ( SATFINDER PANEL )

    self.satfinderTunerEntry = getConfigListEntry(_("Tuner"), self.satfinder_scan_nims)

replaced by this :

    self.satfinderTunerEntry = getConfigListEntry(_(" "), self.satfinder_scan_nims)

Note: "Tuner" is imported from NimManager, though is duplicated and overlaps ( can be seen at for example OE-A skin_default )
A space needed between " " ... at getConfigListEntry