### PR TITLE
[enigma2] fix for crash during enigma2 shutdown

### DIFF
--- a/lib/service/listboxservice.cpp
+++ b/lib/service/listboxservice.cpp
@@ -623,8 +623,11 @@ void eListboxServiceContent::setItemHeight(int height)
 
 bool eListboxServiceContent::checkServiceIsRecorded(eServiceReference ref)
 {
+	eNavigation *nav = eNavigation::getInstance();
+	if (!nav)
+		return false;
 	std::map<ePtr<iRecordableService>, eServiceReference, std::less<iRecordableService*> > recordedServices;
-	recordedServices = eNavigation::getInstance()->getRecordingsServices();
+	recordedServices = nav->getRecordingsServices();
 	for (std::map<ePtr<iRecordableService>, eServiceReference >::iterator it = recordedServices.begin(); it != recordedServices.end(); ++it)
 	{
 		if (ref.flags & eServiceReference::isGroup)
@@ -632,6 +635,8 @@ bool eListboxServiceContent::checkServiceIsRecorded(eServiceReference ref)
 			ePtr<iDVBChannelList> db;
 			ePtr<eDVBResourceManager> res;
 			eDVBResourceManager::getInstance(res);
+			if (!res)
+				continue;
 			res->getChannelList(db);
 			eBouquet *bouquet = NULL;
 			if (!db->getBouquet(ref, bouquet))


### PR DESCRIPTION
fix for the following crash:

22:59:51.6652 PC: 00224f88
22:59:51.6653 Fault Address: 00000164
22:59:51.6653 Error Code: 519
22:59:51.6653 Backtrace:
22:59:51.6655 /usr/bin/enigma2(_Z17handleFatalSignaliP9siginfo_tPv) [0x85060]
22:59:51.6656 /lib/libc.so.6(__default_rt_sa_restorer) [0xB5C54680]
22:59:51.6658 /usr/bin/enigma2(_ZN22eListboxServiceContent22checkServiceIsRecordedE17eServiceReference) [0x224F88]
22:59:51.6661 /usr/bin/enigma2(_ZN22eListboxServiceContent5paintER8gPainterR12eWindowStyleRK6ePointi) [0x2258C0]
22:59:51.6663 /usr/bin/enigma2(_ZN8eListbox5eventEiPvS0_) [0x1849A8]
22:59:51.6664 /usr/bin/enigma2(_ZN7eWidget7doPaintER8gPainterRK7gRegioni) [0x19389C]
22:59:51.6666 /usr/bin/enigma2(_ZN7eWidget7doPaintER8gPainterRK7gRegioni) [0x193904]
22:59:51.6668 /usr/bin/enigma2(_ZN7eWidget7doPaintER8gPainterRK7gRegioni) [0x193904]
22:59:51.6670 /usr/bin/enigma2(_ZN14eWidgetDesktop10paintLayerEP7eWidgeti) [0x195F1C]
22:59:51.6672 /usr/bin/enigma2(_ZN14eWidgetDesktop5paintEv) [0x196044]
22:59:51.6673 /usr/bin/enigma2(main) [0x81FE8]
22:59:51.6674 /lib/libc.so.6(n/a) [0xB5C40B88]
22:59:51.6675 /lib/libc.so.6(__libc_start_main) [0xB5C40CFC]
22:59:51.6676 -------FATAL SIGNAL (11)

Two guards added to listboxservice.cpp:

1. eNavigation::getInstance() null check — the primary crash. During shutdown the navigation instance is already destroyed, so painting the listbox called checkServiceIsRecorded which dereferenced null at offset 0x164.
2. eDVBResourceManager::getInstance(res) null check — same class of bug inside the bouquet branch; res can also be null if the resource manager is gone.