### PR TITLE
[MoviePlayer] Prevent potential crash when loading saved subtitles

### DIFF
--- a/lib/python/Screens/InfoBar.py
+++ b/lib/python/Screens/InfoBar.py
@@ -666,10 +666,16 @@ class MoviePlayer(InfoBarBase, InfoBarShowHide, InfoBarLongKeyDetection, InfoBar
 		return False
 
 	def loadSavedSubtitle(self, service):
-		subtitle_parsed = self.load_subconf(service.getPath())
-		if subtitle_parsed:
-			subtitle = (subtitle_parsed[0], subtitle_parsed[1], subtitle_parsed[2], subtitle_parsed[3], subtitle_parsed[4], self.runSubtitles, subtitle_parsed[6])
-			self.runSubtitles(subtitle=subtitle)
+		path = service.getPath()
+		if not path:
+			return
+		try:
+			subtitle_parsed = self.load_subconf(path)
+			if subtitle_parsed:
+				subtitle = (subtitle_parsed[0], subtitle_parsed[1], subtitle_parsed[2], subtitle_parsed[3], subtitle_parsed[4], self.runSubtitles, subtitle_parsed[6])
+				self.runSubtitles(subtitle=subtitle)
+		except:
+			pass  # this in case sometimes event comes too fast and is got by the MoviePlayer before the InfoBar, so the subconf file is not yet created, or any other issue with loading/parsing the file.
 
 	def __evServiceStartInit(self):
 		service = self.session.nav.getCurrentlyPlayingServiceReference()


### PR DESCRIPTION
This pull request makes a small but important improvement to the `loadSavedSubtitle` method in `lib/python/Screens/InfoBar.py`. The change adds error handling and a check for a valid path to prevent potential crashes when loading subtitle configuration files.

Key improvement:

* Added a check to ensure `service.getPath()` returns a valid path before attempting to load the subtitle configuration, and wrapped the loading logic in a try-except block to gracefully handle errors (such as missing or malformed files), preventing crashes if the subtitle config file isn't ready or can't be parsed.