### PR TITLE
PEP8.sh: Use date instead of Travis build number as nobody uses Travi…

### DIFF
--- a/PEP8.sh
+++ b/PEP8.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+COMMITDATE=$(date +"%F")
+
 echo ""
 echo "PEP8 double aggressive safe cleanup by Persian Prince"
 # Script by Persian Prince for https://github.com/OpenVisionE2
@@ -13,56 +15,56 @@ echo "PEP8 double aggressive E401"
 autopep8 . -a -a -j 0 --recursive --select=E401 --in-place
 git add -u
 git add *
-git commit -m "PEP8 double aggressive E401 (build $TRAVIS_BUILD_NUMBER)"
+git commit -m "PEP8 double aggressive E401 ($COMMITDATE)"
 
 echo ""
 echo "PEP8 double aggressive E701, E70 and E502"
 autopep8 . -a -a -j 0 --recursive --select=E701,E70,E502 --in-place
 git add -u
 git add *
-git commit -m "PEP8 double aggressive E701, E70 and E502 (build $TRAVIS_BUILD_NUMBER)"
+git commit -m "PEP8 double aggressive E701, E70 and E502 ($COMMITDATE)"
 
 echo ""
 echo "PEP8 double aggressive E251 and E252"
 autopep8 . -a -a -j 0 --recursive --select=E251,E252 --in-place
 git add -u
 git add *
-git commit -m "PEP8 double aggressive E251 and E252 (build $TRAVIS_BUILD_NUMBER)"
+git commit -m "PEP8 double aggressive E251 and E252 ($COMMITDATE)"
 
 echo ""
 echo "PEP8 double aggressive E20 and E211"
 autopep8 . -a -a -j 0 --recursive --select=E20,E211 --in-place
 git add -u
 git add *
-git commit -m "PEP8 double aggressive E20 and E211 (build $TRAVIS_BUILD_NUMBER)"
+git commit -m "PEP8 double aggressive E20 and E211 ($COMMITDATE)"
 
 echo ""
 echo "PEP8 double aggressive E22, E224, E241, E242 and E27"
 autopep8 . -a -a -j 0 --recursive --select=E22,E224,E241,E242,E27 --in-place
 git add -u
 git add *
-git commit -m "PEP8 double aggressive E22, E224, E241, E242 and E27 (build $TRAVIS_BUILD_NUMBER)"
+git commit -m "PEP8 double aggressive E22, E224, E241, E242 and E27 ($COMMITDATE)"
 
 echo ""
 echo "PEP8 double aggressive E225 ~ E228 and E231"
 autopep8 . -a -a -j 0 --recursive --select=E225,E226,E227,E228,E231 --in-place
 git add -u
 git add *
-git commit -m "PEP8 double aggressive E225 ~ E228 and E231 (build $TRAVIS_BUILD_NUMBER)"
+git commit -m "PEP8 double aggressive E225 ~ E228 and E231 ($COMMITDATE)"
 
 echo ""
 echo "PEP8 double aggressive E301 ~ E306"
 autopep8 . -a -a -j 0 --recursive --select=E301,E302,E303,E304,E305,E306 --in-place
 git add -u
 git add *
-git commit -m "PEP8 double aggressive E301 ~ E306 (build $TRAVIS_BUILD_NUMBER)"
+git commit -m "PEP8 double aggressive E301 ~ E306 ($COMMITDATE)"
 
 echo ""
 echo "PEP8 double aggressive W291 ~ W293 and W391"
 autopep8 . -a -a -j 0 --recursive --select=W291,W292,W293,W391 --in-place
 git add -u
 git add *
-git commit -m "PEP8 double aggressive W291 ~ W293 and W391 (build $TRAVIS_BUILD_NUMBER)"
+git commit -m "PEP8 double aggressive W291 ~ W293 and W391 ($COMMITDATE)"
 
 echo ""
 finish=$(date +"%s")


### PR DESCRIPTION
…s anymore and we run this script monthly (usually/manually)