### PR TITLE
[HDR Detection] remove unused HDR-related constants and methods

### DIFF
--- a/lib/python/Components/Converter/ServiceInfo.py
+++ b/lib/python/Components/Converter/ServiceInfo.py
@@ -93,8 +93,6 @@ class ServiceInfo(Poll, Converter):
 	IS_VIDEO_HEVC = 43
 	IS_SOFTCSA = 44
 
-
-i
 	def __init__(self, type):
 		Poll.__init__(self)
 		Converter.__init__(self, type)

--- a/lib/python/Components/Converter/ServiceInfo.py
+++ b/lib/python/Components/Converter/ServiceInfo.py
@@ -92,13 +92,6 @@ class ServiceInfo(Poll, Converter):
 	IS_VIDEO_AVC = 42
 	IS_VIDEO_HEVC = 43
 	IS_SOFTCSA = 44
-	IS_STREAM_RELAY = 45
-	HDR_TYPE = 46
-	IS_HDR10_FILE = 47
-	IS_HLG_FILE = 48
-	IS_DV_FILE = 49
-	IS_ANYHDR_FILE = 50
-	IS_HDR_GENERIC_FILE = 51
 
 	def __init__(self, type):
 		Poll.__init__(self)
@@ -150,15 +143,7 @@ class ServiceInfo(Poll, Converter):
 			"IsVideoMPEG2": (self.IS_VIDEO_MPEG2, (iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
 			"IsVideoAVC": (self.IS_VIDEO_AVC, (iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
 			"IsVideoHEVC": (self.IS_VIDEO_HEVC, (iPlayableService.evUpdatedInfo, iPlayableService.evVideoSizeChanged)),
-			"HDRType": (self.HDR_TYPE, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
-			"IsHDR10File": (self.IS_HDR10_FILE, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
-			"IsHLGFile": (self.IS_HLG_FILE, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
-			"IsDVFile": (self.IS_DV_FILE, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
-			"IsHDRGenericFile": (self.IS_HDR_GENERIC_FILE, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
-			"IsAnyHDRFile": (self.IS_ANYHDR_FILE, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
 		}[type]
-		if self.type in (self.HDR_TYPE, self.IS_HDR10_FILE, self.IS_HLG_FILE, self.IS_DV_FILE, self.IS_ANYHDR_FILE, self.IS_HDR_GENERIC_FILE):
-			self.poll_interval = 2000
 
 	def isVideoService(self, info, service):
 		if not service or not isinstance(service, eServiceReference):
@@ -175,29 +160,6 @@ class ServiceInfo(Poll, Converter):
 		if v == -2:
 			return info.getInfoString(what)
 		return convert(v)
-
-	def _readHDRType(self):
-		# sHDRType: 0=SDR 1=HDR10 2=HLG 3=HDR (plain/generic BT.2020 traditional gamma)
-		# Falls back to sGamma (0=SDR 1=HDR 2=HDR10 3=HLG) when sHDRType is unavailable
-		service = self.source.service
-		info = service and service.info()
-		if not info:
-			return 0
-		try:
-			hdr = info.getInfo(iServiceInformation.sHDRType)
-			if hdr > 0:
-				return hdr
-			# sGamma: 1=HDR(generic), 2=HDR10(SMPTE ST2084), 3=HLG
-			gamma = info.getInfo(iServiceInformation.sGamma)
-			if gamma == 2:
-				return 1  # HDR10
-			if gamma == 3:
-				return 2  # HLG
-			if gamma == 1:
-				return 3  # plain HDR
-			return 0
-		except Exception:
-			return 0
 
 	@cached
 	def getBoolean(self):
@@ -299,18 +261,6 @@ class ServiceInfo(Poll, Converter):
 			elif self.type == self.IS_HLG and not isRef:
 				hdr = info.getInfo(iServiceInformation.sHDRType)
 				return hdr == 2 if hdr > 0 else info.getInfo(iServiceInformation.sGamma) == 3
-			elif self.type == self.IS_HDR10_FILE:
-				return self._readHDRType() == 1
-			elif self.type == self.IS_HLG_FILE:
-				return self._readHDRType() == 2
-			elif self.type == self.IS_DV_FILE:
-				return self._readHDRType() == 4
-			elif self.type == self.IS_HDR_GENERIC_FILE:
-				return self._readHDRType() == 3
-			elif self.type == self.IS_ANYHDR_FILE:
-				return self._readHDRType() > 0
-			elif self.type == self.HDR_TYPE and not isRef:
-				return self._readHDRType() > 0
 			elif self.type == self.IS_VIDEO_MPEG2 and not isRef:
 				return info.getInfo(iServiceInformation.sVideoType) == 0
 			elif self.type == self.IS_VIDEO_AVC and not isRef:

--- a/lib/python/Components/Converter/ServiceInfo.py
+++ b/lib/python/Components/Converter/ServiceInfo.py
@@ -93,6 +93,8 @@ class ServiceInfo(Poll, Converter):
 	IS_VIDEO_HEVC = 43
 	IS_SOFTCSA = 44
 
+
+i
 	def __init__(self, type):
 		Poll.__init__(self)
 		Converter.__init__(self, type)

--- a/lib/python/Screens/ServiceInfo.py
+++ b/lib/python/Screens/ServiceInfo.py
@@ -193,7 +193,22 @@ class ServiceInfo(Screen):
 					resolution += ("i", "p", "")[self.info.getInfo(iServiceInformation.sProgressive)]
 					aspect = self.getServiceInfoValue(iServiceInformation.sAspect)
 					resolution += " - %s" % (aspect in (1, 2, 5, 6, 9, 0xA, 0xD, 0xE) and "4:3" or "16:9")
-				gamma = ("SDR", "HDR", "HDR10", "HLG", "")[self.info.getInfo(iServiceInformation.sGamma)]
+				hdr = self.info.getInfo(iServiceInformation.sHDRType)
+				if hdr >= 0:
+					if hdr == 0:
+						gamma = "SDR"
+						if self.info.getInfo(iServiceInformation.sGamma) == 1:
+							gamma = "HDR"
+						elif self.info.getInfo(iServiceInformation.sGamma) == 2:
+							gamma = "HDR10"
+						elif self.info.getInfo(iServiceInformation.sGamma) == 3:
+							gamma = "HLG"
+					elif hdr == 1:
+						gamma = "HDR10"
+					elif hdr == 2:
+						gamma = "HLG"
+					elif hdr == 3:
+						gamma = "HDR"
 				if gamma:
 					resolution += " - %s" % gamma
 			self.toggle_pid_button()


### PR DESCRIPTION
This pull request removes all code related to HDR (High Dynamic Range) file type detection and handling from the `ServiceInfo` converter. This includes the removal of several constants, dictionary entries, methods, and logic branches related to HDR types and file checks.

Removed HDR file support:

* Removed HDR-related constants such as `HDR_TYPE`, `IS_HDR10_FILE`, `IS_HLG_FILE`, `IS_DV_FILE`, `IS_ANYHDR_FILE`, and `IS_HDR_GENERIC_FILE` from the `ServiceInfo` class.
* Removed HDR-related entries from the `type` mapping in the `__init__` method, and the special polling interval for these types.
* Removed the `_readHDRType` method, which was responsible for determining the HDR type from service information.
* Removed all branches in the `getBoolean` method that checked for HDR file types or used `_readHDRType`.