### PR TITLE
Universal actions to eListbox

### DIFF
--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -198,6 +198,7 @@ void eListbox::moveSelection(long dir)
 			while (newsel != oldsel && !m_content->currentCursorSelectable());
 			break;
 		case moveTop:
+		case moveStart:
 			m_content->cursorHome();
 			[[fallthrough]];
 		case justCheck:

--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -140,27 +140,22 @@ void eListbox::moveToEnd()
 void eListbox::moveSelection(long dir)
 {
 	long r_dir = dir;
-	switch (dir) {
-		case moveUp:
-			if (m_orientation == orHorizontal){
+	// For compatability reasons we add this so to support current listbox actions in horizontal listboxes
+	if (m_orientation == orHorizontal) {
+		switch (dir) {
+			case moveUp:
 				r_dir = pageUp;
-			}
-			break;
-		case moveDown:
-			if (m_orientation == orHorizontal){
+				break;
+			case moveDown:
 				r_dir = pageDown;
-			}
-			break;
-		case pageUp:
-			if (m_orientation == orHorizontal){
+				break;
+			case pageUp:
 				r_dir = moveUp;
-			}
-			break;
-		case pageDown:
-			if (m_orientation == orHorizontal){
+				break;
+			case pageDown:
 				r_dir = moveDown;
-			}
-			break;
+				break;
+		}
 	}
 	/* refuse to do anything without a valid list. */
 	if (!m_content)
@@ -180,6 +175,7 @@ void eListbox::moveSelection(long dir)
 			m_content->cursorEnd();
 			[[fallthrough]];
 		case moveUp:
+		case prevItem:
 			do
 			{
 				m_content->cursorMove(-1);
@@ -209,6 +205,7 @@ void eListbox::moveSelection(long dir)
 				break;
 			[[fallthrough]];
 		case moveDown:
+		case nextItem:
 			do
 			{
 				m_content->cursorMove(1);
@@ -222,7 +219,8 @@ void eListbox::moveSelection(long dir)
 			}
 			while (newsel != oldsel && !m_content->currentCursorSelectable());
 			break;
-		case pageUp: {
+		case pageUp: 
+		case prevPage: {
 			int pageind;
 			do
 			{
@@ -261,7 +259,8 @@ void eListbox::moveSelection(long dir)
 			while (newsel == prevsel);
 			break;
 		}
-		case pageDown: {
+		case pageDown:
+		case nextPage: {
 			int pageind;
 			do
 			{

--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -144,18 +144,36 @@ void eListbox::moveSelection(long dir)
 	if (m_orientation == orHorizontal) {
 		switch (dir) {
 			case moveUp:
-				r_dir = pageUp;
+				r_dir = prevPage;
 				break;
 			case moveDown:
-				r_dir = pageDown;
+				r_dir = nextPage;
 				break;
 			case pageUp:
-				r_dir = moveUp;
+				r_dir = prevItem;
 				break;
 			case pageDown:
-				r_dir = moveDown;
+				r_dir = nextItem;
 				break;
 		}
+	}
+
+	// Map universal actions to the corresponding action for Horizontal and vertical eListbox
+	switch (dir) {
+		case prevItemPage:
+			if (m_orientation == orHorizontal){
+				r_dir = prevPage;
+			} else {
+				r_dir = prevItem;
+			}
+			break;
+		case nextItemPage:
+			if (m_orientation == orHorizontal){
+				r_dir = nextPage;
+			} else {
+				r_dir = nextItem;
+			}
+			break;
 	}
 	/* refuse to do anything without a valid list. */
 	if (!m_content)

--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -174,6 +174,20 @@ void eListbox::moveSelection(long dir)
 				r_dir = nextItem;
 			}
 			break;
+		case prevPageItem:
+			if (m_orientation == orVertical){
+				r_dir = prevPage;
+			} else {
+				r_dir = prevItem;
+			}
+			break;
+		case nextPageItem:
+			if (m_orientation == orVertical){
+				r_dir = nextPage;
+			} else {
+				r_dir = nextItem;
+			}
+			break;
 	}
 	/* refuse to do anything without a valid list. */
 	if (!m_content)

--- a/lib/gui/elistbox.h
+++ b/lib/gui/elistbox.h
@@ -144,8 +144,10 @@ public:
 		moveStartTop,
 		moveStart,
 		prevItemPage,
+		prevPageItem,
 		prevItem,
 		nextItemPage,
+		nextPageItem,
 		nextItem,
 		prevPage,
 		nextPage

--- a/lib/gui/elistbox.h
+++ b/lib/gui/elistbox.h
@@ -141,8 +141,11 @@ public:
 		pageUp,
 		pageDown,
 		justCheck,
+		moveStartTop,
 		moveStart,
+		prevItemPage,
 		prevItem,
+		nextItemPage,
 		nextItem,
 		prevPage,
 		nextPage

--- a/lib/gui/elistbox.h
+++ b/lib/gui/elistbox.h
@@ -141,6 +141,7 @@ public:
 		pageUp,
 		pageDown,
 		justCheck,
+		moveStart,
 		prevItem,
 		nextItem,
 		prevPage,

--- a/lib/gui/elistbox.h
+++ b/lib/gui/elistbox.h
@@ -140,7 +140,11 @@ public:
 		moveEnd,
 		pageUp,
 		pageDown,
-		justCheck
+		justCheck,
+		prevItem,
+		nextItem,
+		prevPage,
+		nextPage
 	};
 
 	void setItemHeight(int h);


### PR DESCRIPTION
Added universal actions to eListbox so to be better supported by keymaps.
The old actions are still supported by compatibility reasons. (supported by mapping)
The new actions are:
prevItem,
nextItem,
prevPage,
nextPage,
moveStart

That actions are just aliases to the old with normalized names so to not imply the type of the listbox.

---

prevItemPage, - item in vertical, page in horizontal
prevPageItem, - page in vertical, item in horizontal
nextItemPage, - item in vertical, page in horizontal
nextPageItem - page in vertical, item in horizontal

That actions can be used for both horizontal and vertical eListbox. It maps to correct action based on eListbox orientation internally.