### PR TITLE
[RecordTimer] Fix logic error in cleanup()

### DIFF
--- a/lib/python/RecordTimer.py
+++ b/lib/python/RecordTimer.py
@@ -1477,7 +1477,7 @@ class RecordTimer(Timer):
 		self.saveTimer()
 
 	def cleanup(self):
-		removed_timers = [entry for entry in self.processed_timers if not not entry.disabled]
+		removed_timers = [entry for entry in self.processed_timers if not entry.disabled]
 		Timer.cleanup(self)
 		for entry in removed_timers:
 			for f in self.onTimerRemoved:


### PR DESCRIPTION
When record timer remove callbacks were added to RecordTimer.cleanup(), the condition in constructing the removed_timers list should have had "not" rather than "not not".

The error happened when the changes were rewritten from the original to allow merging with OpenViX, where the cleanup() method was already defined, while it was not in the original Beyonwiz code.

The commit removes the unwanted extra "not".