### PR TITLE
[HDR] Refine event dispatch for HDR status changes

### DIFF
--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -4562,9 +4562,9 @@ void eDVBServicePlay::hdrResult(int result)
 	m_hdr_type = result;
 	/* Fire all three events so every skin pattern is covered:
 	 * - evVideoGammaChanged: skins that track gamma/HDR changes
-	 * - evVideoSizeChanged:  skins that refresh video info on size events
 	 * - evUpdatedInfo:       general service-info listeners (ServiceInfo converter) */
 	m_event((iPlayableService*)this, evVideoGammaChanged);
+	m_event((iPlayableService*)this, evUpdatedInfo);
 }
 #endif /* HAS_SOFTWARE_HDR_DETECTION */
 

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -1612,7 +1612,7 @@ void eServiceMP3::startHDRProbe()
 				if (hdrFromCaps != m_hdr_type)
 				{
 					m_hdr_type = hdrFromCaps;
-					m_event((iPlayableService*)this, evVideoGammaChanged);
+					m_event((iPlayableService*)this, evUpdatedInfo);
 				}
 				return;
 			}
@@ -1699,11 +1699,12 @@ void eServiceMP3::checkHDRProbe()
 	{
 		int newHdrType = (result == HevcHDR::HDR_HDR10) ? 1 :
 		                 (result == HevcHDR::HDR_HLG)   ? 2 : 3;
+		eDebug("[eServiceMP3] HDR probe: result %d from bitstream", newHdrType);
 		stopHDRProbe();
 		if (newHdrType != m_hdr_type)
 		{
 			m_hdr_type = newHdrType;
-			m_event((iPlayableService*)this, evVideoGammaChanged);
+			m_event((iPlayableService*)this, evUpdatedInfo);
 		}
 		return;
 	}
@@ -1797,13 +1798,15 @@ void eServiceMP3::updateHDRFromVideoPad()
 		gst_iterator_free(eit);
 	}
 
+	eDebug("[eServiceMP3] HDR probe: result %d from video pad colorimetry", hdr);
+
 	/* Only update m_hdr_type when caps give a positive result.
 	 * Do NOT reset a previously probed HDR result just because
 	 * caps lack colorimetry (e.g. older STB GStreamer builds). */
 	if (hdr > 0 && hdr != m_hdr_type)
 	{
 		m_hdr_type = hdr;
-		m_event((iPlayableService*)this, evVideoGammaChanged);
+		m_event((iPlayableService*)this, evUpdatedInfo);
 	}
 }
 #endif /* HAS_SOFTWARE_HDR_DETECTION */


### PR DESCRIPTION
This pull request updates the way HDR (High Dynamic Range) change events are signaled in both the DVB and MP3 service handling code. Instead of firing the more specific `evVideoGammaChanged` event when HDR type changes, the code now fires the more general `evUpdatedInfo` event, ensuring that all relevant service info listeners are notified. Additionally, debug logging has been added to help trace HDR detection results in the MP3 service.

**Event Notification Changes:**

* Changed event notification from `evVideoGammaChanged` to `evUpdatedInfo` when HDR type changes in `eServiceMP3::startHDRProbe`, `eServiceMP3::checkHDRProbe`, and `eServiceMP3::updateHDRFromVideoPad`, ensuring broader notification to service info listeners. [[1]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL1615-R1615) [[2]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fR1702-R1707) [[3]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fR1801-R1809)
* In `eDVBServicePlay::hdrResult`, removed the `evVideoSizeChanged` event and now only fire `evVideoGammaChanged` and `evUpdatedInfo` to cover all skin patterns and listeners.

**Debug Logging Improvements:**

* Added debug output in `eServiceMP3::checkHDRProbe` and `eServiceMP3::updateHDRFromVideoPad` to log HDR detection results, aiding in diagnostics and development. [[1]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fR1702-R1707) [[2]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fR1801-R1809)