### PR TITLE
Refactor passthrough audio handling and update configurations

### DIFF
--- a/lib/python/Components/AVSwitch.py
+++ b/lib/python/Components/AVSwitch.py
@@ -337,7 +337,8 @@ avSwitch = iAVSwitch  # Not used by OpenViX. For compatibility with OpenATV. Use
 
 
 def InitAVSwitch():
-	config.av.passthrough_fix = ConfigBoolean(default=False)
+	if SystemInfo["Vu_EAC3_fix"] and config.av.downmix_ac3.value == "passthrough":
+		config.av.passthrough_fix = ConfigBoolean(default=True)
 	config.av.yuvenabled = ConfigBoolean(default=True)
 	colorformat_choices = {
 		"cvbs": _("CVBS"),

--- a/lib/python/Screens/VideoMode.py
+++ b/lib/python/Screens/VideoMode.py
@@ -69,7 +69,8 @@ class VideoSetup(Setup):
 		if config.usage.setup_level.index >= 1:
 			if SystemInfo["CanDownmixAC3"]:
 				self.list.append(getConfigListEntry(_("AC3 downmix"), config.av.downmix_ac3, _("Choose whether multi channel ac3 sound tracks should be downmixed to stereo.")))
-				self.list.append(getConfigListEntry(_("Passthrough audio fix"), config.av.passthrough_fix, _("Enabled/Disable audio passthrough fix for SoftCSA, DVB and Gstreamer.")))
+				if SystemInfo["Vu_EAC3_fix"] and config.av.downmix_ac3.value == "passthrough":
+					self.list.append(getConfigListEntry(_("AC3+ Passthrough audio fix"), config.av.passthrough_fix, _("Enabled/Disable audio passthrough fix.")))
 			if SystemInfo["CanDownmixDTS"]:
 				self.list.append(getConfigListEntry(_("DTS downmix"), config.av.downmix_dts, _("Choose whether multi channel dts sound tracks should be downmixed to stereo.")))
 			if SystemInfo["CanDownmixAACPlus"]:

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -3517,7 +3517,7 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 #ifdef PASSTHROUGH_FIX
 void eDVBServicePlay::forceAudioReset()
 {
-	if (!eConfigManager::getConfigBoolValue("config.av.passthrough_fix", false)
+	if (!eConfigManager::getConfigBoolValue("config.av.passthrough_fix", false))
 		return;
 	// Toggle Bluetooth audio off->on->off to force audio driver reinitialization
 	std::string btaudio = CFile::read("/proc/stb/audio/btaudio");

--- a/lib/service/servicedvbsoftdecoder.cpp
+++ b/lib/service/servicedvbsoftdecoder.cpp
@@ -750,12 +750,6 @@ void eDVBSoftDecoder::updateDecoder(int vpid, int vpidtype, int pcrpid)
 			m_decoder->play();
 			eDebug("[eDVBSoftDecoder] Decoder PLAY with vpid=%04x vpidtype=%d", vpid, vpidtype);
 			m_decoder_ready();
-
-			if (!m_noaudio)
-			{
-				// Force audio reset after decoder start to fix audio dropouts
-				forceAudioReset();
-			}
 		}
 		else
 		{
@@ -768,20 +762,6 @@ void eDVBSoftDecoder::videoEvent(struct iTSMPEGDecoder::videoEvent event)
 {
 	// Forward video events to parent
 	m_video_event(event);
-}
-
-// Toggle Bluetooth audio off->on->off to force audio driver reinitialization
-void eDVBSoftDecoder::forceAudioReset()
-{
-	if (!eSimpleConfig::getBool("config.av.passthrough_fix", false))
-		return;
-	std::string btaudio = CFile::read("/proc/stb/audio/btaudio");
-	if (!btaudio.empty() && btaudio.find("off") != std::string::npos)
-	{
-		eDebug("[eDVBSoftDecoder] Force audio reset: toggling btaudio on and back off");
-		CFile::writeStr("/proc/stb/audio/btaudio", "on");
-		CFile::writeStr("/proc/stb/audio/btaudio", "off");
-	}
 }
 
 // ============================================================================

--- a/lib/service/servicedvbsoftdecoder.h
+++ b/lib/service/servicedvbsoftdecoder.h
@@ -149,8 +149,6 @@ private:
 	void updatePids(bool withDecoder = true);
 	void updateDecoder(int vpid, int vpidtype, int pcrpid);
 
-	// Force audio reset after decoder start (fixes audio dropouts on some problematic boxes)
-	void forceAudioReset();
 	// Video Event Signal
 	sigc::signal<void(struct iTSMPEGDecoder::videoEvent)> m_video_event;
 	ePtr<eConnection> m_video_event_conn;

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -797,7 +797,7 @@ eServiceMP3::~eServiceMP3()
 #ifdef PASSTHROUGH_FIX
 void eServiceMP3::forceAudioReset()
 {
-	if (!eConfigManager::getConfigBoolValue("config.av.passthrough_fix", false)
+	if (!eConfigManager::getConfigBoolValue("config.av.passthrough_fix", false))
 		return;
 	// Toggle Bluetooth audio off->on->off to force audio driver reinitialization
 	std::string btaudio = CFile::read("/proc/stb/audio/btaudio");


### PR DESCRIPTION
This pull request introduces targeted improvements to the handling of audio passthrough fixes, especially for devices requiring the `Vu_EAC3_fix`. The changes ensure that the passthrough fix is only enabled and presented in the setup UI when relevant, and clean up redundant code in the soft decoder related to audio reset logic.

**Device-specific passthrough fix handling:**

* The `config.av.passthrough_fix` setting is now only enabled by default if the device requires the `Vu_EAC3_fix` and AC3 downmix is set to "passthrough", ensuring the fix is only active when needed.
* The setup UI in `VideoMode.py` only displays the "AC3+ Passthrough audio fix" option when both `Vu_EAC3_fix` is required and AC3 downmix is set to "passthrough", preventing unnecessary configuration options for other devices.

**Codebase cleanup and bug fixes:**

* Removed the redundant `forceAudioReset` method and its usage from `eDVBSoftDecoder`, as the logic is now centralized and managed elsewhere. [[1]](diffhunk://#diff-6d425757dbbfb7b0db89df41b167531cbe15799fffdc8baad666f45f5a44a139L773-L786) [[2]](diffhunk://#diff-6d425757dbbfb7b0db89df41b167531cbe15799fffdc8baad666f45f5a44a139L753-L758) [[3]](diffhunk://#diff-2e3de1301570c54262baec37c0dab63f79564fb072c48a039c919ad5cac9511cL152-L153)
* Fixed a syntax error in the conditional for checking the passthrough fix configuration in both `servicedvb.cpp` and `servicemp3.cpp`. [[1]](diffhunk://#diff-1f8b160a277841ebdffdee6785bc83eb5a9864737558c453872cc06441ab2202L3520-R3520) [[2]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL800-R800)