### PR TITLE
[UsageConfig] Freesat EPG change default to "no"

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -736,7 +736,7 @@ def InitUsageConfig():
 	config.epg = ConfigSubsection()
 	config.epg.eit = ConfigYesNo(default=True)
 	config.epg.mhw = ConfigYesNo(default=False)
-	config.epg.freesat = ConfigYesNo(default=True)
+	config.epg.freesat = ConfigYesNo(default=False)
 	config.epg.viasat = ConfigYesNo(default=True)
 	config.epg.netmed = ConfigYesNo(default=True)
 	config.epg.virgin = ConfigYesNo(default=True)


### PR DESCRIPTION
As recommendations for OpenTV EPG reader are to disable Freesat in order to avoid conflicts, make this recommendation the default option.