### PR TITLE
[enigma2] fix text cutoff in templated lists with RT_HALIGN_RIGHT

### DIFF
--- a/lib/gdi/grc.cpp
+++ b/lib/gdi/grc.cpp
@@ -919,6 +919,24 @@ void gDC::exec(const gOpcode *o)
 		}
 
 		para->setBlend(flags & gPainter::RT_BLEND);
+
+		// For RT_HALIGN_RIGHT, precisely expand the DC clip to prevent the last
+		// glyph's right-side bearing from being clipped by the render area boundary.
+		gRegion savedClip;
+		bool clipExpanded = false;
+		if (flags & gPainter::RT_HALIGN_RIGHT)
+		{
+			const eRect &bbox = para->getBoundBox();
+			int areaRight = o->parm.renderText->area.right() + offset.x();
+			int overflow = bbox.right() + offset.x() - areaRight;
+			if (overflow > 0)
+			{
+				savedClip = m_current_clip;
+				clipExpanded = true;
+				m_current_clip |= gRegion(eRect(areaRight, o->parm.renderText->area.top() + offset.y(),
+										overflow + 1, o->parm.renderText->area.height()));
+			}
+		}
 		
 		if (o->parm.renderText->border)
 		{
@@ -929,6 +947,8 @@ void gDC::exec(const gOpcode *o)
 		{
 			para->blit(*this, offset, m_background_color_rgb, m_foreground_color_rgb);
 		}
+		if (clipExpanded)
+			m_current_clip = savedClip;
 		delete o->parm.renderText;
 		break;
 	}

--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -733,11 +733,22 @@ void eListbox::updateScrollBar()
 		}
 		else
 		{
-			if (m_orientation == orVertical)
-				m_content->setSize(eSize(width, m_itemheight));
-			else if (m_orientation == orHorizontal)
-				m_content->setSize(eSize(m_itemwidth, height));
-			else
+			// showOnDemand with no scrollbar needed: still reserve scrollbar space
+			// so item width stays constant if scrollbar later appears (avoids
+			// clipping fixed-position template content when scrollbar toggles).
+			if (m_orientation == orVertical) {
+				if (m_scrollbar_mode == showOnDemand) {
+					m_content->setSize(eSize(width-m_scrollbar_width-5, m_itemheight));
+				} else {
+					m_content->setSize(eSize(width, m_itemheight));
+				}
+			} else if (m_orientation == orHorizontal) {
+				if (m_scrollbar_mode == showOnDemand) {
+					m_content->setSize(eSize(m_itemwidth, height-m_scrollbar_height-5));
+				} else {
+					m_content->setSize(eSize(m_itemwidth, height));
+				}
+			} else
 				m_content->setSize(eSize(m_itemwidth, m_itemwidth));
 
 			m_scrollbar->hide();


### PR DESCRIPTION
in templated lists last field in a row is cutoff by 10-20 pixels with scrollbar and without when using RT_HALIGN_RIGHT.
changing size or position of the field doesn't fix it.
problem with scrollbar (without is the same):
<img width="1920" height="1080" alt="cutoffwithscrollbar" src="https://github.com/user-attachments/assets/e9c7be00-905c-4827-b637-5c5dea86adbb" />

fix with scrollbar:
<img width="1920" height="1080" alt="fixedcutoffwithscrollbar" src="https://github.com/user-attachments/assets/e9dcad9e-7a62-4497-9ca1-f4a12674fba8" />

fix without scrollbar:
<img width="1920" height="1080" alt="fixedcutoffwithoutscrollbar" src="https://github.com/user-attachments/assets/1c91c1cb-65d3-4615-af34-a59a49633385" />



