### PR TITLE
[Fixed] initialize event tracker for service start in MoviePlayer

### DIFF
--- a/lib/python/Components/Converter/ServiceName.py
+++ b/lib/python/Components/Converter/ServiceName.py
@@ -137,8 +137,8 @@ class ServiceName(Converter):
 
 	def getNumber(self):
 		numservice = hasattr(self.source, "serviceref") and self.source.serviceref
-		cnannelNumInt = numservice and numservice.getChannelNum() or 0
-		channelnum = str(cnannelNumInt) if cnannelNumInt else ""
+		channelNumInt = numservice and numservice.getChannelNum() or 0
+		channelnum = str(channelNumInt) if channelNumInt else ""
 		return channelnum
 
 	def getProvider(self, ref, info):

--- a/lib/python/Components/Sources/CurrentService.py
+++ b/lib/python/Components/Sources/CurrentService.py
@@ -47,7 +47,7 @@ class CurrentService(PerServiceBase, Source):
 
 	serviceref = property(getCurrentServiceRef)
 
-	def newService(self, ref):
+	def newService(self, ref, num=0):
 		if ref and isinstance(ref, bool):
 			self.info = None
 		elif ref:
@@ -57,6 +57,9 @@ class CurrentService(PerServiceBase, Source):
 
 		for x in self.onManualNewService:
 			x()
+
+		if num > 0:
+			self.serviceref.setChannelNum(num)
 
 		self.changed((self.CHANGED_SPECIFIC, iPlayableService.evStart))
 

--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -322,6 +322,8 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarLongKeyDetection, InfoBar
 
 	def clearHooks(self):
 		AudioSelection.fillSubtitleExt = None
+		if self.onAudioSubTrackChanged in AudioSelection.hooks:
+			AudioSelection.hooks.remove(self.onAudioSubTrackChanged)
 
 	def __onClose(self):
 		# clear the instance value so the skin reloader works correctly

--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -298,6 +298,7 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarLongKeyDetection, InfoBar
 		self.onChangedEntry = []
 		self.servicelist = slist
 		self.lastservice = lastservice or session.nav.getCurrentlyPlayingServiceOrGroup()
+		self.last_chnumber = self.lastservice and self.lastservice.getChannelNum() or 0
 		session.nav.playService(service)
 		self.cur_service = service
 		self.returning = False
@@ -306,7 +307,11 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarLongKeyDetection, InfoBar
 		AudioSelection.fillSubtitleExt = self.subtitleListInject
 		if self.onAudioSubTrackChanged not in AudioSelection.hooks:
 			AudioSelection.hooks.append(self.onAudioSubTrackChanged)
-		self.__evServiceStartInit()
+
+		self.__event_tracker = ServiceEventTracker(screen=self, eventmap={
+			enigma.iPlayableService.evStart: self.__evServiceStartInit})
+		self.loadSavedSubtitle(service)
+
 		config.misc.standbyCounter.addNotifier(self.standbyCountChanged, initial_call=False)
 
 		if type(self) is MoviePlayer:
@@ -336,7 +341,7 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarLongKeyDetection, InfoBar
 		self.session.nav.playService(self.lastservice)
 		# Simulate service start event due to the fact when exit from playing
 		# a recording there is no evStart event because the same service is already playing
-		self.session.screen["CurrentService"].newService(self.lastservice)
+		self.session.screen["CurrentService"].newService(self.lastservice, self.last_chnumber)
 		config.usage.last_movie_played.value = self.cur_service.toString()
 		config.usage.last_movie_played.save()
 
@@ -659,15 +664,18 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarLongKeyDetection, InfoBar
 			path.unlink()   # remove the file
 			return True
 		return False
+	
+	def loadSavedSubtitle(self, service):
+		subtitle_parsed = self.load_subconf(service.getPath())
+		if subtitle_parsed:
+			subtitle = (subtitle_parsed[0], subtitle_parsed[1], subtitle_parsed[2], subtitle_parsed[3], subtitle_parsed[4], self.runSubtitles, subtitle_parsed[6])
+			self.runSubtitles(subtitle=subtitle)
 
 	def __evServiceStartInit(self):
 		service = self.session.nav.getCurrentlyPlayingServiceReference()
 		if not service:
 			return
-		subtitle_parsed = self.load_subconf(service.getPath())
-		subtitle = (subtitle_parsed[0], subtitle_parsed[1], subtitle_parsed[2], subtitle_parsed[3], subtitle_parsed[4], self.runSubtitles, subtitle_parsed[6]) if subtitle_parsed else None
-		if subtitle:
-			self.runSubtitles(subtitle=subtitle)
+		self.loadSavedSubtitle(service)
 
 	def extract_language_from_filename(self, path: Path) -> str | None:
 		"""


### PR DESCRIPTION
This pull request introduces an improvement to the `InfoBar` class initialization by adding a `ServiceEventTracker` to handle service start events. This change helps ensure that service initialization logic is triggered appropriately when a new service starts.

**Enhancement to event handling:**

* Added a `ServiceEventTracker` instance in the `__init__` method of `InfoBar` to listen for `evStart` events and call `__evServiceStartInit` when a service starts.