### PR TITLE
[Satfinder] Remove duplicated entry.

### DIFF
--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -168,7 +168,7 @@ class Satfinder(ScanSetup, ServiceScan):
 	def createSetup(self):
 		self.list = []
 		indent = "- "
-		self.satfinderTunerEntry = getConfigListEntry(_("Tuner"), self.satfinder_scan_nims)
+		self.satfinderTunerEntry = getConfigListEntry(_(" "), self.satfinder_scan_nims)
 		self.list.append(self.satfinderTunerEntry)
 		self.DVB_type = self.nim_type_dict[int(self.satfinder_scan_nims.value)]["selection"]
 		self.DVB_TypeEntry = getConfigListEntry(_("DVB type"), self.DVB_type) # multitype?


### PR DESCRIPTION
Line 171.

Removed the word "Tuner" from line:

		self.satfinderTunerEntry = getConfigListEntry(_("Tuner"), self.satfinder_scan_nims)

This avoids the duplicated entry of the word tuner at SKIN satfinder Panel.