### PR TITLE
[dreambox led] fix blinking when recording

### DIFF
--- a/lib/python/Screens/SessionGlobals.py
+++ b/lib/python/Screens/SessionGlobals.py
@@ -48,8 +48,8 @@ class SessionGlobals(Screen):
 			FrontpanelLed(which=0, boolean=False, patterns=[PATTERN_OFF, PATTERN_BLINK, PATTERN_OFF, PATTERN_BLINK]).connect(combine)
 		elif nr_leds == 2:
 			if MODEL in ("dm900", "dm920"):
-				FrontpanelLed(which=1, boolean=False, patterns=[PATTERN_OFF, PATTERN_BLINK, PATTERN_OFF, PATTERN_BLINK]).connect(combine)
-				FrontpanelLed(which=0, boolean=False, patterns=[PATTERN_ON, PATTERN_ON, PATTERN_OFF, PATTERN_OFF]).connect(combine)
+				FrontpanelLed(which=1, boolean=False, patterns=[PATTERN_OFF, PATTERN_OFF, PATTERN_OFF, PATTERN_OFF]).connect(combine)
+				FrontpanelLed(which=0, boolean=False, patterns=[PATTERN_ON, PATTERN_BLINK, PATTERN_OFF, PATTERN_BLINK]).connect(combine)
 			else:
 				FrontpanelLed(which=0, boolean=False, patterns=[PATTERN_OFF, PATTERN_BLINK, PATTERN_ON, PATTERN_BLINK]).connect(combine)
 				FrontpanelLed(which=1, boolean=False, patterns=[PATTERN_ON, PATTERN_ON, PATTERN_OFF, PATTERN_OFF]).connect(combine)


### PR DESCRIPTION
problem: when recording the blue led was steadily on, and the red led was blinking in addition. this was not visible well. blue dominated and red was kind of blinking in the background, hard to see.
so i changed the red led to stay off and the blue led to blink when recording. 
why not red only blinking? well, in my mind red blinking signals an error.