### PR TITLE
Improve passthrough audio handling and add timer support

### DIFF
--- a/lib/python/Components/AVSwitch.py
+++ b/lib/python/Components/AVSwitch.py
@@ -337,8 +337,7 @@ avSwitch = iAVSwitch  # Not used by OpenViX. For compatibility with OpenATV. Use
 
 
 def InitAVSwitch():
-	if SystemInfo["Vu_EAC3_fix"] and config.av.downmix_ac3.value == "passthrough":
-		config.av.passthrough_fix = ConfigBoolean(default=True)
+	config.av.passthrough_fix = ConfigBoolean(default=True)
 	config.av.yuvenabled = ConfigBoolean(default=True)
 	colorformat_choices = {
 		"cvbs": _("CVBS"),

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -435,6 +435,9 @@ eServiceMP3::eServiceMP3(eServiceReference ref):
 	m_dvb_subtitle_sync_timer = eTimer::create(eApp);
 	m_dvb_subtitle_parser = new eDVBSubtitleParser();
 	m_dvb_subtitle_parser->connectNewPage(sigc::mem_fun(*this, &eServiceMP3::newDVBSubtitlePage), m_new_dvb_subtitle_page_connection);
+#ifdef PASSTHROUGH_FIX
+	m_passthrough_fix_timer = eTimer::create(eApp);
+#endif
 	m_stream_tags = 0;
 	m_currentAudioStream = -1;
 	m_currentSubtitleStream = -1;
@@ -486,6 +489,9 @@ eServiceMP3::eServiceMP3(eServiceReference ref):
 	CONNECT(m_dvb_subtitle_sync_timer->timeout, eServiceMP3::pushDVBSubtitles);
 	CONNECT(m_pump.recv_msg, eServiceMP3::gstPoll);
 	CONNECT(m_nownext_timer->timeout, eServiceMP3::updateEpgCacheNowNext);
+#ifdef PASSTHROUGH_FIX
+	CONNECT(m_passthrough_fix_timer->timeout, eServiceMP3::forceAudioReset);
+#endif
 
 	m_aspect = m_width = m_height = m_framerate = m_progressive = m_gamma = -1;
 
@@ -1740,7 +1746,11 @@ int eServiceMP3::selectAudioStream(int i, bool skipAudioFix)
 					std::string pass = CFile::read("/proc/stb/audio/ac3");
 					if (replace_all(replace_all(pass, "\r", ""), "\n", "") == "passthrough")
 					{
-						forceAudioReset();
+						if (m_clear_buffers)
+						{
+							m_passthrough_fix_timer->stop();
+							m_passthrough_fix_timer->start(apidtype == atEAC3 && i > 0 && current_audio_orig > -1 ? 2000 : 100, true);
+						}
 					}
 					else
 					{

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -400,6 +400,9 @@ private:
 	void sourceTimeout();
 	void clearBuffers(bool force=false);
 #ifdef PASSTHROUGH_FIX
+	ePtr<eTimer> m_passthrough_fix_timer;
+#endif
+#ifdef PASSTHROUGH_FIX
 	void forceAudioReset();
 #endif
 	sourceStream m_sourceinfo;


### PR DESCRIPTION
This pull request introduces improvements to audio stream handling for passthrough scenarios, primarily focused on the EAC3 passthrough fix. The changes add a timer-based mechanism to more reliably reset audio when switching streams, conditional on the `PASSTHROUGH_FIX` macro. This should help address issues where audio does not reset correctly during passthrough.

**Audio passthrough fix enhancements:**

* Added a new timer member `m_passthrough_fix_timer` to the `eServiceMP3` class, which is only included when the `PASSTHROUGH_FIX` macro is defined. (`lib/service/servicemp3.h`)
* Initialized `m_passthrough_fix_timer` in the `eServiceMP3` constructor and connected its timeout signal to the `forceAudioReset` method, gated by the `PASSTHROUGH_FIX` macro. (`lib/service/servicemp3.cpp`) [[1]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fR438-R440) [[2]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fR492-R494)
* Updated the audio stream selection logic to use the new timer for delayed audio reset when passthrough is enabled and buffers need clearing, improving reliability of the reset process. (`lib/service/servicemp3.cpp`)

**Configuration and initialization changes:**

* Removed a conditional check for `Vu_EAC3_fix` and passthrough mode in the AV switch initialization, simplifying the configuration setup. (`lib/python/Components/AVSwitch.py`)