### PR TITLE
[enigma2] Fix PiG video flash when opening a child screen

### DIFF
--- a/lib/gui/evideo.cpp
+++ b/lib/gui/evideo.cpp
@@ -43,7 +43,16 @@ int eVideoWidget::event(int event, void *data, void *data2)
 
 eVideoWidget::~eVideoWidget()
 {
-	updatePosition(1);
+	/* Only restore fullscreen if this widget has ever set the video position.
+	   m_state & 1 means updatePosition() was called and the position was committed.
+	   This avoids restoring fullscreen when the widget was never active. */
+	if (m_state & 1)
+	{
+		pendingFullsize |= (1 << m_decoder);
+		forceFullsizeDecoder |= (1 << m_decoder);
+		eVideoWidget::setPosition(m_decoder, posFullsizeLeft, posFullsizeTop, posFullsizeWidth, posFullsizeHeight);
+		fullsizeTimer->start(100, true);
+	}
 }
 
 void eVideoWidget::setFBSize(eSize size)
@@ -134,10 +143,10 @@ void eVideoWidget::updatePosition(int disable)
 	else
 	{
 		m_state &= ~8;
-		pendingFullsize |= (1 << m_decoder);
-		forceFullsizeDecoder |= (1 << m_decoder);
-		eVideoWidget::setPosition(m_decoder, posFullsizeLeft, posFullsizeTop, posFullsizeWidth, posFullsizeHeight);
-		fullsizeTimer->start(100, true);
+		/* Do NOT restore fullscreen here. The widget is only temporarily hidden
+		   (e.g. a child screen is opening on top). Restoring fullscreen now would
+		   cause a visible flash before the child screen finishes painting.
+		   Fullscreen is restored by the destructor when the widget is actually destroyed. */
 	}
 }
 


### PR DESCRIPTION
Problem:
When a screen containing a PiG (Picture in Graphic) was visible and a child screen without a PiG was opened, a brief but visible flash occurred: the live TV video would momentarily scale to fullscreen and appear cropped inside the parent screen's PiG area before the child screen finished rendering.

Root cause:
updatePosition could not distinguish between two fundamentally different situations that both call it with disable=1:
The PiG widget's parent screen is temporarily hidden because a child screen is being pushed on top (widget still alive, will become visible again when the child closes).
The PiG widget is being destroyed because its screen is closing completely (fullscreen must be restored).

Fix:
Fullscreen restoration is moved entirely into ~eVideoWidget(). The destructor checks m_state & 1 — the flag that is set the first time updatePosition commits a position to the hardware — to confirm this widget actually controlled the decoder before writing the restore. The else branch of updatePosition (the temporary-hide path) now only clears the hardware-applied state flag and does nothing to the decoder position.