### PR TITLE
[MoviePlayer] Properly remove audio/subtitle track change hook

### DIFF
--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -322,6 +322,8 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarLongKeyDetection, InfoBar
 
 	def clearHooks(self):
 		AudioSelection.fillSubtitleExt = None
+		if self.onAudioSubTrackChanged in AudioSelection.hooks:
+			AudioSelection.hooks.remove(self.onAudioSubTrackChanged)
 
 	def __onClose(self):
 		# clear the instance value so the skin reloader works correctly

--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -306,8 +306,7 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarLongKeyDetection, InfoBar
 		AudioSelection.fillSubtitleExt = self.subtitleListInject
 		if self.onAudioSubTrackChanged not in AudioSelection.hooks:
 			AudioSelection.hooks.append(self.onAudioSubTrackChanged)
-		self.__event_tracker = ServiceEventTracker(screen=self, eventmap={
-			enigma.iPlayableService.evStart: self.__evServiceStartInit})
+		self.__evServiceStartInit()
 		config.misc.standbyCounter.addNotifier(self.standbyCountChanged, initial_call=False)
 
 		if type(self) is MoviePlayer:
@@ -662,7 +661,10 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarLongKeyDetection, InfoBar
 		return False
 
 	def __evServiceStartInit(self):
-		subtitle_parsed = self.load_subconf(self.cur_service.getPath())
+		service = self.session.nav.getCurrentlyPlayingServiceReference()
+		if not service:
+			return
+		subtitle_parsed = self.load_subconf(service.getPath())
 		subtitle = (subtitle_parsed[0], subtitle_parsed[1], subtitle_parsed[2], subtitle_parsed[3], subtitle_parsed[4], self.runSubtitles, subtitle_parsed[6]) if subtitle_parsed else None
 		if subtitle:
 			self.runSubtitles(subtitle=subtitle)


### PR DESCRIPTION
This pull request makes a minor improvement to the `InfoBar.py` file by ensuring that the `onAudioSubTrackChanged` hook is properly removed from `AudioSelection.hooks` during the `clearHooks` process. This helps prevent potential issues with lingering hooks after they are no longer needed.