### PR TITLE
[HDR Detection] refine logic for starting HDR detection on video PID …

### DIFF
--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -3432,15 +3432,16 @@ void eDVBServicePlay::updateDecoder(bool sendSeekableStateChanged)
 		m_current_video_pid_type = vpidtype;
 		m_have_video_pid = (vpid > 0 && vpid < 0x2000);
 
-		if ((!m_is_pvr || m_is_stream) && m_have_video_pid && vpidtype == eDVBVideo::H265_HEVC)
+		if (m_have_video_pid && vpidtype == eDVBVideo::H265_HEVC)
 		{
 #ifdef HAS_SOFTWARE_HDR_DETECTION
-			/* Start detection immediately so FTA/stream channels accumulate data
-			 * right away.  For encrypted channels eventSizeChanged will restart
-			 * with a fresh recorder once clear data is flowing. */
+			/* Start detection immediately so channels accumulate data right away.
+			 * For encrypted live channels eventSizeChanged will restart with a
+			 * fresh recorder once clear data is flowing (m_hdr_firstframe_restarted).
+			 * For PVR the content is already clear so skip the first-frame restart. */
 			if (m_hdr_detect_vpid != vpid)
 			{
-				m_hdr_firstframe_restarted = false;
+				m_hdr_firstframe_restarted = m_is_pvr;
 				startHDRDetection(vpid);
 			}
 #endif


### PR DESCRIPTION
This pull request updates the logic for starting HDR detection in the `eDVBServicePlay::updateDecoder` method to ensure that HDR detection is started for all channels with an H.265/HEVC video PID, regardless of whether the channel is a PVR or stream. It also adjusts how the `m_hdr_firstframe_restarted` flag is set, particularly for PVR content.

HDR detection improvements:

* HDR detection now starts for all channels with H.265/HEVC video, not just for non-PVR or stream channels.
* The `m_hdr_firstframe_restarted` flag is now set to `true` for PVR content, reflecting that PVR content is already clear and does not require a first-frame restart, while for other content it remains `false`.…changes