### PR TITLE
[enigma2] New TemplatedMultiContentEx converter

### DIFF
--- a/lib/python/Components/Converter/TemplatedMultiContentEx.py
+++ b/lib/python/Components/Converter/TemplatedMultiContentEx.py
@@ -1,0 +1,66 @@
+from enigma import eListbox
+from Components.Converter.TemplatedMultiContent import TemplatedMultiContent
+from Components.Converter.StringList import StringList
+
+
+class TemplatedMultiContentEx(TemplatedMultiContent):
+	"""TemplatedMultiContent with e (item width) and c (item horizontal center) available in the template."""
+
+	def __init__(self, args):
+		self._raw_args = args
+		self._size_resolved = False
+		StringList.__init__(self, args)
+		from enigma import (BT_SCALE, BT_KEEP_ASPECT_RATIO, BT_ALPHATEST, BT_ALPHABLEND,
+		                    BT_FIXRATIO, BT_HALIGN_LEFT, BT_HALIGN_CENTER, BT_HALIGN_RIGHT,
+		                    BT_VALIGN_TOP, BT_VALIGN_CENTER, BT_VALIGN_BOTTOM, BT_ALIGN_CENTER,
+		                    RT_HALIGN_CENTER, RT_HALIGN_LEFT, RT_HALIGN_RIGHT, RT_VALIGN_BOTTOM,
+		                    RT_VALIGN_CENTER, RT_VALIGN_TOP, RT_WRAP, RT_BLEND,
+		                    eListboxPythonMultiContent, gFont)
+		from Components.MultiContent import (MultiContentEntryLinearGradient, MultiContentEntryLinearGradientAlphaBlend,
+		                                     MultiContentEntryPixmap, MultiContentEntryPixmapAlphaBlend,
+		                                     MultiContentEntryPixmapAlphaTest, MultiContentEntryProgress,
+		                                     MultiContentEntryProgressPixmap, MultiContentEntryText,
+		                                     MultiContentTemplateColor)
+		from skin import parseFont, getSkinFactor
+		f = getSkinFactor()
+		e = 0
+		c = 0
+		i = int
+		loc = locals()
+		del loc["self"]
+		del loc["args"]
+		self._eval_locals = loc
+		self.active_style = None
+		self.template = eval(args, {}, loc)
+		self.scale = None
+		self.orientations = {
+			"orHorizontal": eListbox.orHorizontal,
+			"orVertical": eListbox.orVertical,
+			"orGrid": eListbox.orGrid,
+		}
+		assert "fonts" in self.template
+		assert "itemHeight" in self.template
+		assert "template" in self.template or "templates" in self.template
+		assert "template" in self.template or "default" in self.template["templates"]
+		if "template" not in self.template:
+			templateDefault = self.template["templates"]["default"]
+			self.template["template"] = templateDefault[1]
+			self.template["itemHeight"] = templateDefault[0]
+			if len(templateDefault) > 2:
+				self.template["selectionEnabled"] = templateDefault[2]
+			if len(templateDefault) > 3:
+				self.template["scrollbarMode"] = templateDefault[3]
+			if len(templateDefault) > 5:
+				self.template["itemWidth"] = templateDefault[4]
+				self.template["orientation"] = templateDefault[5]
+
+	def setTemplate(self):
+		if not self._size_resolved and self.master and self.master.instance:
+			width = self.master.instance.size().width()
+			if width > 0:
+				self._eval_locals["e"] = width
+				self._eval_locals["c"] = width // 2
+				self.template = eval(self._raw_args, {}, self._eval_locals)
+				self._size_resolved = True
+				self.active_style = None  # force parent to re-apply the updated template
+		TemplatedMultiContent.setTemplate(self)


### PR DESCRIPTION
TemplatedMultiContentEx adds two things to the eval context:

e — the actual pixel width of the listbox widget, resolved at runtime from self.master.instance.size().width()
c — horizontal center shorthand (e // 2)
i = int — a short alias for explicit integer casting in expressions

Deferred template evaluation:
TemplatedMultiContent evaluates the template string once in __init__ with a fixed set of skin/font locals and never revisits it. TemplatedMultiContentEx stores the raw args string and re-evaluates it in setTemplate() the first time a valid widget size is available (width > 0). This is what makes e meaningful — by setTemplate() time, applySkin has already resolved the widget's pixel dimensions.

_size_resolved flag:
The re-evaluation only happens once (first call with width > 0), so there's no repeated re-parsing on every list update.

In practice:
TemplatedMultiContent templates must use only constants and skin-time values. TemplatedMultiContentEx templates can express positions and sizes proportionally to the widget's actual width, making the layout automatically adapt to different screen resolutions without any hardcoded pixel values.

Here is an example of a skin:
(The "var" key was already supported in the original TemplatedMultiContent converter.)

		<widget enableWrapAround="1" position="20,65" render="Listbox" scrollbarMode="showNever" size="e-40,e-140" source="list" transparent="1">
			<convert type="TemplatedMultiContentEx">
				{
				"var": (
					ih := 70,
					hspace := 10,
					thumb_w := ih * 2 - 10,
					thumb_h := ih - 10,
					x1 := hspace // 2 + thumb_w + hspace,
					col3_w := ih * 3,
					col2_w := (e - x1) // 4,
					x3 := e - col3_w - hspace // 2,
					x2 := x3 - col2_w - hspace,
					col1_w := x2 - x1 - hspace
				),
				"template": [
					MultiContentEntryPixmapAlphaTest(pos=(hspace//2, (ih-thumb_h)//2), size=(thumb_w, thumb_h), png=0, backcolor=None, flags=BT_SCALE|BT_KEEP_ASPECT_RATIO),
					MultiContentEntryText(pos=(x1, 0), size=(col1_w, ih), flags=RT_VALIGN_CENTER, text=1),
					MultiContentEntryText(pos=(x2, 0), size=(col2_w, ih), flags=RT_VALIGN_CENTER, text=2),
					MultiContentEntryText(pos=(x3, 0), size=(col3_w, ih), flags=RT_VALIGN_CENTER|RT_HALIGN_RIGHT, text=3)
				],
				"fonts": [gFont("Regular", 26)],
				"itemHeight": ih
				}
			</convert>
		</widget>

... and the result:
<img width="1920" height="1080" alt="tso" src="https://github.com/user-attachments/assets/295276ec-8cd8-4a19-a3df-ddf43029fbe7" />
