### PR TITLE
[EventName] fix ETSI Classifications

### DIFF
--- a/lib/python/Components/Converter/EventName.py
+++ b/lib/python/Components/Converter/EventName.py
@@ -31,7 +31,7 @@ class ETSIClassifications(dict):
 			return "ratings/ETSI-%d.png" % age
 
 	def __init__(self):
-		self.update([(i, (self.shortRating(c), self.longRating(c), self.imageRating(c))) for i, c in enumerate(range(0, 15))])
+		self.update([(i, (self.shortRating(c), self.longRating(c), self.imageRating(c))) for i, c in enumerate(range(0, 18))])
 
 
 class AusClassifications(dict):

--- a/lib/python/Components/Converter/EventName.py
+++ b/lib/python/Components/Converter/EventName.py
@@ -31,7 +31,7 @@ class ETSIClassifications(dict):
 			return "ratings/ETSI-%d.png" % age
 
 	def __init__(self):
-		self.update([(i, (self.shortRating(c), self.longRating(c), self.imageRating(c))) for i, c in enumerate(range(0, 18))])
+		self.update([(i, (self.shortRating(c), self.longRating(c), self.imageRating(c))) for i, c in enumerate(range(0, 16))])
 
 
 class AusClassifications(dict):


### PR DESCRIPTION
ETSI Classifications for min age 18 years is wrongly converted to Rating defined by broadcaster. since this patch: https://github.com/OpenViX/enigma2/commit/9702fa89efeeb60a87851d0e349b3fe1dc2a366f