### PR TITLE
[skin] add piconMargin as channel list parameter

### DIFF
--- a/lib/python/Components/ServiceList.py
+++ b/lib/python/Components/ServiceList.py
@@ -236,6 +236,9 @@ class ServiceList(GUIComponent):
 		def itemsDistances(value):
 			self.l.setItemsDistances(parseScale(value))
 
+		def piconMargin(value):
+			self.l.setPiconMargin(parseScale(value))
+
 		def sidesMargin(value):
 			self.sidesMargin = parseScale(value)
 

--- a/lib/service/listboxservice.cpp
+++ b/lib/service/listboxservice.cpp
@@ -354,7 +354,7 @@ void eListboxServiceContent::sort()
 DEFINE_REF(eListboxServiceContent);
 
 eListboxServiceContent::eListboxServiceContent()
-	:m_visual_mode(visModeSimple), m_size(0), m_current_marked(false), m_itemheight(25), m_hide_number_marker(false), m_servicetype_icon_mode(0), m_crypto_icon_mode(0), m_record_indicator_mode(0), m_column_width(0), m_progressbar_height(6), m_progressbar_border_width(2), m_nonplayable_margins(10), m_items_distances(8), m_sides_margin(0), m_marker_as_line(0), m_markerline_color_set(0)
+	:m_visual_mode(visModeSimple), m_size(0), m_current_marked(false), m_itemheight(25), m_hide_number_marker(false), m_servicetype_icon_mode(0), m_crypto_icon_mode(0), m_record_indicator_mode(0), m_column_width(0), m_progressbar_height(6), m_progressbar_border_width(2), m_nonplayable_margins(10), m_items_distances(8), m_picon_margin(0), m_sides_margin(0), m_marker_as_line(0), m_markerline_color_set(0)
 {
 	memset(m_color_set, 0, sizeof(m_color_set));
 	cursorHome();
@@ -971,7 +971,9 @@ void eListboxServiceContent::paint(gPainter &painter, eWindowStyle &style, const
 
 			if (hasPicon)
 			{
-				eRect piconArea =  eRect(xoffs, offset.y(), 125, m_itemheight);
+				int piconH = m_itemheight - 2 * m_picon_margin;
+				int piconY = offset.y() + m_picon_margin;
+				eRect piconArea =  eRect(xoffs, piconY, 125, piconH);
 				/* PIcons are usually about 100:60. Make it a
 				* bit wider in case the icons are diffently
 				* shaped, and to add a bit of margin between
@@ -985,13 +987,13 @@ void eListboxServiceContent::paint(gPainter &painter, eWindowStyle &style, const
 					painter.clip(piconArea);
 					if (isPIconSVG) {
 						painter.blit(piconPixmap,
-						eRect(xoffs, offset.y(), 125, m_itemheight),
+						eRect(xoffs, piconY, 125, piconH),
 						eRect(),
 						pflags
 						);
 					} else {
 						painter.blitScale(piconPixmap,
-							eRect(xoffs, offset.y(), 125, m_itemheight),
+							eRect(xoffs, piconY, 125, piconH),
 							piconArea,
 							pflags);
 					}
@@ -1403,7 +1405,9 @@ void eListboxServiceContent::paint(gPainter &painter, eWindowStyle &style, const
 				}
 
 				if (hasPicons) {
-					eRect piconArea =  eRect(xoffs, offset.y(), piconWidth, m_itemheight);
+					int piconH = m_itemheight - 2 * m_picon_margin;
+					int piconY = offset.y() + m_picon_margin;
+					eRect piconArea =  eRect(xoffs, piconY, piconWidth, piconH);
 					/* PIcons are usually about 100:60. Make it a
 					* bit wider in case the icons are diffently
 					* shaped, and to add a bit of margin between
@@ -1417,13 +1421,13 @@ void eListboxServiceContent::paint(gPainter &painter, eWindowStyle &style, const
 						painter.clip(piconArea);
 						if (isPIconSVG) {
 							painter.blit(piconPixmap,
-							eRect(xoffs, offset.y(), piconWidth, m_itemheight),
+							eRect(xoffs, piconY, piconWidth, piconH),
 							eRect(),
 							pflags
 							);
 						} else {
 							painter.blitScale(piconPixmap,
-								eRect(xoffs, offset.y(), piconWidth, m_itemheight),
+								eRect(xoffs, piconY, piconWidth, piconH),
 								piconArea,
 								pflags);
 						}

--- a/lib/service/listboxservice.h
+++ b/lib/service/listboxservice.h
@@ -105,6 +105,7 @@ public:
 	void setProgressbarBorderWidth(int value) { m_progressbar_border_width = value; }
 	void setNonplayableMargins(int value) { m_nonplayable_margins = value; }
 	void setItemsDistances(int value) { m_items_distances = value; }
+	void setPiconMargin(int value) { m_picon_margin = value; }
 	void setSidesMargin(int value) { m_sides_margin = value; }
 	void setMarkerAsLine(int value) { m_marker_as_line = value; }
 	void setChannelNumbersVisible(bool visible) { m_chanel_number_visible = visible; }
@@ -220,6 +221,7 @@ private:
 	int m_progressbar_border_width;
 	int m_nonplayable_margins;
 	int m_items_distances;
+	int m_picon_margin;
 	int m_sides_margin;
 	int m_marker_as_line;
 	gRGB m_markerline_color;


### PR DESCRIPTION
before: when you activate picons in the channel list then picons are scaled to itemHeight which leaves no space between the 
icons:
<img width="1920" height="1080" alt="picons1" src="https://github.com/user-attachments/assets/e5efa5b5-87e1-41c8-aaa9-ea29f07fd20a" />

after:
with the piconMargin parameter you can define how much space is left between the picons (picture was generated using piconMargin="2", looks much nicer):
<img width="1920" height="1080" alt="picons2" src="https://github.com/user-attachments/assets/073713b4-f639-4acc-94a9-35e08ed8cafd" />
