### PR TITLE
[Added] Possibility to exclude first CA device per CI slot.

### DIFF
--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -1281,6 +1281,10 @@ eDVBCISlot::eDVBCISlot(eMainloop *context, int nr)
 	snprintf(config_key_operator_profile, 255, "config.ci.%d.disable_operator_profile", slotid);
 	bool operator_profile_disabled = eSimpleConfig::getBool(config_key_operator_profile, false);
 	m_operator_profiles_disabled = operator_profile_disabled;
+	char config_key_ca0_excluded[255];
+	snprintf(config_key_ca0_excluded, 255, "config.ci.%d.exclude_ca0_device", slotid);
+	bool ca0_excluded = eSimpleConfig::getBool(config_key_ca0_excluded, false);
+	m_ca0_excluded = ca0_excluded;
 	if (enabled)
 		openDevice();
 	else

--- a/lib/dvb_ci/dvbci.h
+++ b/lib/dvb_ci/dvbci.h
@@ -78,6 +78,7 @@ class eDVBCISlot: public iObject, public sigc::trackable
 	eMainloop *m_context;
 	int m_ciplus_routing_tunernum;
 	bool m_operator_profiles_disabled;
+	bool m_ca0_excluded;
 	std::string m_ciplus_routing_input;
 	std::string m_ciplus_routing_ci_input;
 
@@ -130,6 +131,7 @@ public:
 	int getNumOfServices();
 	int getVersion();
 	bool getIsOperatorProfileDisabled() { return m_operator_profiles_disabled; };
+	bool getIsCA0Excluded() { return m_ca0_excluded; };
 	int16_t getCADemuxID() { return m_ca_demux_id; };
 	int getTunerNum() { return m_tunernum; };
 	int getUseCount() { return use_count; };

--- a/lib/dvb_ci/dvbci_ccmgr.cpp
+++ b/lib/dvb_ci/dvbci_ccmgr.cpp
@@ -792,13 +792,13 @@ void eDVBCICcSession::set_descrambler_key()
 	if (m_descrambler_fd != -1 && m_current_ca_demux_id != m_slot->getCADemuxID())
 	{
 		descrambler_deinit(m_descrambler_fd);
-		m_descrambler_fd = descrambler_init(m_slot->getSlotID(), m_slot->getCADemuxID());
+		m_descrambler_fd = descrambler_init(m_slot->getSlotID(), m_slot->getCADemuxID() + (m_slot->getIsCA0Excluded() ? 1 : 0));
 		m_current_ca_demux_id = m_slot->getCADemuxID();
 	}
 
 	if (m_descrambler_fd == -1 && m_slot->getCADemuxID() > -1)
 	{
-		m_descrambler_fd = descrambler_init(m_slot->getSlotID(), m_slot->getCADemuxID());
+		m_descrambler_fd = descrambler_init(m_slot->getSlotID(), m_slot->getCADemuxID() + (m_slot->getIsCA0Excluded() ? 1 : 0));
 		m_current_ca_demux_id = m_slot->getCADemuxID();
 	}
 

--- a/lib/python/Screens/Ci.py
+++ b/lib/python/Screens/Ci.py
@@ -46,6 +46,7 @@ def InitCiConfig():
 			config.ci[slot].static_pin = ConfigPIN(default=0)
 			config.ci[slot].show_ci_messages = ConfigYesNo(default=True)
 			config.ci[slot].disable_operator_profile = ConfigYesNo(default=False)
+			config.ci[slot].exclude_ca0_device = ConfigYesNo(default=False)
 			if SystemInfo["CI%dSupportsHighBitrates" % slot]:
 				with open("/proc/stb/tsmux/ci%d_tsclk_choices" % slot) as fd:
 					procChoices = fd.read().strip()
@@ -475,6 +476,7 @@ class CiSelection(Screen):
 		self.list.append(getConfigListEntry(_("Show CI messages"), config.ci[slot].show_ci_messages, 3, slot))
 		self.list.append(getConfigListEntry(_("Disable operator profiles"), config.ci[slot].disable_operator_profile, 3, slot))
 		self.list.append(getConfigListEntry(_("Multiple service support"), config.ci[slot].canDescrambleMultipleServices, 3, slot))
+		self.list.append(getConfigListEntry(_("Exclude first CA device"), config.ci[slot].exclude_ca0_device, 3, slot))
 		if SystemInfo["CI%dSupportsHighBitrates" % slot]:
 			self.list.append(getConfigListEntry(_("High bitrate support"), config.ci[slot].highBitrate))
 		if SystemInfo["CI%dRelevantPidsRoutingSupport" % slot]:


### PR DESCRIPTION
[Added] Possibility to exclude first CA device per CI slot. Useful for boxes/drivers where CA devices cant be shared between modules and emus.