### PR TITLE
Fix session handling and subtitle list injection issues

### DIFF
--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -702,11 +702,14 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarLongKeyDetection, InfoBar
 		return matches
 
 	def subtitleListInject(self, subtitlesList):
+		service = self.session.nav.getCurrentService()
+		if not service:
+			return
 		if len(subtitlesList) > 0:
 			i = subtitlesList[-1][1] + 1
 		else:
 			i = 1
-		subtitletracks = self.find_related_srt_files(self.cur_service.getPath())
+		subtitletracks = self.find_related_srt_files(service.getPath())
 		for stream in subtitletracks:
 			subtitlesList.append((2, i, 4, i, stream["language"], self.runSubtitles, stream["path"]))
 

--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -702,7 +702,7 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarLongKeyDetection, InfoBar
 		return matches
 
 	def subtitleListInject(self, subtitlesList):
-		service = self.session.nav.getCurrentService()
+		service = self.session.nav.getCurrentlyPlayingServiceReference()
 		if not service:
 			return
 		if len(subtitlesList) > 0:
@@ -718,7 +718,7 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarLongKeyDetection, InfoBar
 	def onAudioSubTrackChanged(self):
 		if self.selected_subtitle and len(self.selected_subtitle) > 5:
 			return
-		service = self.session.nav.getCurrentService()
+		service = self.session.nav.getCurrentlyPlayingServiceReference()
 		if service:
 			self.delete_subconf(service.getPath())
 		self.curSubsIndex = -1

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -4354,6 +4354,9 @@ class InfoBarSubtitleSupport:
 		service = self.session.nav.getCurrentService()
 		subtitle = service and service.subtitle()
 		subtitlelist = subtitle and subtitle.getSubtitleList()
+		from Screens.AudioSelection import AudioSelection
+		if callable(AudioSelection.fillSubtitleExt):
+			AudioSelection.fillSubtitleExt(subtitlelist)
 		if self.selected_subtitle or subtitlelist and len(subtitlelist) > 0:
 			from Screens.AudioSelection import SubtitleSelection
 			self.session.open(SubtitleSelection, self)

--- a/lib/python/Tools/SubtitleRenderer.py
+++ b/lib/python/Tools/SubtitleRenderer.py
@@ -16,6 +16,9 @@ class SubtitleRenderer:
 		self.current_sub_end_pts = -1
 
 	def _check_pts_and_show_sub(self):
+		if not hasattr(self.player, "session") or self.player.session is None:
+			self.stopSubtitles()
+			return
 		seek = self.player.getSeek()
 		if seek is None:
 			return


### PR DESCRIPTION
This pull request improves the handling of subtitles in the codebase by making the subtitle-related methods more robust to missing or unavailable service and session objects. The changes ensure that subtitle operations do not proceed when required dependencies are not available, preventing potential errors or crashes.

Error handling and robustness improvements:

* Added a check in `subtitleListInject` (in `InfoBar.py`) to ensure that the current service is available before attempting to find related subtitle files, and updated the method to use the current service from the session instead of a potentially outdated reference.
* Updated `_check_pts_and_show_sub` (in `SubtitleRenderer.py`) to verify that the `player` object has a valid `session` before proceeding, stopping subtitles and returning early if the session is missing.