### PR TITLE
[Menu] Re-Add software update to main menu

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -245,4 +245,12 @@ self.session.scart.VCRSbChanged(3)
 		<item entryID="maintenance_mode" level="0" text="Recovery Mode" requires="RecoveryMode"><screen module="Standby" screen="TryQuitMainloop">16</screen></item>
 		<item entryID="android_mode" level="0" text="Android Mode" requires="AndroidMode"><screen module="Standby" screen="TryQuitMainloop">12</screen></item>
 	</menu>
+
+	<!-- Menu / Software Update -->
+	<menu weight="1000" level="0" text="Software update" entryID="software_update">
+		<id val="softwareupdatemenu"/>
+		<item weight="1" level="0" text="Settings" entryID="onlineupdate_setup"><setup id="softwareupdate"/></item>
+		<item weight="2" level="0" text="Software update" entryID="software_update"><screen module="SoftwareUpdate" screen="UpdatePlugin"/></item>
+	</menu>
+
 </menu>


### PR DESCRIPTION
This also allows for the unstable updates to be toggled for plugins and matches the text returned when feeds are unstable 