### PR TITLE
Ice tv merge py3

### DIFF
--- a/lib/dvb/db.h
+++ b/lib/dvb/db.h
@@ -73,12 +73,12 @@ public:
 	RESULT getBouquet(const eServiceReference &ref, eBouquet* &bouquet);
 //////
 	void loadBouquet(const char *path);
-	eServiceReference searchReference(int tsid, int onid, int sid);
 	void searchAllReferences(std::vector<eServiceReference> &result, int tsid, int onid, int sid);
 	eDVBDB();
 	virtual ~eDVBDB();
 	int renumberBouquet(eBouquet &bouquet, int startChannelNum = 1);
 #endif
+	eServiceReference searchReference(int tsid, int onid, int sid);
 	void setNumberingMode(bool numberingMode);
 	void setLoadUnlinkedUserbouquets(bool value) { m_load_unlinked_userbouquets=value; }
 	void renumberBouquet();

--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -2164,7 +2164,7 @@ void eEPGCache::importEvents(ePyObject serviceReferences, ePyObject list)
 	{
 		if (PyTuple_Size(serviceReferences) != 3)
 		{
-			eDebug("[eEPGCache:import] serviceReferences tuple must contain 3 numbers (tsid, onid, sid), aborting");
+			eDebug("[eEPGCache:import] serviceReferences tuple must contain 3 numbers (onid, tsid, sid), aborting");
 			return;
 		}
 		int onid = PyLong_AsLong(PyTuple_GET_ITEM(serviceReferences, 0));
@@ -2194,7 +2194,7 @@ void eEPGCache::importEvents(ePyObject serviceReferences, ePyObject list)
 			{
 				if (PyTuple_Size(item) != 3)
 				{
-					eDebug("[eEPGCache:import] serviceReferences[%d] tuple must contain 3 numbers (tsid, onid, sid)", i);
+					eDebug("[eEPGCache:import] serviceReferences[%d] tuple must contain 3 numbers (onid, tsid, sid)", i);
 				}
 				int onid = PyLong_AsLong(PyTuple_GET_ITEM(item, 0));
 				int tsid = PyLong_AsLong(PyTuple_GET_ITEM(item, 1));

--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -2244,8 +2244,8 @@ void eEPGCache::importEvents(ePyObject serviceReferences, ePyObject list)
 			return;
 		}
 
-		long start = PyLong_AsLong(PyTuple_GET_ITEM(singleEvent, 0));
-		long duration = PyLong_AsLong(PyTuple_GET_ITEM(singleEvent, 1));
+		long start = PyLong_AsUnsignedLongMask(PyTuple_GET_ITEM(singleEvent, 0));
+		long duration = PyLong_AsUnsignedLongMask(PyTuple_GET_ITEM(singleEvent, 1));
 		const char *title = getStringFromPython(PyTuple_GET_ITEM(singleEvent, 2));
 		const char *short_summary = getStringFromPython(PyTuple_GET_ITEM(singleEvent, 3));
 		const char *long_description = getStringFromPython(PyTuple_GET_ITEM(singleEvent, 4));
@@ -2257,11 +2257,11 @@ void eEPGCache::importEvents(ePyObject serviceReferences, ePyObject list)
 			event_types.reserve(numberOfEventTypes);
 			for (int j = 0; j < numberOfEventTypes;  ++j)
 			{
-				uint8_t event_type = (uint8_t) PyLong_AsLong(eventTypeIsTuple ? PyTuple_GET_ITEM(eventTypeList, j) : PyList_GET_ITEM(eventTypeList, j));
+				uint8_t event_type = (uint8_t) PyLong_AsUnsignedLongMask(eventTypeIsTuple ? PyTuple_GET_ITEM(eventTypeList, j) : PyList_GET_ITEM(eventTypeList, j));
 				event_types.push_back(event_type);
 			}
 		} else if (PyLong_Check(eventTypeList)) {
-			uint8_t event_type = (uint8_t) PyLong_AsLong(eventTypeList);
+			uint8_t event_type = (uint8_t) PyLong_AsUnsignedLongMask(eventTypeList);
 			event_types.push_back(event_type);
 		} else {
 			eDebug("[eEPGCache:import] event type must be a single integer or a list or tuple of integers, aborting");
@@ -2271,7 +2271,7 @@ void eEPGCache::importEvents(ePyObject serviceReferences, ePyObject list)
 		uint16_t eventId = 0;
 		if (tupleSize >= 7)
 		{
-			eventId = (uint16_t) PyLong_AsLong(PyTuple_GET_ITEM(singleEvent, 6));
+			eventId = (uint16_t) PyLong_AsUnsignedLongMask(PyTuple_GET_ITEM(singleEvent, 6));
 		}
 
 		std::vector<eit_parental_rating> parental_ratings;
@@ -2298,7 +2298,7 @@ void eEPGCache::importEvents(ePyObject serviceReferences, ePyObject list)
 					}
 					eit_parental_rating p_rating;
 					memcpy(p_rating.country_code, country, 3);
-					u_char rating = (u_char) PyLong_AsLong(PyTuple_GET_ITEM(parentalInfo, 1));
+					u_char rating = (u_char) PyLong_AsUnsignedLongMask(PyTuple_GET_ITEM(parentalInfo, 1));
 					p_rating.rating = rating;
 					parental_ratings.push_back(p_rating);
 				}

--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -1876,16 +1876,18 @@ static inline uint8_t LO(int x) { return (uint8_t) (x & 0xFF); }
  * @param title title of the event. Must not be NULL.
  * @param short_summary summary of the event
  * @param long_description full description of the event
- * @param event_type event type/genre classification
+ * @param event_types vector of event type/genre classification
+ * @param parental_ratings vector of parental rating country/rating pairs
  * @param eventId optional EIT event id, defaults to 0 = auto-generated hash based on start time
  * @return void
  */
 void eEPGCache::submitEventData(const std::vector<eServiceReferenceDVB>& serviceRefs, long start,
 	long duration, const char* title, const char* short_summary,
-	const char* long_description, char event_type, uint16_t eventId)
+	const char* long_description, std::vector<uint8_t> event_types, std::vector<eit_parental_rating> parental_ratings, uint16_t eventId)
 {
 	std::vector<int> sids;
 	std::vector<eDVBChannelID> chids;
+	chids.reserve(serviceRefs.size());
 	for (std::vector<eServiceReferenceDVB>::const_iterator serviceRef = serviceRefs.begin();
 		serviceRef != serviceRefs.end();
 		++serviceRef)
@@ -1902,12 +1904,25 @@ void eEPGCache::submitEventData(const std::vector<eServiceReferenceDVB>& service
 			service->m_flags |= eDVBService::dxNoEIT;
 		}
 	}
-	submitEventData(sids, chids, start, duration, title, short_summary, long_description, event_type, eventId, EPG_IMPORT);
+	submitEventData(sids, chids, start, duration, title, short_summary, long_description, event_types, parental_ratings, eventId, EPG_IMPORT);
 }
 
 void eEPGCache::submitEventData(const std::vector<int>& sids, const std::vector<eDVBChannelID>& chids, long start,
 	long duration, const char* title, const char* short_summary,
 	const char* long_description, char event_type, int event_id, int source)
+{
+	std::vector<uint8_t> event_types;
+	std::vector<eit_parental_rating> parental_ratings;
+	if(event_type != 0)
+	{
+		event_types.push_back(event_type);
+	}
+	submitEventData(sids, chids, start, duration, title, short_summary, long_description, event_types, parental_ratings, event_id, EPG_IMPORT);
+}
+
+void eEPGCache::submitEventData(const std::vector<int>& sids, const std::vector<eDVBChannelID>& chids, long start,
+	long duration, const char* title, const char* short_summary,
+	const char* long_description, std::vector<uint8_t> event_types, std::vector<eit_parental_rating> parental_ratings, int event_id, int source)
 {
 	if (!title)
 		return;
@@ -1979,13 +1994,49 @@ void eEPGCache::submitEventData(const std::vector<int>& sids, const std::vector<
 	}
 
 	//Content type
-	if (event_type != 0)
+	if (!event_types.empty())
 	{
-		x[0] = 0x54;
-		x[1] = 2;
-		x[2] = event_type;
-		x[3] = 0;
-		x += 4;
+		const int max_etypes = (256 - 2) / 2;
+		int count = event_types.size();
+		if (count > max_etypes)
+			count = max_etypes;
+
+		x[0] = CONTENT_DESCRIPTOR;
+		x[1] = 2 * event_types.size();
+		x += 2;
+		for (std::vector<uint8_t>::const_iterator event_type = event_types.begin();
+			event_type != event_types.end();
+			++event_type)
+		{
+			if(--count < 0)
+				break;
+			x[0] = *event_type;
+			x[1] = 0;
+			x += 2;
+		}
+	}
+
+	//Parental rating
+	if (!parental_ratings.empty())
+	{
+		const int max_ratings = (256 - 2) / 4;
+		int count = parental_ratings.size();
+		if (count > max_ratings)
+			count = max_ratings;
+
+		x[0] = PARENTAL_RATING_DESCRIPTOR;
+		x[1] = 4 * count;
+		x += 2;
+		for (std::vector<eit_parental_rating>::const_iterator parental_rating = parental_ratings.begin();
+			parental_rating != parental_ratings.end();
+			++parental_rating)
+		{
+			if(--count < 0)
+				break;
+			memcpy(x, parental_rating->country_code, 3);
+			x[3] = parental_rating->rating;
+			x += 4;
+		}
 	}
 
 	//Long description
@@ -2086,9 +2137,11 @@ void eEPGCache::importEvent(ePyObject serviceReference, ePyObject list)
  * 3. event title (string)
  * 4. short description (string)
  * 5. extended description (string)
- * 6. event type (byte)
+ * 6. event type (byte) or list or tuple of event types
  * 7. optional event ID (int), if not supplied, it will default to 0, which implies an
  *    an auto-generated ID based on the start time.
+ * 8. optional list or tuple of tuples
+ *    (country[string 3 bytes], parental_rating [byte]).
  *
  * @return void
  */
@@ -2196,15 +2249,66 @@ void eEPGCache::importEvents(ePyObject serviceReferences, ePyObject list)
 		const char *title = getStringFromPython(PyTuple_GET_ITEM(singleEvent, 2));
 		const char *short_summary = getStringFromPython(PyTuple_GET_ITEM(singleEvent, 3));
 		const char *long_description = getStringFromPython(PyTuple_GET_ITEM(singleEvent, 4));
-		char event_type = (char) PyLong_AsLong(PyTuple_GET_ITEM(singleEvent, 5));
+		std::vector<uint8_t> event_types;
+		ePyObject eventTypeList = PyTuple_GET_ITEM(singleEvent, 5);
+		bool eventTypeIsTuple = PyTuple_Check(eventTypeList);
+		if(eventTypeIsTuple || PyList_Check(eventTypeList)) {
+			int numberOfEventTypes = eventTypeIsTuple ? PyTuple_Size(eventTypeList) : PyList_Size(eventTypeList);
+			event_types.reserve(numberOfEventTypes);
+			for (int j = 0; j < numberOfEventTypes;  ++j)
+			{
+				uint8_t event_type = (uint8_t) PyLong_AsLong(eventTypeIsTuple ? PyTuple_GET_ITEM(eventTypeList, j) : PyList_GET_ITEM(eventTypeList, j));
+				event_types.push_back(event_type);
+			}
+		} else if (PyLong_Check(eventTypeList)) {
+			uint8_t event_type = (uint8_t) PyLong_AsLong(eventTypeList);
+			event_types.push_back(event_type);
+		} else {
+			eDebug("[eEPGCache:import] event type must be a single integer or a list or tuple of integers, aborting");
+			return;
+		}
+
 		uint16_t eventId = 0;
 		if (tupleSize >= 7)
 		{
 			eventId = (uint16_t) PyLong_AsLong(PyTuple_GET_ITEM(singleEvent, 6));
 		}
 
+		std::vector<eit_parental_rating> parental_ratings;
+		if (tupleSize >= 8)
+		{
+			ePyObject parentalInfoList = PyTuple_GET_ITEM(singleEvent, 7);
+			bool parentalInfoIsTuple = PyTuple_Check(parentalInfoList);
+			if(parentalInfoIsTuple || PyList_Check(parentalInfoList)) {
+				int numberOfpInfoTypes = parentalInfoIsTuple ? PyTuple_Size(parentalInfoList) : PyList_Size(parentalInfoList);
+				parental_ratings.reserve(numberOfpInfoTypes);
+				for (int j = 0; j < numberOfpInfoTypes;  ++j)
+				{
+					ePyObject parentalInfo = parentalInfoIsTuple ? PyTuple_GET_ITEM(parentalInfoList, j) :  PyList_GET_ITEM(parentalInfoList, j);
+					if (!PyTuple_Check(parentalInfo) || PyTuple_Size(parentalInfo) != 2)
+					{
+						eDebug("[eEPGCache:import] parental rating must be a tuple of length 2, aborting");
+						return;
+					}
+					const char* country = getStringFromPython(PyTuple_GET_ITEM(parentalInfo, 0));
+					if (strlen(country) != 3)
+					{
+						eDebug("[eEPGCache:import] parental rating country code must be of length 3, aborting");
+						return;
+					}
+					eit_parental_rating p_rating;
+					memcpy(p_rating.country_code, country, 3);
+					u_char rating = (u_char) PyLong_AsLong(PyTuple_GET_ITEM(parentalInfo, 1));
+					p_rating.rating = rating;
+					parental_ratings.push_back(p_rating);
+				}
+			} else {
+				eDebug("[eEPGCache:import] parental ratings must be a list or tuple of parental rating tuples, aborting");
+			}
+		}
+
 		Py_BEGIN_ALLOW_THREADS;
-		submitEventData(refs, start, duration, title, short_summary, long_description, event_type, eventId);
+		submitEventData(refs, start, duration, title, short_summary, long_description, event_types, parental_ratings, eventId);
 		Py_END_ALLOW_THREADS;
 	}
 }

--- a/lib/dvb/epgcache.h
+++ b/lib/dvb/epgcache.h
@@ -257,7 +257,7 @@ public:
 	void setEpgSources(unsigned int mask);
 	unsigned int getEpgSources();
 
-	void submitEventData(const std::vector<eServiceReferenceDVB>& serviceRefs, long start, long duration, const char* title, const char* short_summary, const char* long_description, char event_type);
+	void submitEventData(const std::vector<eServiceReferenceDVB>& serviceRefs, long start, long duration, const char* title, const char* short_summary, const char* long_description, char event_type, uint16_t eventId=0);
 
 	void importEvents(SWIG_PYOBJECT(ePyObject) serviceReferences, SWIG_PYOBJECT(ePyObject) list);
 	void importEvent(SWIG_PYOBJECT(ePyObject) serviceReference, SWIG_PYOBJECT(ePyObject) list);

--- a/lib/dvb/epgcache.h
+++ b/lib/dvb/epgcache.h
@@ -98,6 +98,10 @@ typedef std::tr1::unordered_map<uniqueEPGKey, EventCacheItem, hash_uniqueEPGKey,
 	typedef std::tr1::unordered_map<uniqueEPGKey, contentMap, hash_uniqueEPGKey, uniqueEPGKey::equal > contentMaps;
 #endif
 
+struct eit_parental_rating {
+        u_char  country_code[3];
+        u_char  rating;
+};
 #endif
 
 class eEPGCache: public eMainloop, private eThread, public sigc::trackable
@@ -159,6 +163,7 @@ private:
 	void gotMessage(const Message &message);
 	void cleanLoop();
 	void submitEventData(const std::vector<int>& sids, const std::vector<eDVBChannelID>& chids, long start, long duration, const char* title, const char* short_summary, const char* long_description, char event_type, int event_id, int source);
+	void submitEventData(const std::vector<int>& sids, const std::vector<eDVBChannelID>& chids, long start, long duration, const char* title, const char* short_summary, const char* long_description, std::vector<uint8_t> event_types, std::vector<eit_parental_rating> parental_ratings, int event_id, int source);
 	void clearCompleteEPGCache();
 
 	eServiceReferenceDVB *m_timeQueryRef;
@@ -257,7 +262,7 @@ public:
 	void setEpgSources(unsigned int mask);
 	unsigned int getEpgSources();
 
-	void submitEventData(const std::vector<eServiceReferenceDVB>& serviceRefs, long start, long duration, const char* title, const char* short_summary, const char* long_description, char event_type, uint16_t eventId=0);
+	void submitEventData(const std::vector<eServiceReferenceDVB>& serviceRefs, long start, long duration, const char* title, const char* short_summary, const char* long_description, std::vector<uint8_t> event_types, std::vector<eit_parental_rating> parental_ratings, uint16_t eventId=0);
 
 	void importEvents(SWIG_PYOBJECT(ePyObject) serviceReferences, SWIG_PYOBJECT(ePyObject) list);
 	void importEvent(SWIG_PYOBJECT(ePyObject) serviceReference, SWIG_PYOBJECT(ePyObject) list);

--- a/lib/python/Components/Converter/genre.py
+++ b/lib/python/Components/Converter/genre.py
@@ -1,11 +1,12 @@
+from Components.config import config
+
+
 #
 # Genre types taken from DVB standards documentation
 #
 # some broadcaster do define other types so this list
 # may grow or be replaced..
 #
-
-
 class GenresETSI:
 	maintype = (
 		_("Reserved"),
@@ -234,6 +235,481 @@ class GenresAUS:
 	}
 
 
+class GenresAUSIceTV:
+	maintype = (
+		_("Miscellaneous"),
+		_("Movie/Drama"),
+		_("News/Current Affairs"),
+		_("Show/Games show"),
+		_("Sports"),
+		_("Children/Youth"),
+		_("Music/Ballet/Dance"),
+		_("Arts/Culture"),
+		_("Social/Political/Economics"),
+		_("Education/Science/Factual"),
+		_("Leisure hobbies"),
+		_("Special"),
+		_("Comedy"),
+		_("Drama"),
+		_("Documentary"),
+		_("Real Life"),
+	)
+
+	subtype = {
+		# Miscellaneous
+		0: (
+			"",  # 0x00
+			_("Cult"),  # 0x01
+			_("Youth"),  # 0x02 remapped from 0x01
+			_("Wrestling"),  # 0x03 remapped from 0x01
+			_("Violence"),  # 0x04 remapped from 0x01
+			_("Short Film"),  # 0x05 remapped from 0x01
+			_("Sailing"),  # 0x06 remapped from 0x01
+			_("Renovation"),  # 0x07 remapped from 0x01
+			_("Mini Series"),  # 0x08 remapped from 0x01
+			_("MMA"),  # 0x09 remapped from 0x01
+			_("Horse Racing"),  # 0x0a remapped from 0x01
+			_("Finance"),  # 0x0b remapped from 0x01
+			_("Film-Noir"),  # 0x0c remapped from 0x01
+			_("Family"),  # 0x0d remapped from 0x01
+			_("Cycling"),  # 0x0e remapped from 0x01
+			_("Weightlifting"),  # 0x0f remapped from 0x01
+		),
+		# Movie/Drama
+		1: (
+			_("Movie"),  # 0x10
+			_("Crime"),  # 0x11
+			_("Adventure"),  # 0x12
+			_("Sci-Fi"),  # 0x13
+			_("Comedy"),  # 0x14
+			_("Soap Opera"),  # 0x15
+			_("Romance"),  # 0x16
+			_("Historical"),  # 0x17
+			_("Adult"),  # 0x18
+			_("Drama"),  # 0x19 remapped from 0x10
+			_("Thriller"),  # 0x1a remapped from 0x11
+			_("Mystery"),  # 0x1b remapped from 0x11
+			_("Murder"),  # 0x1c remapped from 0x11
+			_("Western"),  # 0x1d remapped from 0x12
+			_("War"),  # 0x1e remapped from 0x12
+			_("Action"),  # 0x1f remapped from 0x12
+		),
+		# News/Current Affairs
+		2: (
+			_("News"),  # 0x20
+			_("Weather"),  # 0x21
+			_("General Show"),  # 0x22 remapped from 0x01
+			_("Documentary"),  # 0x23
+			_("General News"),  # 0x24 remapped from 0x01
+			_("General Music"),  # 0x25 remapped from 0x01
+			_("General Movie"),  # 0x26 remapped from 0x01
+			_("General Education"),  # 0x27 remapped from 0x01
+			_("General Children's"),  # 0x28 remapped from 0x01
+			_("General Arts"),  # 0x29 remapped from 0x01
+			_("Gaelic Games"),  # 0x2a remapped from 0x01
+			_("Gaelic Football"),  # 0x2b remapped from 0x01
+			_("Formula One"),  # 0x2c remapped from 0x01
+			_("Football - International"),  # 0x2d remapped from 0x01
+			_("Football - Club"),  # 0x2e remapped from 0x01
+			_("Folkloric"),  # 0x2f remapped from 0x01
+		),
+		# Show/Games show
+		3: (
+			_("Entertainment"),  # 0x30
+			_("Game Show"),  # 0x31
+			_("Variety"),  # 0x32
+			_("Talk Show"),  # 0x33
+			_("Folk"),  # 0x34 remapped from 0x01
+			_("Fitness & Health"),  # 0x35 remapped from 0x01
+			_("Film"),  # 0x36 remapped from 0x01
+			_("Factual Topics"),  # 0x37 remapped from 0x01
+			_("Extreme"),  # 0x38 remapped from 0x01
+			_("Equestrian"),  # 0x39 remapped from 0x01
+			_("Environment"),  # 0x3a remapped from 0x01
+			_("Economics"),  # 0x3b remapped from 0x01
+			_("Discussion"),  # 0x3c remapped from 0x01
+			_("Detective"),  # 0x3d remapped from 0x01
+			_("Debate"),  # 0x3e remapped from 0x01
+			_("Darts"),  # 0x3f remapped from 0x01
+		),
+		# Sports
+		4: (
+			_("Sport"),  # 0x40
+			_("Olympics"),  # 0x41
+			_("Golf"),  # 0x42 remapped from 0x40
+			_("Soccer"),  # 0x43
+			_("Tennis"),  # 0x44
+			_("Football"),  # 0x45
+			_("Athletics"),  # 0x46
+			_("Motor Sport"),  # 0x47
+			_("Swimming"),  # 0x48
+			_("Winter Sports"),  # 0x49
+			_("Boxing"),  # 0x4a remapped from 0x40
+			_("Rugby League"),  # 0x4b remapped from 0x45
+			_("Rugby"),  # 0x4c remapped from 0x45
+			_("Netball"),  # 0x4d remapped from 0x45
+			_("Hockey"),  # 0x4e remapped from 0x45
+			_("Cricket"),  # 0x4f remapped from 0x45
+		),
+		# Children/Youth
+		5: (
+			_("Children"),  # 0x50
+			_("Cartoon"),  # 0x51 remapped from 0x55
+			_("DIY"),  # 0x52 remapped from 0x01
+			_("Culture"),  # 0x53 remapped from 0x01
+			_("Combat Sports (without own category)"),  # 0x54 remapped from 0x01
+			_("Animation"),  # 0x55
+			_("Classical Music"),  # 0x56 remapped from 0x01
+			_("Cinema"),  # 0x57 remapped from 0x01
+			_("Challenge"),  # 0x58 remapped from 0x01
+			_("Cartoons"),  # 0x59 remapped from 0x01
+			_("Ballet"),  # 0x5a remapped from 0x01
+			_("Badminton"),  # 0x5b remapped from 0x01
+			_("Animated Movie"),  # 0x5c remapped from 0x01
+			_("Animals"),  # 0x5d remapped from 0x01
+			_("Advertisement"),  # 0x5e remapped from 0x01
+			_("Adult Movie"),  # 0x5f remapped from 0x01
+		),
+		# Music/Ballet/Dance
+		6: (
+			_("Music"),  # 0x60
+			_("Musical"),  # 0x61 remapped from 0x60
+			_("Dance"),  # 0x62 remapped from 0x60
+		),
+		# Arts/Culture
+		7: (
+			_("Arts & Culture"),  # 0x70
+			_("Unused 0x71"),  # 0x71
+			_("Unused 0x72"),  # 0x72
+			_("Religion"),  # 0x73
+		),
+		# Social/Political/Economics
+		8: (
+			_("Society & Culture"),  # 0x80
+			_("Current Affairs"),  # 0x81
+			_("Parliament"),  # 0x82 remapped from 0x80
+			_("Biography"),  # 0x83
+			_("Business & Finance"),  # 0x84 remapped from 0x80
+		),
+		# Education/Science/Factual
+		9: (
+			_("Education"),  # 0x90
+			_("Nature"),  # 0x91
+			_("Science & Tech"),  # 0x92
+			_("Medical"),  # 0x93
+			_("Science"),  # 0x94 remapped from 0x90
+		),
+		# Leisure hobbies
+		10: (
+			_("Infotainment"),  # 0xa0
+			_("Travel"),  # 0xa1
+			_("Lifestyle"),  # 0xa2 remapped from 0xa0
+			_("Fishing"),  # 0xa3 remapped from 0xa0
+			_("Food/Wine"),  # 0xa4 remapped from 0xa5
+			_("Cooking"),  # 0xa5
+			_("Shopping"),  # 0xa6
+			_("Gardening"),  # 0xa7
+		),
+		# Special
+		11: (
+			_("Special"),  # 0xb0
+			_("Special"),  # 0xb1 remapped from 0xb0
+			_("Unused 0xb2"),  # 0xb2
+			_("Live"),  # 0xb3
+		),
+		# Comedy
+		12: (
+			_("Comedy"),  # 0xc0
+			_("Table Tennis"),  # 0xc1 remapped from 0x01
+			_("Strongman Contests"),  # 0xc2 remapped from 0x01
+			_("Sports Magazines"),  # 0xc3 remapped from 0x01
+			_("Soap"),  # 0xc4 remapped from 0x01
+			_("Snooker"),  # 0xc5 remapped from 0x01
+			_("Skiing"),  # 0xc6 remapped from 0x01
+			_("Sketches"),  # 0xc7 remapped from 0x01
+			_("Serious Music"),  # 0xc8 remapped from 0x01
+			_("Science Fiction"),  # 0xc9 remapped from 0x01
+			_("Rugby Union - International"),  # 0xca remapped from 0x01
+			_("Rugby Union - Domestic"),  # 0xcb remapped from 0x01
+			_("Rugby League - International"),  # 0xcc remapped from 0x01
+			_("Rugby League - Domestic"),  # 0xcd remapped from 0x01
+			_("Rock"),  # 0xce remapped from 0x01
+			_("Regional News"),  # 0xcf remapped from 0x01
+		),
+		# Drama
+		13: (
+			_("Drama"),  # 0xd0
+			_("Reality Show"),  # 0xd1 remapped from 0x01
+			_("Rallying"),  # 0xd2 remapped from 0x01
+			_("Quiz"),  # 0xd3 remapped from 0x01
+			_("Puppets"),  # 0xd4 remapped from 0x01
+			_("Powerboating"),  # 0xd5 remapped from 0x01
+			_("Pop"),  # 0xd6 remapped from 0x01
+			_("Politics"),  # 0xd7 remapped from 0x01
+			_("Political Issues"),  # 0xd8 remapped from 0x01
+			_("Poker"),  # 0xd9 remapped from 0x01
+			_("Other"),  # 0xda remapped from 0x01
+			_("Opera"),  # 0xdb remapped from 0x01
+			_("News Magazine"),  # 0xdc remapped from 0x01
+			_("National News"),  # 0xdd remapped from 0x01
+			_("Motoring"),  # 0xde remapped from 0x01
+			_("Motorcycling"),  # 0xdf remapped from 0x01
+		),
+		# Documentary
+		14: (
+			_("Documentary"),  # 0xe0
+			_("Modern Dance"),  # 0xe1 remapped from 0x01
+			_("Minority Sports"),  # 0xe2 remapped from 0x01
+			_("Melodrama"),  # 0xe3 remapped from 0x01
+			_("Martial Sports"),  # 0xe4 remapped from 0x01
+			_("Jazz"),  # 0xe5 remapped from 0x01
+			_("Interview"),  # 0xe6 remapped from 0x01
+			_("International News"),  # 0xe7 remapped from 0x01
+			_("Ice Skating"),  # 0xe8 remapped from 0x01
+			_("Ice Hockey"),  # 0xe9 remapped from 0x01
+			_("Horse racing"),  # 0xea remapped from 0x01
+			_("History"),  # 0xeb remapped from 0x01
+			_("Health & Fitness"),  # 0xec remapped from 0x01
+			_("Gymnastics"),  # 0xed remapped from 0x01
+			_("General Sports"),  # 0xee remapped from 0x01
+			_("General Social"),  # 0xef remapped from 0x01
+		),
+		# Real Life
+		15: (
+			_("Real Life"),  # 0xf0
+			_("Horror"),  # 0xf1 remapped from 0x13
+			_("Fantasy"),  # 0xf2 remapped from 0x13
+			_("Sitcom"),  # 0xf3 remapped from 0x14
+			_("Basketball"),  # 0xf4 remapped from 0x45
+			_("Baseball"),  # 0xf5 remapped from 0x45
+			_("American Football"),  # 0xf6 remapped from 0x45
+			_("AFL"),  # 0xf7 remapped from 0x45
+			_("Rowing"),  # 0xf8 remapped from 0x48
+			_("Water Sport"),  # 0xf9 remapped from 0x01
+			_("Volleyball"),  # 0xfa remapped from 0x01
+			_("Urban Music"),  # 0xfb remapped from 0x01
+			_("Triathlon"),  # 0xfc remapped from 0x01
+			_("Traditional Music"),  # 0xfd remapped from 0x01
+			_("Tourism"),  # 0xfe remapped from 0x01
+			_("Technology"),  # 0xff remapped from 0x01
+		),
+	}
+
+
+class GenresDEUIceTV:
+	maintype = (
+		_("Miscellaneous"),
+		_("Movie/Drama"),
+		_("News/Current Affairs"),
+		_("Show/Games show"),
+		_("Sports"),
+		_("Children/Youth"),
+		_("Music/Ballet/Dance"),
+		_("Arts/Culture"),
+		_("Social/Political/Economics"),
+		_("Education/Science/Factual"),
+		_("Leisure hobbies"),
+		_("Special"),
+		_("Comedy"),
+		_("Drama"),
+		_("Documentary"),
+		_("Real Life"),
+	)
+
+	subtype = {
+		# Miscellaneous
+		0: (
+			'',  # 0x00
+			_('Abenteuer'),  # 0x01
+			_('Zirkus'),  # 0x02 remapped from 0x01
+			_('Zeichentrick'),  # 0x03 remapped from 0x01
+			_('Wissenschaft'),  # 0x04 remapped from 0x01
+			_('Wirtschaft'),  # 0x05 remapped from 0x01
+			_('Wintersport'),  # 0x06 remapped from 0x01
+			_('Wetter'),  # 0x07 remapped from 0x01
+			_('Wettbewerb'),  # 0x08 remapped from 0x01
+			_('Western'),  # 0x09 remapped from 0x01
+			_('Werbung'),  # 0x0a remapped from 0x01
+			_('Wassersport'),  # 0x0b remapped from 0x01
+			_('Waffen'),  # 0x0c remapped from 0x01
+			_('Vorschau'),  # 0x0d remapped from 0x01
+			_('Videoclip'),  # 0x0e remapped from 0x01
+			_('Verschiedenes'),  # 0x0f remapped from 0x01
+		),
+		# Movie/Drama
+		1: (
+			_('Kunst'),  # 0x10 remapped from 0x01
+			_('Kultur'),  # 0x11 remapped from 0x01
+			_('Kriminalit\xc3\xa4t'),  # 0x12 remapped from 0x01
+			_('Krimi'),  # 0x13 remapped from 0x01
+			_('Comedy'),  # 0x14
+			_('Krieg'),  # 0x15 remapped from 0x01
+			_('Kraftsport'),  # 0x16 remapped from 0x01
+			_('Kom\xc3\xb6die'),  # 0x17 remapped from 0x01
+			_('Kneipensport'),  # 0x18 remapped from 0x01
+			_('Klassiker'),  # 0x19 remapped from 0x01
+			_('Kinder'),  # 0x1a remapped from 0x01
+			_('Katastrophe'),  # 0x1b remapped from 0x01
+			_('Kampfsport'),  # 0x1c remapped from 0x01
+			_('Justiz'),  # 0x1d remapped from 0x01
+			_('Jugend'),  # 0x1e remapped from 0x01
+			_('International'),  # 0x1f remapped from 0x01
+		),
+		# News/Current Affairs
+		2: (
+			_('Information'),  # 0x20 remapped from 0x01
+			_('Independent'),  # 0x21 remapped from 0x01
+			_('Horror'),  # 0x22 remapped from 0x01
+			_('Hobbys'),  # 0x23 remapped from 0x01
+			_('Heimwerker'),  # 0x24 remapped from 0x01
+			_('Heimat'),  # 0x25 remapped from 0x01
+			_('Handball'),  # 0x26 remapped from 0x01
+			_('Gesundheit'),  # 0x27 remapped from 0x01
+			_('Gesellschaft'),  # 0x28 remapped from 0x01
+			_('Geschichte'),  # 0x29 remapped from 0x01
+			_('Garten'),  # 0x2a remapped from 0x01
+			_('Gangster'),  # 0x2b remapped from 0x01
+			_('F\xc3\xbcr Kinder'),  # 0x2c remapped from 0x01
+			_('Fu\xc3\x9fball'),  # 0x2d remapped from 0x01
+			_('Frauen'),  # 0x2e remapped from 0x01
+			_('Fantasy'),  # 0x2f remapped from 0x01
+		),
+		# Show/Games show
+		3: (
+			_('Familie'),  # 0x30 remapped from 0x01
+			_('Extremsport'),  # 0x31 remapped from 0x01
+			_('Event'),  # 0x32 remapped from 0x01
+			_('Essen'),  # 0x33 remapped from 0x01
+			_('Esoterik'),  # 0x34 remapped from 0x01
+			_('Erotik'),  # 0x35 remapped from 0x01
+			_('Epos'),  # 0x36 remapped from 0x01
+			_('Energie'),  # 0x37 remapped from 0x01
+			_('Einzelsportart'),  # 0x38 remapped from 0x01
+			_('Eastern'),  # 0x39 remapped from 0x01
+			_('Drogen'),  # 0x3a remapped from 0x01
+			_('Drama'),  # 0x3b remapped from 0x01
+			_('Dokumentation'),  # 0x3c remapped from 0x01
+			_('Detektiv'),  # 0x3d remapped from 0x01
+			_('Dating'),  # 0x3e remapped from 0x01
+			_('Computer'),  # 0x3f remapped from 0x01
+		),
+		# Sports
+		4: (
+			_('Sport'),  # 0x40
+			_('Comic'),  # 0x41 remapped from 0x01
+			_('Chronik'),  # 0x42 remapped from 0x01
+			_('Casting'),  # 0x43 remapped from 0x01
+			_('Call-in'),  # 0x44 remapped from 0x01
+			_('Boxen'),  # 0x45 remapped from 0x01
+			_('Boulevard'),  # 0x46 remapped from 0x01
+			_('Bollywood'),  # 0x47 remapped from 0x01
+			_('Biografie'),  # 0x48 remapped from 0x01
+			_('Bildung'),  # 0x49 remapped from 0x01
+			_('Beziehung'),  # 0x4a remapped from 0x01
+			_('Berufe'),  # 0x4b remapped from 0x01
+			_('Bericht'),  # 0x4c remapped from 0x01
+			_('B-Movie'),  # 0x4d remapped from 0x01
+			_('Automobil'),  # 0x4e remapped from 0x01
+			_('Arzt'),  # 0x4f remapped from 0x01
+		),
+		# Children/Youth
+		5: (
+			_('Architektur'),  # 0x50 remapped from 0x01
+			_('Anime'),  # 0x51 remapped from 0x01
+			_('American Sports'),  # 0x52 remapped from 0x01
+			_('Agenten'),  # 0x53 remapped from 0x01
+			_('Adel'),  # 0x54 remapped from 0x01
+			_('Animation'),  # 0x55
+			_('Action'),  # 0x56 remapped from 0x01
+		),
+		# Social/Political/Economics
+		8: (
+			_('Unused 0x80'),  # 0x80
+			_('Current Affairs'),  # 0x81
+		),
+		# Special
+		11: (
+			_('Special'),  # 0xb0
+		),
+		# Comedy
+		12: (
+			_('Comedy'),  # 0xc0
+			_('Show'),  # 0xc1 remapped from 0x01
+			_('Serie'),  # 0xc2 remapped from 0x01
+			_('Science-Fiction'),  # 0xc3 remapped from 0x01
+			_('Satire'),  # 0xc4 remapped from 0x01
+			_('Saga'),  # 0xc5 remapped from 0x01
+			_('Romantik'),  # 0xc6 remapped from 0x01
+			_('Revue'),  # 0xc7 remapped from 0x01
+			_('Reportage'),  # 0xc8 remapped from 0x01
+			_('Religion'),  # 0xc9 remapped from 0x01
+			_('Reiten'),  # 0xca remapped from 0x01
+			_('Reisen'),  # 0xcb remapped from 0x01
+			_('Regional'),  # 0xcc remapped from 0x01
+			_('Reality'),  # 0xcd remapped from 0x01
+			_('Radsport'),  # 0xce remapped from 0x01
+			_('Quiz'),  # 0xcf remapped from 0x01
+		),
+		# Drama
+		13: (
+			_('Drama'),  # 0xd0
+			_('Puppentrick'),  # 0xd1 remapped from 0x01
+			_('Psychologie'),  # 0xd2 remapped from 0x01
+			_('Prominent'),  # 0xd3 remapped from 0x01
+			_('Portr\xc3\xa4t'),  # 0xd4 remapped from 0x01
+			_('Politik'),  # 0xd5 remapped from 0x01
+			_('Poker'),  # 0xd6 remapped from 0x01
+			_('Parodie'),  # 0xd7 remapped from 0x01
+			_('Parabel'),  # 0xd8 remapped from 0x01
+			_('Outdoor'),  # 0xd9 remapped from 0x01
+			_('Olympia'),  # 0xda remapped from 0x01
+			_('Neue Medien'),  # 0xdb remapped from 0x01
+			_('Natur'),  # 0xdc remapped from 0x01
+			_('National'),  # 0xdd remapped from 0x01
+			_('Nachrichten'),  # 0xde remapped from 0x01
+			_('M\xc3\xa4rchen'),  # 0xdf remapped from 0x01
+		),
+		# Documentary
+		14: (
+			_('Documentary'),  # 0xe0
+			_('Mystery'),  # 0xe1 remapped from 0x01
+			_('Musik'),  # 0xe2 remapped from 0x01
+			_('Musical'),  # 0xe3 remapped from 0x01
+			_('Motorsport'),  # 0xe4 remapped from 0x01
+			_('Mode'),  # 0xe5 remapped from 0x01
+			_('Medien'),  # 0xe6 remapped from 0x01
+			_('Mannschaftssport'),  # 0xe7 remapped from 0x01
+			_('Magazin'),  # 0xe8 remapped from 0x01
+			_('Literaturverfilmung'),  # 0xe9 remapped from 0x01
+			_('Literatur'),  # 0xea remapped from 0x01
+			_('Lifestyle'),  # 0xeb remapped from 0x01
+			_('Leichtathletik'),  # 0xec remapped from 0x01
+			_('Late Night'),  # 0xed remapped from 0x01
+			_('Landestypisch'),  # 0xee remapped from 0x01
+			_('Kurzfilm'),  # 0xef remapped from 0x01
+		),
+		# Real Life
+		15: (
+			_('Verkehr'),  # 0xf0 remapped from 0x01
+			_('Unterhaltung'),  # 0xf1 remapped from 0x01
+			_('Umweltbewusstsein'),  # 0xf2 remapped from 0x01
+			_('Trag\xc3\xb6die'),  # 0xf3 remapped from 0x01
+			_('Tiere'),  # 0xf4 remapped from 0x01
+			_('Thriller'),  # 0xf5 remapped from 0x01
+			_('Theater'),  # 0xf6 remapped from 0x01
+			_('Technik'),  # 0xf7 remapped from 0x01
+			_('Tanz'),  # 0xf8 remapped from 0x01
+			_('Talk'),  # 0xf9 remapped from 0x01
+			_('Stumm'),  # 0xfa remapped from 0x01
+			_('Sprache'),  # 0xfb remapped from 0x01
+			_('Spielfilm'),  # 0xfc remapped from 0x01
+			_('Spiele'),  # 0xfd remapped from 0x01
+			_('Soap'),  # 0xfe remapped from 0x01
+			_('Slapstick'),  # 0xff remapped from 0x01
+		),
+	}
+
+
 def __getGenreStringMain(hn, ln, genres):
 	# if hn == 0:
 	# 	return _("Undefined content")
@@ -260,8 +736,26 @@ def __getGenreStringSub(hn, ln, genres):
 	return ""
 
 
+def __getGenreStringMainIceTV(hn, ln, genres):
+	if hn < len(genres.maintype):
+		return genres.maintype[hn]
+	if hn == 15:
+		return _("User defined 0x%02x" % ((hn << 4) | ln))
+	return ""
+
+
+def __getGenreStringSubIceTV(hn, ln, genres):
+	if hn in genres.subtype and ln < len(genres.subtype[hn]):
+		return genres.subtype[hn][ln]
+	if hn == 15 or ln == 15:
+		return _("User defined 0x%02x" % ((hn << 4) | ln))
+	return ""
+
 countries = {
 	"AUS": (__getGenreStringMain, __getGenreStringMain, GenresAUS()),
+	# Use illegal country names for IceTV genre tables so that they won't match real countries
+	"AUSIceTV": (__getGenreStringMainIceTV, __getGenreStringSubIceTV, GenresAUSIceTV()),
+	"DEUIceTV": (__getGenreStringMainIceTV, __getGenreStringSubIceTV, GenresDEUIceTV()),
 }
 
 defaultGenre = GenresETSI()
@@ -273,23 +767,33 @@ maintype = defaultGenre.maintype
 subtype = defaultGenre.subtype
 
 
+def __remapCountry(country):
+	if hasattr(config.plugins, "icetv") and config.plugins.icetv.enable_epg.value:
+		if not country:
+			country = config.plugins.icetv.member.country.value
+		iceTVCountry = country + "IceTV"
+		if iceTVCountry in countries:
+			return iceTVCountry
+	return country
+
+
 def getGenreStringMain(hn, ln, country=None):
-	countryInfo = countries.get(country, defaultCountryInfo)
+	countryInfo = countries.get(__remapCountry(country), defaultCountryInfo)
 	return countryInfo[0](hn, ln, countryInfo[2])
 
 
 def getGenreStringSub(hn, ln, country=None):
-	countryInfo = countries.get(country, defaultCountryInfo)
+	countryInfo = countries.get(__remapCountry(country), defaultCountryInfo)
 	return countryInfo[1](hn, ln, countryInfo[2])
 
 
 def getGenreStringLong(hn, ln, country=None):
 	# if hn == 0:
 	# 	return _("Undefined content") + " " + str(ln)
-	if hn == 15:
+	if hn == 15 and not (hasattr(config.plugins, "icetv") and config.plugins.icetv.enable_epg.value):
 		return _("User defined") + " " + str(ln)
 	main = getGenreStringMain(hn, ln, country=country)
-	sub = getGenreStringSub(hn, ln)
+	sub = getGenreStringSub(hn, ln, country=country)
 	if main and main != sub:
 		return main + ": " + sub
 	else:

--- a/lib/python/Components/EpgListBase.py
+++ b/lib/python/Components/EpgListBase.py
@@ -38,6 +38,11 @@ class EPGListBase(GUIComponent):
 		]
 
 		self.autotimericon = LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, "icons/epgclock_autotimer.png"))
+		try:
+			from Plugins.SystemPlugins.IceTV import loadIceTVIcon
+			self.icetvicon = loadIceTVIcon("epgclock_icetv.png")
+		except ImportError:
+			self.icetvicon = None
 
 		self.listHeight = 0
 		self.listWidth = 0
@@ -148,7 +153,7 @@ class EPGListBase(GUIComponent):
 		if matchType == 3:
 			# recording whole event, add timer type onto pixmap lookup index
 			matchType += 2 if timer.always_zap else 1 if timer.justplay else 0
-			autoTimerIcon = self.autotimericon if timer.isAutoTimer else None
+			autoTimerIcon = self.icetvicon if hasattr(timer, "ice_timer_id") and timer.ice_timer_id else (self.autotimericon if timer.isAutoTimer else None)
 		return self.selclocks[matchType] if selected else self.clocks[matchType], autoTimerIcon
 
 	def queryEPG(self, list):

--- a/lib/python/Components/TimerList.py
+++ b/lib/python/Components/TimerList.py
@@ -88,7 +88,9 @@ class TimerList(GUIComponent):
 		if not processed:
 			if timer.state == TimerEntry.StateWaiting:
 				state = _("waiting")
-				if timer.isAutoTimer:
+				if self.iconIceTVTimer and hasattr(timer, "ice_timer_id") and timer.ice_timer_id:
+					icon = self.iconIceTVTimer
+				elif timer.isAutoTimer:
 					icon = self.iconAutoTimer
 				else:
 					icon = self.iconWait
@@ -156,6 +158,11 @@ class TimerList(GUIComponent):
 		self.iconDisabled = LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, "icons/timer_off.png"))
 		self.iconFailed = LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, "icons/timer_failed.png"))
 		self.iconAutoTimer = LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, "icons/timer_autotimer.png"))
+		try:
+			from Plugins.SystemPlugins.IceTV import loadIceTVIcon
+			self.iconIceTVTimer = loadIceTVIcon("timer_icetv.png")
+		except ImportError:
+			self.iconIceTVTimer = None
 
 	def applySkin(self, desktop, parent):
 		def itemHeight(value):

--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -203,8 +203,9 @@ class RecordTimerEntry(TimerEntry):
 		else:
 			self.service_ref = eServiceReference()
 		self.dontSave = False
+		self.eit = None
 		if not description or not name or not eit:
-			evt = self.getEventFromEPG()
+			evt = self.getEventFromEPGId(eit) or self.getEventFromEPG()
 			if evt:
 				if not description:
 					description = evt.getShortDescription()
@@ -353,6 +354,12 @@ class RecordTimerEntry(TimerEntry):
 		self.Filename = Directories.getRecordingFilename(filename, self.MountPath)
 		self.log(0, "Filename calculated as: '%s'" % self.Filename)
 		return self.Filename
+
+	def getEventFromEPGId(self, id=None):
+		id = id or self.eit
+		epgcache = eEPGCache.getInstance()
+		ref = self.service_ref and self.service_ref.ref
+		return id and epgcache.lookupEventId(ref, id) or None
 
 	def getEventFromEPG(self):
 		epgcache = eEPGCache.getInstance()

--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -205,13 +205,16 @@ class RecordTimerEntry(TimerEntry):
 		# print("[RecordTimer][RecordTimerEntry2] serviceref", self.service_ref)				
 		self.eit = eit
 		self.dontSave = False
-		self.name = name
-		if not description:
+		if not description or not name:
 			evt = self.getEventFromEPG()
 			if evt:
-				description = evt.getShortDescription()
+				if not description:
+					description = evt.getShortDescription()
 				if not description:
 					description = evt.getExtendedDescription()
+				if not name:
+					name = evt.getEventName()
+		self.name = name
 		self.description = description
 		self.disabled = disabled
 		self.timer = None

--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -275,10 +275,13 @@ class RecordTimerEntry(TimerEntry):
 		self.resetState()
 
 	def __repr__(self):
+		ice = ""
+		if self.iceTimerId is not None:
+			ice = ", iceTimerId=%s" % self.iceTimerId
 		if not self.disabled:
-			return "RecordTimerEntry(name=%s, begin=%s, serviceref=%s, justplay=%s, isAutoTimer=%s, autoTimerId=%s)" % (self.name, ctime(self.begin), self.service_ref, self.justplay, self.isAutoTimer, self.autoTimerId)
+			return "RecordTimerEntry(name=%s, begin=%s, serviceref=%s, justplay=%s, isAutoTimer=%s, autoTimerId=%s%s)" % (self.name, ctime(self.begin), self.service_ref, self.justplay, self.isAutoTimer, self.autoTimerId, ice)
 		else:
-			return "RecordTimerEntry(name=%s, begin=%s, serviceref=%s, justplay=%s, isAutoTimer=%s, autoTimerId=%s, Disabled)" % (self.name, ctime(self.begin), self.service_ref, self.justplay, self.isAutoTimer, self.autoTimerId)
+			return "RecordTimerEntry(name=%s, begin=%s, serviceref=%s, justplay=%s, isAutoTimer=%s, autoTimerId=%s%s, Disabled)" % (self.name, ctime(self.begin), self.service_ref, self.justplay, self.isAutoTimer, self.autoTimerId, ice)
 
 	def log(self, code, msg):
 		self.log_entries.append((int(time()), code, msg))

--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -206,6 +206,12 @@ class RecordTimerEntry(TimerEntry):
 		self.eit = eit
 		self.dontSave = False
 		self.name = name
+		if not description:
+			evt = self.getEventFromEPG()
+			if evt:
+				description = evt.getShortDescription()
+				if not description:
+					description = evt.getExtendedDescription()
 		self.description = description
 		self.disabled = disabled
 		self.timer = None
@@ -343,6 +349,12 @@ class RecordTimerEntry(TimerEntry):
 		self.Filename = Directories.getRecordingFilename(filename, self.MountPath)
 		self.log(0, "Filename calculated as: '%s'" % self.Filename)
 		return self.Filename
+
+	def getEventFromEPG(self):
+		epgcache = eEPGCache.getInstance()
+		queryTime = self.begin + (self.end - self.begin) // 2
+		ref = self.service_ref and self.service_ref.ref
+		return epgcache.lookupEventTime(ref, queryTime)
 
 	def tryPrepare(self):
 		if self.justplay:

--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -981,13 +981,13 @@ def createTimer(xml):
 
 	return entry
 
-
 class RecordTimer(Timer):
 	def __init__(self):
 		Timer.__init__(self)
 
 		self.onTimerAdded = []
 		self.onTimerRemoved = []
+		self.onTimerChanged = []
 
 		self.Filename = Directories.resolveFilename(Directories.SCOPE_CONFIG, "timers.xml")
 
@@ -995,6 +995,11 @@ class RecordTimer(Timer):
 			self.loadTimer()
 		except IOError:
 			print("[RecordTimer] unable to load timers from file!")
+
+	def timeChanged(self, entry, dosave=True):
+		Timer.timeChanged(self, entry, dosave)
+		for f in self.onTimerChanged:
+			f(entry)
 
 	def doActivate(self, w, dosave=True):
 		# when activating a timer for servicetype 4097,	

--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -202,10 +202,8 @@ class RecordTimerEntry(TimerEntry):
 			self.service_ref = serviceref
 		else:
 			self.service_ref = eServiceReference()
-		# print("[RecordTimer][RecordTimerEntry2] serviceref", self.service_ref)				
-		self.eit = eit
 		self.dontSave = False
-		if not description or not name:
+		if not description or not name or not eit:
 			evt = self.getEventFromEPG()
 			if evt:
 				if not description:
@@ -214,6 +212,9 @@ class RecordTimerEntry(TimerEntry):
 					description = evt.getExtendedDescription()
 				if not name:
 					name = evt.getEventName()
+				if not eit:
+					eit = evt.getEventId()
+		self.eit = eit
 		self.name = name
 		self.description = description
 		self.disabled = disabled

--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -1311,12 +1311,14 @@ class RecordTimer(Timer):
 		print("[Timer] Record %s" % entry)
 		entry.Timer = self
 		self.addTimerEntry(entry)
-		if dosave:
-			self.saveTimer()
 
 		# Trigger onTimerAdded callbacks
 		for f in self.onTimerAdded:
 			f(entry)
+
+		if dosave:
+			self.saveTimer()
+
 		return answer
 
 	@staticmethod
@@ -1464,11 +1466,12 @@ class RecordTimer(Timer):
 		# now the timer should be in the processed_timers list. remove it from there.
 		if entry in self.processed_timers:
 			self.processed_timers.remove(entry)
-		self.saveTimer()
 
 		# Trigger onTimerRemoved callbacks
 		for f in self.onTimerRemoved:
 			f(entry)
+
+		self.saveTimer()
 
 	def shutdown(self):
 		self.saveTimer()

--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -1450,5 +1450,9 @@ class RecordTimer(Timer):
 		self.saveTimer()
 
 	def cleanup(self):
+		removed_timers = [entry for entry in self.processed_timers if not not entry.disabled]
 		Timer.cleanup(self)
+		for entry in removed_timers:
+			for f in self.onTimerRemoved:
+				f(entry)
 		self.saveTimer()

--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -184,7 +184,7 @@ wasRecTimerWakeup = False
 
 
 class RecordTimerEntry(TimerEntry):
-	def __init__(self, serviceref, begin, end, name, description, eit, disabled=False, justplay=False, afterEvent=AFTEREVENT.AUTO, checkOldTimers=False, dirname=None, tags=None, descramble="notset", record_ecm="notset", isAutoTimer=False, always_zap=False, rename_repeat=True, conflict_detection=True, pipzap=False, autoTimerId=None):
+	def __init__(self, serviceref, begin, end, name, description, eit, disabled=False, justplay=False, afterEvent=AFTEREVENT.AUTO, checkOldTimers=False, dirname=None, tags=None, descramble="notset", record_ecm="notset", isAutoTimer=False, always_zap=False, rename_repeat=True, conflict_detection=True, pipzap=False, autoTimerId=None, iceTimerId=None):
 		TimerEntry.__init__(self, int(begin), int(end))
 		if checkOldTimers:
 			if self.begin < time() - 1209600:
@@ -268,6 +268,7 @@ class RecordTimerEntry(TimerEntry):
 		self.ts_dialog = None
 		self.isAutoTimer = isAutoTimer or autoTimerId is not None
 		self.autoTimerId = autoTimerId
+		self.iceTimerId = iceTimerId
 		self.wasInStandby = False
 
 		self.flags = set()
@@ -961,8 +962,9 @@ def createTimer(xml):
 	autoTimerId = xml.get("autoTimerId")
 	if autoTimerId is not None:
 		autoTimerId = int(autoTimerId)
+	iceTimerId = xml.get("iceTimerId")
 	name = str(xml.get("name"))
-	entry = RecordTimerEntry(serviceref, begin, end, name, description, eit, disabled, justplay, afterevent, dirname=location, tags=tags, descramble=descramble, record_ecm=record_ecm, isAutoTimer=isAutoTimer, always_zap=always_zap, rename_repeat=rename_repeat, conflict_detection=conflict_detection, pipzap=pipzap, autoTimerId=autoTimerId)
+	entry = RecordTimerEntry(serviceref, begin, end, name, description, eit, disabled, justplay, afterevent, dirname=location, tags=tags, descramble=descramble, record_ecm=record_ecm, isAutoTimer=isAutoTimer, always_zap=always_zap, rename_repeat=rename_repeat, conflict_detection=conflict_detection, pipzap=pipzap, autoTimerId=autoTimerId, iceTimerId=iceTimerId)
 	entry.repeated = int(repeated)
 	flags = xml.get("flags")
 	if flags:
@@ -1148,6 +1150,8 @@ class RecordTimer(Timer):
 				list.append(' disabled="' + str(int(entry.disabled)) + '"')
 			if entry.autoTimerId:
 				list.append(' autoTimerId="' + str(entry.autoTimerId) + '"')
+			if entry.iceTimerId is not None:
+				list.append(' iceTimerId="' + str(entry.iceTimerId) + '"')
 			if entry.flags:
 				list.append(' flags="' + ' '.join([stringToXML(x) for x in entry.flags]) + '"')
 

--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -1462,7 +1462,8 @@ class RecordTimer(Timer):
 				if x.setAutoincreaseEnd():
 					self.timeChanged(x, False)
 		# now the timer should be in the processed_timers list. remove it from there.
-		self.processed_timers.remove(entry)
+		if entry in self.processed_timers:
+			self.processed_timers.remove(entry)
 		self.saveTimer()
 
 		# Trigger onTimerRemoved callbacks

--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -986,6 +986,9 @@ class RecordTimer(Timer):
 	def __init__(self):
 		Timer.__init__(self)
 
+		self.onTimerAdded = []
+		self.onTimerRemoved = []
+
 		self.Filename = Directories.resolveFilename(Directories.SCOPE_CONFIG, "timers.xml")
 
 		try:
@@ -1282,6 +1285,10 @@ class RecordTimer(Timer):
 		self.addTimerEntry(entry)
 		if dosave:
 			self.saveTimer()
+
+		# Trigger onTimerAdded callbacks
+		for f in self.onTimerAdded:
+			f(entry)
 		return answer
 
 	@staticmethod
@@ -1429,6 +1436,10 @@ class RecordTimer(Timer):
 		# now the timer should be in the processed_timers list. remove it from there.
 		self.processed_timers.remove(entry)
 		self.saveTimer()
+
+		# Trigger onTimerRemoved callbacks
+		for f in self.onTimerRemoved:
+			f(entry)
 
 	def shutdown(self):
 		self.saveTimer()

--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -184,7 +184,7 @@ wasRecTimerWakeup = False
 
 
 class RecordTimerEntry(TimerEntry):
-	def __init__(self, serviceref, begin, end, name, description, eit, disabled=False, justplay=False, afterEvent=AFTEREVENT.AUTO, checkOldTimers=False, dirname=None, tags=None, descramble="notset", record_ecm="notset", isAutoTimer=False, always_zap=False, rename_repeat=True, conflict_detection=True, pipzap=False, autoTimerId=None, iceTimerId=None):
+	def __init__(self, serviceref, begin, end, name, description, eit, disabled=False, justplay=False, afterEvent=AFTEREVENT.AUTO, checkOldTimers=False, dirname=None, tags=None, descramble="notset", record_ecm="notset", isAutoTimer=False, always_zap=False, rename_repeat=True, conflict_detection=True, pipzap=False, autoTimerId=None, ice_timer_id=None):
 		TimerEntry.__init__(self, int(begin), int(end))
 		if checkOldTimers:
 			if self.begin < time() - 1209600:
@@ -268,7 +268,7 @@ class RecordTimerEntry(TimerEntry):
 		self.ts_dialog = None
 		self.isAutoTimer = isAutoTimer or autoTimerId is not None
 		self.autoTimerId = autoTimerId
-		self.iceTimerId = iceTimerId
+		self.ice_timer_id = ice_timer_id
 		self.wasInStandby = False
 
 		self.flags = set()
@@ -276,8 +276,8 @@ class RecordTimerEntry(TimerEntry):
 
 	def __repr__(self):
 		ice = ""
-		if self.iceTimerId is not None:
-			ice = ", iceTimerId=%s" % self.iceTimerId
+		if self.ice_timer_id is not None:
+			ice = ", ice_timer_id=%s" % self.ice_timer_id
 		if not self.disabled:
 			return "RecordTimerEntry(name=%s, begin=%s, serviceref=%s, justplay=%s, isAutoTimer=%s, autoTimerId=%s%s)" % (self.name, ctime(self.begin), self.service_ref, self.justplay, self.isAutoTimer, self.autoTimerId, ice)
 		else:
@@ -965,9 +965,9 @@ def createTimer(xml):
 	autoTimerId = xml.get("autoTimerId")
 	if autoTimerId is not None:
 		autoTimerId = int(autoTimerId)
-	iceTimerId = xml.get("iceTimerId")
+	ice_timer_id = xml.get("ice_timer_id")
 	name = str(xml.get("name"))
-	entry = RecordTimerEntry(serviceref, begin, end, name, description, eit, disabled, justplay, afterevent, dirname=location, tags=tags, descramble=descramble, record_ecm=record_ecm, isAutoTimer=isAutoTimer, always_zap=always_zap, rename_repeat=rename_repeat, conflict_detection=conflict_detection, pipzap=pipzap, autoTimerId=autoTimerId, iceTimerId=iceTimerId)
+	entry = RecordTimerEntry(serviceref, begin, end, name, description, eit, disabled, justplay, afterevent, dirname=location, tags=tags, descramble=descramble, record_ecm=record_ecm, isAutoTimer=isAutoTimer, always_zap=always_zap, rename_repeat=rename_repeat, conflict_detection=conflict_detection, pipzap=pipzap, autoTimerId=autoTimerId, ice_timer_id=ice_timer_id)
 	entry.repeated = int(repeated)
 	flags = xml.get("flags")
 	if flags:
@@ -1161,8 +1161,8 @@ class RecordTimer(Timer):
 				list.append(' disabled="' + str(int(entry.disabled)) + '"')
 			if entry.autoTimerId:
 				list.append(' autoTimerId="' + str(entry.autoTimerId) + '"')
-			if entry.iceTimerId is not None:
-				list.append(' iceTimerId="' + str(entry.iceTimerId) + '"')
+			if entry.ice_timer_id is not None:
+				list.append(' ice_timer_id="' + str(entry.ice_timer_id) + '"')
 			if entry.flags:
 				list.append(' flags="' + ' '.join([stringToXML(x) for x in entry.flags]) + '"')
 

--- a/lib/service/event.cpp
+++ b/lib/service/event.cpp
@@ -293,7 +293,7 @@ RESULT eServiceEvent::getGenreData(ePtr<eGenreData> &dest) const
 	return -1;
 }
 
-PyObject *eServiceEvent::getGenreData() const
+PyObject *eServiceEvent::getGenreDataList() const
 {
 	ePyObject ret = PyList_New(m_genres.size());
 	int cnt=0;
@@ -321,7 +321,7 @@ RESULT eServiceEvent::getParentalData(ePtr<eParentalData> &dest) const
 	return -1;
 }
 
-PyObject *eServiceEvent::getParentalData() const
+PyObject *eServiceEvent::getParentalDataList() const
 {
 	ePyObject ret = PyList_New(m_ratings.size());
 	int cnt = 0;
@@ -351,7 +351,7 @@ RESULT eServiceEvent::getComponentData(ePtr<eComponentData> &dest, int tagnum) c
 	return -1;
 }
 
-PyObject *eServiceEvent::getComponentData() const
+PyObject *eServiceEvent::getComponentDataList() const
 {
 	ePyObject ret = PyList_New(m_component_data.size());
 	int cnt = 0;

--- a/lib/service/event.h
+++ b/lib/service/event.h
@@ -116,7 +116,7 @@ public:
 	PyObject *getComponentDataList() const;
 	PyObject *getComponentData() const
 	{
-		return getGenreDataList();
+		return getComponentDataList();
 	}
 	int getNumOfLinkageServices() const { return m_linkage_services.size(); }
 	SWIG_VOID(RESULT) getLinkageService(eServiceReference &SWIG_OUTPUT, eServiceReference &parent, int num) const;

--- a/lib/service/event.h
+++ b/lib/service/event.h
@@ -112,13 +112,30 @@ public:
 	std::string getSeriesCrid() const { return m_series_crid; }
 	std::string getEpisodeCrid() const { return m_episode_crid; }
 	SWIG_VOID(RESULT) getComponentData(ePtr<eComponentData> &SWIG_OUTPUT, int tagnum) const;
-	PyObject *getComponentData() const;
+	// Naming to parallel getGenreDataList & getParentalDataList
+	PyObject *getComponentDataList() const;
+	PyObject *getComponentData() const
+	{
+		return getGenreDataList();
+	}
 	int getNumOfLinkageServices() const { return m_linkage_services.size(); }
 	SWIG_VOID(RESULT) getLinkageService(eServiceReference &SWIG_OUTPUT, eServiceReference &parent, int num) const;
 	SWIG_VOID(RESULT) getGenreData(ePtr<eGenreData> &SWIG_OUTPUT) const;
-	PyObject *getGenreData() const;
+	PyObject *getGenreDataList() const;
+	// Deprecated, doesn't differentiate from
+	// getGenreData(ePtr<eGenreData> &SWIG_OUTPUT) in Python
+	PyObject *getGenreData() const
+	{
+		return getGenreDataList();
+	}
 	SWIG_VOID(RESULT) getParentalData(ePtr<eParentalData> &SWIG_OUTPUT) const;
-	PyObject *getParentalData() const;
+	PyObject *getParentalDataList() const;
+	// Deprecated, doesn't differentiate from
+	// getGenreData(ePtr<eGenreData> &SWIG_OUTPUT) in Python
+	PyObject *getParentalData() const
+	{
+		return getParentalDataList();
+	}
 };
 SWIG_TEMPLATE_TYPEDEF(ePtr<eServiceEvent>, eServiceEvent);
 SWIG_EXTEND(ePtr<eServiceEvent>,

--- a/lib/service/iservice.h
+++ b/lib/service/iservice.h
@@ -175,6 +175,9 @@ public:
 		number = 0;
 	}
 	void eServiceReferenceBase(const std::string &string);
+#ifdef SWIG
+	eServiceReference(const eServiceReference &ref);
+#endif
 	eServiceReference(const std::string &string);
 	eServiceReference(const char* string2);
 	std::string toString() const;


### PR DESCRIPTION
Changes to support the IceTV plugin.

They may be useful for other applications.

Main changes:
- Add a timers.xml attribute to store IceTV timer ids (similar to AutoTimer ids).
- Add callback mechanisms to RecordTimer for callbacks on timer creation, modification and deletion.
- Try to fetch timer name and description from the EPG if they are missing when the timer is created.
- Allow timer creation to specify the event_id.
- Add genre tables for the Australian and (now suspended) German IceTV services. Allow both a single ServiceReference or a list, allow servicerefs to be either tuples or strings, allow either a single genre or a list of genres to be imported, add the ability to import a tuple of list of tuples representing age ratings of programs.
- Add a new GenreList conversion type to the EventName conversion to allow lists of program genres to be displayed.
- Fix bug that prevented lists of genres being returned from the C++ EPGCache code to Python.