### PR TITLE
Fix passthrough audio issues and refactor handling

### DIFF
--- a/lib/python/Components/AVSwitch.py
+++ b/lib/python/Components/AVSwitch.py
@@ -338,8 +338,7 @@ avSwitch = iAVSwitch  # Not used by OpenViX. For compatibility with OpenATV. Use
 
 def InitAVSwitch():
 	delay_choices = [(i, ngettext("%d millisecond", "%d milliseconds", i) % i) for i in list(range(0, 3000, 100))]  # noqa: F821
-	config.av.passthrough_fix_long = ConfigSelection(choices=delay_choices, default=1200)
-	config.av.passthrough_fix_short = ConfigSelection(choices=delay_choices, default=100)
+	config.av.passthrough_fix = ConfigBoolean(default=False)
 	config.av.yuvenabled = ConfigBoolean(default=True)
 	colorformat_choices = {
 		"cvbs": _("CVBS"),

--- a/lib/python/Components/AVSwitch.py
+++ b/lib/python/Components/AVSwitch.py
@@ -337,7 +337,6 @@ avSwitch = iAVSwitch  # Not used by OpenViX. For compatibility with OpenATV. Use
 
 
 def InitAVSwitch():
-	delay_choices = [(i, ngettext("%d millisecond", "%d milliseconds", i) % i) for i in list(range(0, 3000, 100))]  # noqa: F821
 	config.av.passthrough_fix = ConfigBoolean(default=False)
 	config.av.yuvenabled = ConfigBoolean(default=True)
 	colorformat_choices = {

--- a/lib/python/Screens/VideoMode.py
+++ b/lib/python/Screens/VideoMode.py
@@ -69,9 +69,7 @@ class VideoSetup(Setup):
 		if config.usage.setup_level.index >= 1:
 			if SystemInfo["CanDownmixAC3"]:
 				self.list.append(getConfigListEntry(_("AC3 downmix"), config.av.downmix_ac3, _("Choose whether multi channel ac3 sound tracks should be downmixed to stereo.")))
-				if SystemInfo["Vu_EAC3_fix"] and config.av.downmix_ac3.value == "passthrough":
-					self.list.append(getConfigListEntry(_("Passthrough audio handling delay AC3"), config.av.passthrough_fix_short, _("Used to specify delay when switching between services and AC3 passthrough is enabled.")))
-					self.list.append(getConfigListEntry(_("Passthrough audio handling delay AC3+"), config.av.passthrough_fix_long, _("Used to specify delay when switching between services and AC3+/Atmos passthrough is enabled.")))
+				self.list.append(getConfigListEntry(_("Passthrough audio fix"), config.av.passthrough_fix, _("Enabled/Disable audio passthrough fix.")))
 			if SystemInfo["CanDownmixDTS"]:
 				self.list.append(getConfigListEntry(_("DTS downmix"), config.av.downmix_dts, _("Choose whether multi channel dts sound tracks should be downmixed to stereo.")))
 			if SystemInfo["CanDownmixAACPlus"]:

--- a/lib/python/Screens/VideoMode.py
+++ b/lib/python/Screens/VideoMode.py
@@ -69,7 +69,7 @@ class VideoSetup(Setup):
 		if config.usage.setup_level.index >= 1:
 			if SystemInfo["CanDownmixAC3"]:
 				self.list.append(getConfigListEntry(_("AC3 downmix"), config.av.downmix_ac3, _("Choose whether multi channel ac3 sound tracks should be downmixed to stereo.")))
-				self.list.append(getConfigListEntry(_("Passthrough audio fix"), config.av.passthrough_fix, _("Enabled/Disable audio passthrough fix.")))
+				self.list.append(getConfigListEntry(_("Passthrough audio fix"), config.av.passthrough_fix, _("Enabled/Disable audio passthrough fix for SoftCSA, DVB and Gstreamer.")))
 			if SystemInfo["CanDownmixDTS"]:
 				self.list.append(getConfigListEntry(_("DTS downmix"), config.av.downmix_dts, _("Choose whether multi channel dts sound tracks should be downmixed to stereo.")))
 			if SystemInfo["CanDownmixAACPlus"]:

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -23,6 +23,7 @@
 #include <lib/dvb/tstools.h>
 #include <lib/python/python.h>
 #include <lib/base/nconfig.h> // access to python config
+#include <lib/base/esimpleconfig.h>
 #include <lib/base/httpsstream.h>
 #include <lib/base/httpstream.h>
 #include <lib/service/servicedvbfcc.h>

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -3533,10 +3533,30 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 		if (!sendSeekableStateChanged && (m_decoder->getVideoProgressive() != -1) != wasSeekable)
 			sendSeekableStateChanged = true;
 	}
+#ifdef PASSTHROUGH_FIX
+	if (!m_noaudio)
+		forceAudioReset();
+#endif
 
 	if (sendSeekableStateChanged)
 		m_event((iPlayableService*)this, evSeekableStatusChanged);
 }
+
+#ifdef PASSTHROUGH_FIX
+void eDVBServicePlay::forceAudioReset()
+{
+	if (!eSimpleConfig::getBool("config.av.passthrough_fix", false))
+		return;
+	// Toggle Bluetooth audio off->on->off to force audio driver reinitialization
+	std::string btaudio = CFile::read("/proc/stb/audio/btaudio");
+	if (!btaudio.empty() && btaudio.find("off") != std::string::npos)
+	{
+		eDebug("[eDVBSoftDecoder] Force audio reset: toggling btaudio on and back off");
+		CFile::writeStr("/proc/stb/audio/btaudio", "on");
+		CFile::writeStr("/proc/stb/audio/btaudio", "off");
+	}
+}
+#endif
 
 void eDVBServicePlay::loadCuesheet()
 {

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -23,7 +23,6 @@
 #include <lib/dvb/tstools.h>
 #include <lib/python/python.h>
 #include <lib/base/nconfig.h> // access to python config
-#include <lib/base/esimpleconfig.h>
 #include <lib/base/httpsstream.h>
 #include <lib/base/httpstream.h>
 #include <lib/service/servicedvbfcc.h>
@@ -3546,7 +3545,7 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 #ifdef PASSTHROUGH_FIX
 void eDVBServicePlay::forceAudioReset()
 {
-	if (!eSimpleConfig::getBool("config.av.passthrough_fix", false))
+	if (!eConfigManager::getConfigBoolValue("config.av.passthrough_fix", false)
 		return;
 	// Toggle Bluetooth audio off->on->off to force audio driver reinitialization
 	std::string btaudio = CFile::read("/proc/stb/audio/btaudio");

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1079,9 +1079,6 @@ eDVBServicePlay::eDVBServicePlay(const eServiceReference &ref, eDVBService *serv
 	m_soft_decoder_video_info_valid(false),
 	m_nownext_timer(eTimer::create(eApp))
 {
-#ifdef PASSTHROUGH_FIX
-	m_passthrough_fix_timer = eTimer::create(eApp);
-#endif
 //	m_is_streamx = m_is_stream;	// sets to false if looking at fallback url at this point as m_is_stream(ref.path.find("://") is false.
 	eDebug("[servicedvb][eDVBServicePlay] now running: m_is_streamx set by m_is_stream %d", m_is_streamx);
 	eDebug("[servicedvb][eDVBServicePlay] now running: m_is_pvr set to; %d", m_is_pvr);
@@ -1091,9 +1088,6 @@ eDVBServicePlay::eDVBServicePlay(const eServiceReference &ref, eDVBService *serv
 	CONNECT(m_event_handler.m_eit_changed, eDVBServicePlay::gotNewEvent);
 	CONNECT(m_subtitle_sync_timer->timeout, eDVBServicePlay::checkSubtitleTiming);
 	CONNECT(m_nownext_timer->timeout, eDVBServicePlay::updateEpgCacheNowNext);
-#ifdef PASSTHROUGH_FIX
-	CONNECT(m_passthrough_fix_timer->timeout, eDVBServicePlay::forcePassthrough);
-#endif
 }
 
 eDVBServicePlay::~eDVBServicePlay()
@@ -1126,15 +1120,6 @@ eDVBServicePlay::~eDVBServicePlay()
 
 	if (m_subtitle_widget) m_subtitle_widget->destroy();
 }
-
-
-#ifdef PASSTHROUGH_FIX
-void eDVBServicePlay::forcePassthrough()
-{
-	eDebug("[eDVBServicePlay] Setting 'passthrough' to force correct operation");
-	CFile::writeStr("/proc/stb/audio/ac3", "passthrough");
-}
-#endif
 
 void eDVBServicePlay::gotNewEvent(int error)
 {
@@ -2490,18 +2475,6 @@ int eDVBServicePlay::selectAudioStream(int i)
 		return -4;
 	}
 
-#ifdef PASSTHROUGH_FIX
-	if (apidtype == eDVBPMTParser::audioStream::atAC3 || apidtype == eDVBPMTParser::audioStream::atAAC || apidtype == eDVBPMTParser::audioStream::atDDP) {
-		std::string pass = CFile::read("/proc/stb/audio/ac3");
-		if (replace_all(replace_all(pass, "\r", ""), "\n", "") == "passthrough")
-		{
-			int shortAudioDelay = eConfigManager::getConfigIntValue("config.av.passthrough_fix_short", 100);
-			m_passthrough_fix_timer->stop();
-			m_passthrough_fix_timer->start(shortAudioDelay, true);
-		}
-	}
-#endif
-
 	if (position != -1)
 	{
 		ret = seekTo(position);
@@ -3537,7 +3510,6 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 	if (!m_noaudio)
 		forceAudioReset();
 #endif
-
 	if (sendSeekableStateChanged)
 		m_event((iPlayableService*)this, evSeekableStatusChanged);
 }
@@ -3554,6 +3526,11 @@ void eDVBServicePlay::forceAudioReset()
 		eDebug("[eDVBSoftDecoder] Force audio reset: toggling btaudio on and back off");
 		CFile::writeStr("/proc/stb/audio/btaudio", "on");
 		CFile::writeStr("/proc/stb/audio/btaudio", "off");
+	}
+	if (btaudio.empty())
+	{
+		int currAudioIndex = getCurrentTrack();
+		selectTrack(currAudioIndex);
 	}
 }
 #endif

--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -268,6 +268,9 @@ protected:
 	void switchToTimeshift();
 
 	void updateDecoder(bool sendSeekableStateChanged=false);
+#ifdef PASSTHROUGH_FIX
+	void forceAudioReset();
+#endif
 
 	int m_skipmode;
 	int m_fastforward;

--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -329,11 +329,6 @@ protected:
 	ePtr<eTimer> m_nownext_timer;
 	void updateEpgCacheNowNext();
 
-#ifdef PASSTHROUGH_FIX
-	ePtr<eTimer> m_passthrough_fix_timer;
-	void forcePassthrough();
-#endif
-
 		/* radiotext */
 	ePtr<eDVBRdsDecoder> m_rds_decoder;
 	ePtr<eConnection> m_rds_decoder_event_connection;

--- a/lib/service/servicedvbsoftdecoder.cpp
+++ b/lib/service/servicedvbsoftdecoder.cpp
@@ -4,6 +4,7 @@
 #include <lib/dvb/demux.h>
 #include <lib/base/eerror.h>
 #include <lib/base/esimpleconfig.h>
+#include <lib/base/cfile.h>
 #include <sys/ioctl.h>
 #include <fcntl.h>
 
@@ -737,6 +738,7 @@ void eDVBSoftDecoder::updateDecoder(int vpid, int vpidtype, int pcrpid)
 
 				// Notify parent about selected audio PID
 				m_audio_pid_selected(apid);
+
 			}
 		}
 
@@ -748,6 +750,12 @@ void eDVBSoftDecoder::updateDecoder(int vpid, int vpidtype, int pcrpid)
 			m_decoder->play();
 			eDebug("[eDVBSoftDecoder] Decoder PLAY with vpid=%04x vpidtype=%d", vpid, vpidtype);
 			m_decoder_ready();
+
+			if (!m_noaudio)
+			{
+				// Force audio reset after decoder start to fix audio dropouts
+				forceAudioReset();
+			}
 		}
 		else
 		{
@@ -762,6 +770,19 @@ void eDVBSoftDecoder::videoEvent(struct iTSMPEGDecoder::videoEvent event)
 	m_video_event(event);
 }
 
+void eDVBSoftDecoder::forceAudioReset()
+{
+	if (!eSimpleConfig::getBool("config.av.passthrough_fix", false))
+		return;
+	std::string btaudio = CFile::read("/proc/stb/audio/btaudio");
+	if (!btaudio.empty() && btaudio.find("off") != std::string::npos)
+	{
+		eDebug("[eDVBSoftDecoder] Force audio reset: toggling btaudio on and back off");
+		CFile::writeStr("/proc/stb/audio/btaudio", "on");
+		CFile::writeStr("/proc/stb/audio/btaudio", "off");
+	}
+}
+	// Toggle Bluetooth audio off->on->off to force audio driver reinitialization
 // ============================================================================
 // Playback Control - Delegate to decoder
 // ============================================================================

--- a/lib/service/servicedvbsoftdecoder.cpp
+++ b/lib/service/servicedvbsoftdecoder.cpp
@@ -770,6 +770,7 @@ void eDVBSoftDecoder::videoEvent(struct iTSMPEGDecoder::videoEvent event)
 	m_video_event(event);
 }
 
+// Toggle Bluetooth audio off->on->off to force audio driver reinitialization
 void eDVBSoftDecoder::forceAudioReset()
 {
 	if (!eSimpleConfig::getBool("config.av.passthrough_fix", false))
@@ -782,7 +783,7 @@ void eDVBSoftDecoder::forceAudioReset()
 		CFile::writeStr("/proc/stb/audio/btaudio", "off");
 	}
 }
-	// Toggle Bluetooth audio off->on->off to force audio driver reinitialization
+
 // ============================================================================
 // Playback Control - Delegate to decoder
 // ============================================================================

--- a/lib/service/servicedvbsoftdecoder.h
+++ b/lib/service/servicedvbsoftdecoder.h
@@ -149,6 +149,8 @@ private:
 	void updatePids(bool withDecoder = true);
 	void updateDecoder(int vpid, int vpidtype, int pcrpid);
 
+	// Force audio reset after decoder start (fixes audio dropouts on some boxes)
+	void forceAudioReset();
 	// Video Event Signal
 	sigc::signal<void(struct iTSMPEGDecoder::videoEvent)> m_video_event;
 	ePtr<eConnection> m_video_event_conn;

--- a/lib/service/servicedvbsoftdecoder.h
+++ b/lib/service/servicedvbsoftdecoder.h
@@ -149,7 +149,7 @@ private:
 	void updatePids(bool withDecoder = true);
 	void updateDecoder(int vpid, int vpidtype, int pcrpid);
 
-	// Force audio reset after decoder start (fixes audio dropouts on some boxes)
+	// Force audio reset after decoder start (fixes audio dropouts on some problematic boxes)
 	void forceAudioReset();
 	// Video Event Signal
 	sigc::signal<void(struct iTSMPEGDecoder::videoEvent)> m_video_event;

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -496,6 +496,7 @@ eServiceMP3::eServiceMP3(eServiceReference ref):
 	const char *filename;
 	std::string filename_str;
 	size_t pos = m_ref.path.find('#');
+	size_t pos_q = m_ref.path.find('?');
 	if (pos != std::string::npos && (m_ref.path.compare(0, 4, "http") == 0 || m_ref.path.compare(0, 4, "rtsp") == 0))
 	{
 		filename_str = m_ref.path.substr(0, pos);
@@ -514,11 +515,27 @@ eServiceMP3::eServiceMP3(eServiceReference ref):
 		}
 	}
 	else
+	{
+		filename_str = m_ref.path;
 		filename = m_ref.path.c_str();
+	}
 
-	const char *ext = strrchr(filename, '.');
+	std::string realFilename_str;
+	const char *realFilename;
+
+	if (pos_q != std::string::npos)
+	{
+		realFilename_str = filename_str.substr(0, pos_q);
+		realFilename = realFilename_str.c_str();
+	}
+	else
+		realFilename = filename_str.c_str();
+
+	const char *ext = strrchr(realFilename, '.');
 	if (!ext)
-		ext = filename + strlen(filename);
+		ext = realFilename + strlen(realFilename);
+
+	eDebug("[ServiceMP3] ext = %s", ext);
 
 	m_sourceinfo.is_video = FALSE;
 	m_sourceinfo.audiotype = atUnknown;
@@ -714,20 +731,6 @@ eServiceMP3::eServiceMP3(eServiceReference ref):
 
 		if (suburi != NULL)
 			g_object_set (G_OBJECT (m_gst_playbin), "suburi", suburi, NULL);
-		else
-		{
-			char srt_filename[ext - filename + 5];
-			strncpy(srt_filename,filename, ext - filename);
-			srt_filename[ext - filename] = '\0';
-			strcat(srt_filename, ".srt");
-			if (::access(srt_filename, R_OK) >= 0)
-			{
-				gchar *luri = g_filename_to_uri(srt_filename, NULL, NULL);
-				eDebug("[eServiceMP3] subtitle uri: %s", luri);
-				g_object_set (m_gst_playbin, "suburi", luri, NULL);
-				g_free(luri);
-			}
-		}
 	} else
 	{
 		m_event((iPlayableService*)this, evUser+12);
@@ -794,6 +797,8 @@ eServiceMP3::~eServiceMP3()
 #ifdef PASSTHROUGH_FIX
 void eServiceMP3::forceAudioReset()
 {
+	if (!eConfigManager::getConfigBoolValue("config.av.passthrough_fix", false)
+		return;
 	// Toggle Bluetooth audio off->on->off to force audio driver reinitialization
 	std::string btaudio = CFile::read("/proc/stb/audio/btaudio");
 	if (!btaudio.empty() && btaudio.find("off") != std::string::npos)
@@ -802,8 +807,15 @@ void eServiceMP3::forceAudioReset()
 		CFile::writeStr("/proc/stb/audio/btaudio", "on");
 		CFile::writeStr("/proc/stb/audio/btaudio", "off");
 	}
-	//m_clear_buffers = true;
-	//clearBuffers();
+
+	if (btaudio.empty())
+	{
+		int currAudioIndex = getCurrentTrack();
+		selectAudioStream(currAudioIndex, true);
+	}
+	}
+	m_clear_buffers = true;
+	clearBuffers();
 }
 #endif
 

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -435,9 +435,6 @@ eServiceMP3::eServiceMP3(eServiceReference ref):
 	m_dvb_subtitle_sync_timer = eTimer::create(eApp);
 	m_dvb_subtitle_parser = new eDVBSubtitleParser();
 	m_dvb_subtitle_parser->connectNewPage(sigc::mem_fun(*this, &eServiceMP3::newDVBSubtitlePage), m_new_dvb_subtitle_page_connection);
-#ifdef PASSTHROUGH_FIX
-	m_passthrough_fix_timer = eTimer::create(eApp);
-#endif
 	m_stream_tags = 0;
 	m_currentAudioStream = -1;
 	m_currentSubtitleStream = -1;
@@ -489,9 +486,7 @@ eServiceMP3::eServiceMP3(eServiceReference ref):
 	CONNECT(m_dvb_subtitle_sync_timer->timeout, eServiceMP3::pushDVBSubtitles);
 	CONNECT(m_pump.recv_msg, eServiceMP3::gstPoll);
 	CONNECT(m_nownext_timer->timeout, eServiceMP3::updateEpgCacheNowNext);
-#ifdef PASSTHROUGH_FIX
-	CONNECT(m_passthrough_fix_timer->timeout, eServiceMP3::forcePassthrough);
-#endif
+
 	m_aspect = m_width = m_height = m_framerate = m_progressive = m_gamma = -1;
 
 	m_state = stIdle;
@@ -797,12 +792,18 @@ eServiceMP3::~eServiceMP3()
 }
 
 #ifdef PASSTHROUGH_FIX
-void eServiceMP3::forcePassthrough()
+void eServiceMP3::forceAudioReset()
 {
-	eDebug("[eServiceMP3] Setting 'passthrough' to force correct operation");
-	CFile::writeStr("/proc/stb/audio/ac3", "passthrough");
-	m_clear_buffers = true;
-	clearBuffers();
+	// Toggle Bluetooth audio off->on->off to force audio driver reinitialization
+	std::string btaudio = CFile::read("/proc/stb/audio/btaudio");
+	if (!btaudio.empty() && btaudio.find("off") != std::string::npos)
+	{
+		eDebug("[eDVBSoftDecoder] Force audio reset: toggling btaudio on and back off");
+		CFile::writeStr("/proc/stb/audio/btaudio", "on");
+		CFile::writeStr("/proc/stb/audio/btaudio", "off");
+	}
+	//m_clear_buffers = true;
+	//clearBuffers();
 }
 #endif
 
@@ -1727,14 +1728,7 @@ int eServiceMP3::selectAudioStream(int i, bool skipAudioFix)
 					std::string pass = CFile::read("/proc/stb/audio/ac3");
 					if (replace_all(replace_all(pass, "\r", ""), "\n", "") == "passthrough")
 					{
-						int longAudioDelay = eConfigManager::getConfigIntValue("config.av.passthrough_fix_long", 1200);
-						int shortAudioDelay = eConfigManager::getConfigIntValue("config.av.passthrough_fix_short", 100);
-						if (m_clear_buffers)
-						{
-							m_passthrough_fix_timer->stop();
-							m_passthrough_fix_timer->start(apidtype == atEAC3 && i > 0 && current_audio_orig > -1 ? longAudioDelay : shortAudioDelay, true);
-						}
-						
+						forceAudioReset();
 					}
 					else
 					{

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -387,9 +387,6 @@ private:
 	subtitle_pages_map_t m_subtitle_pages;
 	ePtr<eTimer> m_subtitle_sync_timer;
 	ePtr<eTimer> m_dvb_subtitle_sync_timer;
-#ifdef PASSTHROUGH_FIX
-	ePtr<eTimer> m_passthrough_fix_timer;
-#endif
 	ePtr<eDVBSubtitleParser> m_dvb_subtitle_parser;
 	ePtr<eConnection> m_new_dvb_subtitle_page_connection;
 	void newDVBSubtitlePage(const eDVBSubtitlePage &p);
@@ -403,7 +400,7 @@ private:
 	void sourceTimeout();
 	void clearBuffers(bool force=false);
 #ifdef PASSTHROUGH_FIX
-	void forcePassthrough();
+	void forceAudioReset();
 #endif
 	sourceStream m_sourceinfo;
 	gulong m_subs_to_pull_handler_id;


### PR DESCRIPTION
This pull request refactors and simplifies the audio passthrough fix logic across the codebase. It replaces the previous timer-based approach (using configurable delays) with a more robust method that forcefully resets the audio driver when needed. The configuration is streamlined to a single boolean option, and redundant code is removed. Additionally, improvements are made to how file extensions are parsed in `eServiceMP3`.

### Audio passthrough fix refactor and simplification

* Replaces the previous timer-based passthrough fix (with `passthrough_fix_short` and `passthrough_fix_long` delays) with a single boolean config option `config.av.passthrough_fix`. The new approach forcefully resets the audio driver by toggling Bluetooth audio or re-selecting the current audio track, improving reliability and maintainability. (`lib/python/Components/AVSwitch.py`, `lib/python/Screens/VideoMode.py`, `lib/service/servicedvb.cpp`, `lib/service/servicedvb.h`, `lib/service/servicedvbsoftdecoder.cpp`, `lib/service/servicedvbsoftdecoder.h`, `lib/service/servicemp3.cpp`, `lib/service/servicemp3.h`) [[1]](diffhunk://#diff-2ca6b000c8740ee42fec074569efddb57e7d9f81de5710d1840558306c64585eL340-R340) [[2]](diffhunk://#diff-2ad6c5cce9f2d0bff6a6d46763f48e41e128844c44efab175853c9359c26c659L72-R72) [[3]](diffhunk://#diff-1f8b160a277841ebdffdee6785bc83eb5a9864737558c453872cc06441ab2202L1082-L1084) [[4]](diffhunk://#diff-1f8b160a277841ebdffdee6785bc83eb5a9864737558c453872cc06441ab2202L1094-L1096) [[5]](diffhunk://#diff-1f8b160a277841ebdffdee6785bc83eb5a9864737558c453872cc06441ab2202L1130-L1138) [[6]](diffhunk://#diff-1f8b160a277841ebdffdee6785bc83eb5a9864737558c453872cc06441ab2202L2493-L2504) [[7]](diffhunk://#diff-1f8b160a277841ebdffdee6785bc83eb5a9864737558c453872cc06441ab2202L3536-R3537) [[8]](diffhunk://#diff-2c6b68c9bcd21b30d4b4eac119a78bb8de5a317513301d7cae7a4f4ca010ceceR271-R273) [[9]](diffhunk://#diff-2c6b68c9bcd21b30d4b4eac119a78bb8de5a317513301d7cae7a4f4ca010ceceL329-L333) [[10]](diffhunk://#diff-6d425757dbbfb7b0db89df41b167531cbe15799fffdc8baad666f45f5a44a139R7) [[11]](diffhunk://#diff-6d425757dbbfb7b0db89df41b167531cbe15799fffdc8baad666f45f5a44a139R753-R758) [[12]](diffhunk://#diff-6d425757dbbfb7b0db89df41b167531cbe15799fffdc8baad666f45f5a44a139R773-R786) [[13]](diffhunk://#diff-2e3de1301570c54262baec37c0dab63f79564fb072c48a039c919ad5cac9511cR152-R153) [[14]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL438-L440) [[15]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL492-R489) [[16]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL800-R816) [[17]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL1730-R1743) [[18]](diffhunk://#diff-dacebfa9a557e700e29cd10b58e83e033d50352340a620b61d1460165a1f5e74L390-L392) [[19]](diffhunk://#diff-dacebfa9a557e700e29cd10b58e83e033d50352340a620b61d1460165a1f5e74L406-R403)

* Removes all code related to the old passthrough fix timers, including timer creation, event connections, and timer-based delay logic. (`lib/service/servicedvb.cpp`, `lib/service/servicedvb.h`, `lib/service/servicemp3.cpp`, `lib/service/servicemp3.h`) [[1]](diffhunk://#diff-1f8b160a277841ebdffdee6785bc83eb5a9864737558c453872cc06441ab2202L1082-L1084) [[2]](diffhunk://#diff-1f8b160a277841ebdffdee6785bc83eb5a9864737558c453872cc06441ab2202L1094-L1096) [[3]](diffhunk://#diff-1f8b160a277841ebdffdee6785bc83eb5a9864737558c453872cc06441ab2202L1130-L1138) [[4]](diffhunk://#diff-1f8b160a277841ebdffdee6785bc83eb5a9864737558c453872cc06441ab2202L2493-L2504) [[5]](diffhunk://#diff-2c6b68c9bcd21b30d4b4eac119a78bb8de5a317513301d7cae7a4f4ca010ceceL329-L333) [[6]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL438-L440) [[7]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL492-R489) [[8]](diffhunk://#diff-dacebfa9a557e700e29cd10b58e83e033d50352340a620b61d1460165a1f5e74L390-L392) [[9]](diffhunk://#diff-dacebfa9a557e700e29cd10b58e83e033d50352340a620b61d1460165a1f5e74L406-R403)

### Configuration and UI changes

* Updates configuration and setup UI to use the new boolean passthrough fix option, removing references to the old delay-based settings. (`lib/python/Components/AVSwitch.py`, `lib/python/Screens/VideoMode.py`) [[1]](diffhunk://#diff-2ca6b000c8740ee42fec074569efddb57e7d9f81de5710d1840558306c64585eL340-R340) [[2]](diffhunk://#diff-2ad6c5cce9f2d0bff6a6d46763f48e41e128844c44efab175853c9359c26c659L72-R72)

### Improvements to file extension handling

* Improves how file extensions are determined in `eServiceMP3` by correctly handling query parameters in filenames, ensuring more reliable subtitle and media type detection. (`lib/service/servicemp3.cpp`) [[1]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fR499) [[2]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fR518-R538) [[3]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL722-L735)

### General code cleanup

* Removes unused variables and redundant code related to the old passthrough logic, and adds missing includes where necessary. (`lib/service/servicedvbsoftdecoder.cpp`, `lib/service/servicemp3.cpp`) [[1]](diffhunk://#diff-6d425757dbbfb7b0db89df41b167531cbe15799fffdc8baad666f45f5a44a139R7) [[2]](diffhunk://#diff-6d425757dbbfb7b0db89df41b167531cbe15799fffdc8baad666f45f5a44a139R741)

These changes make the audio passthrough fix more reliable, easier to configure, and simpler to maintain.