### PR TITLE
[enigma2] fix switch from pig to fullscreen caused by DM9xx driver bug (part 2)

### DIFF
--- a/lib/gui/evideo.cpp
+++ b/lib/gui/evideo.cpp
@@ -164,6 +164,18 @@ void eVideoWidget::updatePosition(int disable)
 
 	if (!disable)
 	{
+		if (bounceFixEnabled()
+			&& left == posFullsizeLeft && top == posFullsizeTop
+			&& width == posFullsizeWidth && height == posFullsizeHeight
+			&& lastPigWidth[m_decoder] > 0 && lastPigHeight[m_decoder] > 0
+			&& (lastPigWidth[m_decoder] != posFullsizeWidth || lastPigHeight[m_decoder] != posFullsizeHeight))
+		{
+			/* dm9xx: decoder may be in a reset/fullscreen state and ignore a direct
+			 * fullscreen command. Bounce via the stored PIG position to force the
+			 * driver to acknowledge the transition (same trick as setFullsize). */
+			setPosition(m_decoder, posFullsizeLeft, posFullsizeTop, posFullsizeWidth, posFullsizeHeight);
+			setPosition(m_decoder, lastPigLeft[m_decoder], lastPigTop[m_decoder], lastPigWidth[m_decoder], lastPigHeight[m_decoder]);
+		}
 		setPosition(m_decoder, left, top, width, height);
 		lastPigLeft[m_decoder]   = left;
 		lastPigTop[m_decoder]    = top;


### PR DESCRIPTION
This is part 2 of https://github.com/xcentaurix/enigma2/commit/8a9df9617049e23489d7c30108961bb7e52cd154
While part 1 is working fine it doesn't cover all scenarios. I found that the playback start of a youtube trailer occasionally didn't switch from pig to fullscreen.
The fix follows the same concept as part1 and is just active for DM9xx boxes.