### PR TITLE
Make the boxtype test simpler to read and modify.

### DIFF
--- a/tools/enigma2.sh.in
+++ b/tools/enigma2.sh.in
@@ -15,14 +15,22 @@ if [ -x @sysconfdir@/enigma2/startup.sh ]; then
 	@sysconfdir@/enigma2/startup.sh
 fi
 
+do_reader_kill=0
 if [ -e /proc/stb/info/boxtype ]; then
+# Set relevant boxtypes to 1 - missing ones are treated as 0.
+	declare -A boxtest=(
+		viper4k 1   beyonwizv2 1    sf8008 1    sf8008m 1
+		sfx6008 1   sx988 1         sx88v2 1    gbmv200 1
+	)
 	stbcheck=`cat /proc/stb/info/boxtype`
-	if [ $stbcheck == "viper4k" ] || [ $stbcheck == "sf8008" ] || [ $stbcheck == "sf8008m" ] || [ $stbcheck == "sx988" ] || [ $stbcheck == "sfx6008" ] || [ $stbcheck == "beyonwizv2" ] || [ $stbcheck == "sx88v2" ] || [ $stbcheck == "gbmv200" ]; then
+	if [ ${boxtest[$stbcheck]:-0} -eq 1 ]; then
 		count=`ps -ef |grep libreader |grep -v "grep" |wc -l`
 		if [ 0 == $count ];then
 			libreader 720P_50
+			do_reader_kill=1
 		fi
 	fi
+	unset boxtest
 fi
 
 if [ -x @bindir@/showiframe ]; then
@@ -338,11 +346,8 @@ wait ${enigma2pid}
 
 
 if [ "$ret" -ne "1" ]; then
-	if [ -e /proc/stb/info/boxtype ]; then
-		stbcheck=`cat /proc/stb/info/boxtype`
-		if [ $stbcheck == "viper4k" ] || [ $stbcheck == "sf8008" ] || [ $stbcheck == "sf8008m" ] || [ $stbcheck == "sx988" ] || [ $stbcheck == "sfx6008" ] || [ $stbcheck == "beyonwizv2" ] || [ $stbcheck == "sx88v2" ] || [ $stbcheck == "gbmv200" ]; then
-			killall -9 libreader; sleep 5
-		fi
+	if [ $do_reader_kill -ne 0 ]; then
+		killall -9 libreader; sleep 5
 	fi
 fi
 


### PR DESCRIPTION
Set a flag from the result for later use rather than redo the same test.