### PR TITLE
[Service] Optimize responsiveness and prevent UI freezes

### DIFF
--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -860,6 +860,17 @@ void eDVBServicePMTHandler::SDTScanEvent(int event)
 	{
 		case eDVBScan::evtFinish:
 		{
+			/* Snapshot m_dvb_scan into a local ePtr before any use.
+			 * This increments the refcount so the eDVBScan object cannot be
+			 * destroyed under us if free() is called concurrently (e.g. from
+			 * another thread or a reentrant signal), and provides a single
+			 * null-check that covers every subsequent dereference. */
+			ePtr<eDVBScan> scan = m_dvb_scan;
+			if (!scan)
+			{
+				eDebug("[eDVBServicePMTHandler] SDTScanEvent: m_dvb_scan is null, skipping SDT update");
+				break;
+			}
 			ePtr<iDVBChannelList> db;
 			if (m_resourceManager->getChannelList(db) != 0)
 				eDebug("[eDVBServicePMTHandler] no channel list");
@@ -867,10 +878,10 @@ void eDVBServicePMTHandler::SDTScanEvent(int event)
 			{
 				eDVBChannelID chid, curr_chid;
 				m_reference.getChannelID(chid);
-				curr_chid = m_dvb_scan->getCurrentChannelID();
+				curr_chid = scan->getCurrentChannelID();
 				if (chid == curr_chid)
 				{
-					m_dvb_scan->insertInto(db, true);
+					scan->insertInto(db, true);
 					eDebug("[eDVBServicePMTHandler] sdt update done!");
 				}
 				else

--- a/lib/python/Components/Sources/CurrentService.py
+++ b/lib/python/Components/Sources/CurrentService.py
@@ -27,7 +27,13 @@ class CurrentService(PerServiceBase, Source):
 		self.onManualNewService = []
 
 	def serviceEvent(self, event):
-		self.info = None
+		# pnav.stopService() fires evEnd and pnav.playService() fires evStart
+		# synchronously, both before any repaint runs.  Preserve the info
+		# pre-populated by newService() across that whole old→new transition so
+		# converters (ServiceName etc.) can display the new service immediately.
+		# Clear when real service data arrives via later events (evUpdatedInfo etc.).
+		if not (getattr(self, 'info', None) is not None and event in (iPlayableService.evEnd, iPlayableService.evStart)):
+			self.info = None
 		self.changed((self.CHANGED_SPECIFIC, event))
 
 	@cached

--- a/lib/python/Components/Sources/EventInfo.py
+++ b/lib/python/Components/Sources/EventInfo.py
@@ -160,7 +160,12 @@ class EventInfo(PerServiceBase, Source):
 		if what == iPlayableService.evEnd and not self.__service:
 			self.changed((self.CHANGED_CLEAR,))
 		else:
-			self.__service = None
+			# pnav.stopService() fires evEnd and pnav.playService() fires evStart
+			# synchronously, both before any repaint runs.  Preserve an eServiceReference
+			# set by updateSource() across that whole old→new transition so renderers
+			# can show cached EPG immediately.  Clear only when real EIT data arrives.
+			if not (isinstance(self.__service, eServiceReference) and what in (iPlayableService.evEnd, iPlayableService.evStart)):
+				self.__service = None
 			self.changed((self.CHANGED_ALL,))
 		# if evUpdatedEventInfo arrives before the event starts the fields will not change, so add an additional future timed event to make sure it does update.
 		if not from_timer and what in (iPlayableService.evUpdatedInfo, iPlayableService.evUpdatedEventInfo):

--- a/lib/python/Navigation.py
+++ b/lib/python/Navigation.py
@@ -238,6 +238,9 @@ class Navigation:
 					"InfoBarInstance": InfoBarInstance, "oldref": oldref,
 					"checkParentalControl": checkParentalControl, "forceRestart": forceRestart,
 					"adjust": adjust, "event": event,
+					# Save the post-setCurrent value so _executePendingPlay can restore it
+					# after evEnd (fired by pnav.stopService) clears currentlyPlaying*.
+					"serviceOrGroup": self.currentlyPlayingServiceOrGroup,
 				}
 				if not hasattr(self, "_pendingPlayTimer"):
 					self._pendingPlayTimer = eTimer()
@@ -269,6 +272,13 @@ class Navigation:
 
 		if not SystemInfo["FCCactive"]:
 			self.pnav.stopService()
+
+		# Restore the service references that evEnd (fired inside stopService) just
+		# cleared.  This mirrors the original synchronous code where these were
+		# assigned *after* pnav.stopService() so that callers such as movieSelected()
+		# always find a valid getCurrentlyPlayingServiceOrGroup() value.
+		self.currentlyPlayingServiceReference = p["playref"]
+		self.currentlyPlayingServiceOrGroup = p["serviceOrGroup"]
 
 		if SystemInfo["FCCactive"] and "%3a//" in ref.toString() and not is_stream_relay:
 			self.pnav.stopService()

--- a/lib/python/Navigation.py
+++ b/lib/python/Navigation.py
@@ -180,16 +180,11 @@ class Navigation:
 			else:
 				playref = ref
 			if self.pnav:
-				if not SystemInfo["FCCactive"]:
-					self.pnav.stopService()
-				else:
+				if SystemInfo["FCCactive"]:
 					self.skipServiceReferenceReset = True
 
 				self.currentlyPlayingServiceReference = playref
 				playref, is_stream_relay = streamrelay.streamrelayChecker(playref)
-
-				if SystemInfo["FCCactive"] and "%3a//" in ref.toString() and not is_stream_relay:
-					self.pnav.stopService()
 
 				playref_str_orig = playref.toString()
 				for f in Navigation.playServiceExtensions:
@@ -233,44 +228,86 @@ class Navigation:
 								if config.usage.frontend_priority_dvbs.value != config.usage.frontend_priority.value:
 									setPreferredTuner(int(config.usage.frontend_priority_dvbs.value))
 									setPriorityFrontend = True
-				if config.misc.softcam_streamrelay_delay.value and self.currentServiceIsStreamRelay:
-					self.currentServiceIsStreamRelay = False
-					self.currentlyPlayingServiceReference = None
-					self.currentlyPlayingServiceOrGroup = None
-					self.retryServicePlayCount = 1  # Pre-arm retry cycle in case play fails after delay.
-					print("[Navigation] Streamrelay was active -> delay the zap till tuner is freed")
-					self.retryServicePlayTimer = eTimer()
-					self.retryServicePlayTimer.callback.append(boundFunction(self.playService, ref, checkParentalControl, forceRestart, adjust))
-					self.retryServicePlayTimer.start(config.misc.softcam_streamrelay_delay.value, True)
-				elif not is_async_play and self.pnav.playService(playref):
-					self.currentlyPlayingServiceReference = None
-					self.originalPlayingServiceReference = None
-					self.currentlyPlayingServiceOrGroup = None
-					if oldref and "://" in oldref.getPath():
-						self.retryServicePlayCount = 1  # Start retry cycle for stream relay tuner deallocation.
-					if 0 < self.retryServicePlayCount <= 20:
-						print(f"[Navigation] Streaming was active -> try again (attempt {self.retryServicePlayCount}).")  # Use timer to give the stream server the time to deallocate the tuner.
-						self.retryServicePlayTimer = eTimer()
-						self.retryServicePlayTimer.callback.append(boundFunction(self.playService, ref, checkParentalControl, forceRestart, adjust))
-						self.retryServicePlayTimer.start(500, True)
-						self.retryServicePlayCount += 1
-					elif self.retryServicePlayCount > 20:
-						print(f"[Navigation] Gave up retrying after {self.retryServicePlayCount - 1} attempts.")
-						self.retryServicePlayCount = 0
+
+				# Defer the actual stop+play to the next event-loop iteration so the
+				# InfoBar repaint (triggered by the early newService/updateSource calls
+				# above) can execute before the synchronous evEnd/evStart chains fire.
+				self._pendingPlay = {
+					"playref": playref, "ref": ref, "is_async_play": is_async_play,
+					"is_stream_relay": is_stream_relay, "setPriorityFrontend": setPriorityFrontend,
+					"InfoBarInstance": InfoBarInstance, "oldref": oldref,
+					"checkParentalControl": checkParentalControl, "forceRestart": forceRestart,
+					"adjust": adjust, "event": event,
+				}
+				if not hasattr(self, "_pendingPlayTimer"):
+					self._pendingPlayTimer = eTimer()
+					self._pendingPlayTimer.callback.append(self._executePendingPlay)
 				else:
-					self.retryServicePlayCount = 0
-				self.skipServiceReferenceReset = False
-				if setPriorityFrontend:
-					setPreferredTuner(int(config.usage.frontend_priority.value))
-				if self.currentlyPlayingServiceReference and self.currentlyPlayingServiceReference.toString() in streamrelay.data:
-					self.currentServiceIsStreamRelay = True
-				if InfoBarInstance and "%3a//" in playref.toString() and not is_async_play:
-					self.originalPlayingServiceReference = None
-					InfoBarInstance.serviceStarted()
+					self._pendingPlayTimer.stop()
+				self._pendingPlayTimer.start(0, True)
 				return 0
 		elif oldref and InfoBarInstance and InfoBarInstance.servicelist.servicelist.setCurrent(ref, adjust):
 			self.currentlyPlayingServiceOrGroup = InfoBarInstance.servicelist.servicelist.getCurrent()
 		return 1
+
+	def _executePendingPlay(self):
+		p = getattr(self, "_pendingPlay", None)
+		if p is None or not self.pnav:
+			return
+		del self._pendingPlay
+
+		playref = p["playref"]
+		ref = p["ref"]
+		is_async_play = p["is_async_play"]
+		is_stream_relay = p["is_stream_relay"]
+		setPriorityFrontend = p["setPriorityFrontend"]
+		InfoBarInstance = p["InfoBarInstance"]
+		oldref = p["oldref"]
+		checkParentalControl = p["checkParentalControl"]
+		forceRestart = p["forceRestart"]
+		adjust = p["adjust"]
+
+		if not SystemInfo["FCCactive"]:
+			self.pnav.stopService()
+
+		if SystemInfo["FCCactive"] and "%3a//" in ref.toString() and not is_stream_relay:
+			self.pnav.stopService()
+
+		if config.misc.softcam_streamrelay_delay.value and self.currentServiceIsStreamRelay:
+			self.currentServiceIsStreamRelay = False
+			self.currentlyPlayingServiceReference = None
+			self.currentlyPlayingServiceOrGroup = None
+			self.retryServicePlayCount = 1  # Pre-arm retry cycle in case play fails after delay.
+			print("[Navigation] Streamrelay was active -> delay the zap till tuner is freed")
+			self.retryServicePlayTimer = eTimer()
+			self.retryServicePlayTimer.callback.append(boundFunction(self.playService, ref, checkParentalControl, forceRestart, adjust))
+			self.retryServicePlayTimer.start(config.misc.softcam_streamrelay_delay.value, True)
+		elif not is_async_play and self.pnav.playService(playref):
+			self.currentlyPlayingServiceReference = None
+			self.originalPlayingServiceReference = None
+			self.currentlyPlayingServiceOrGroup = None
+			if oldref and "://" in oldref.getPath():
+				self.retryServicePlayCount = 1  # Start retry cycle for stream relay tuner deallocation.
+			if 0 < self.retryServicePlayCount <= 20:
+				print(f"[Navigation] Streaming was active -> try again (attempt {self.retryServicePlayCount}).")  # Use timer to give the stream server the time to deallocate the tuner.
+				self.retryServicePlayTimer = eTimer()
+				self.retryServicePlayTimer.callback.append(boundFunction(self.playService, ref, checkParentalControl, forceRestart, adjust))
+				self.retryServicePlayTimer.start(500, True)
+				self.retryServicePlayCount += 1
+			elif self.retryServicePlayCount > 20:
+				print(f"[Navigation] Gave up retrying after {self.retryServicePlayCount - 1} attempts.")
+				self.retryServicePlayCount = 0
+		else:
+			self.retryServicePlayCount = 0
+
+		self.skipServiceReferenceReset = False
+		if setPriorityFrontend:
+			setPreferredTuner(int(config.usage.frontend_priority.value))
+		if self.currentlyPlayingServiceReference and self.currentlyPlayingServiceReference.toString() in streamrelay.data:
+			self.currentServiceIsStreamRelay = True
+		if InfoBarInstance and "%3a//" in playref.toString() and not is_async_play:
+			self.originalPlayingServiceReference = None
+			InfoBarInstance.serviceStarted()
 
 	def getCurrentlyPlayingServiceReference(self):
 		return self.currentlyPlayingServiceReference
@@ -316,6 +353,11 @@ class Navigation:
 		return self.currentlyPlayingService
 
 	def stopService(self):
+		# Cancel any deferred play so it cannot restart the service after an
+		# explicit stop (e.g. when Movie Selection or another screen stops live TV).
+		if hasattr(self, "_pendingPlayTimer"):
+			self._pendingPlayTimer.stop()
+		self.__dict__.pop("_pendingPlay", None)
 		if self.pnav:
 			self.pnav.stopService()
 		self.currentlyPlayingServiceReference = None

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -562,7 +562,7 @@ eServiceMP3::eServiceMP3(eServiceReference ref):
 #ifdef HAS_SOFTWARE_HDR_DETECTION
 	m_hdr_probe_id = 0;
 	m_hdr_probe_pad = NULL;
-	m_hdr_probe_active = false;
+	g_atomic_int_set(&m_hdr_probe_active, 0);
 	m_hdr_probe_last_classify = 0;
 	m_hdr_probe_first_sps_at = 0;
 	g_mutex_init(&m_hdr_probe_mutex);
@@ -1019,7 +1019,7 @@ RESULT eServiceMP3::start()
 		}
 	}
 
-	if (m_ref.path.find("://") == std::string::npos)
+	if (m_ref && m_ref.path.find("://") == std::string::npos)
 	{
 		/* read event from .eit file */
 		size_t pos;
@@ -1043,7 +1043,7 @@ RESULT eServiceMP3::start()
 
 RESULT eServiceMP3::stop()
 {
-	if (!m_gst_playbin || m_state == stStopped)
+	if (!m_gst_playbin || m_state == stStopped || !m_ref)
 		return -1;
 
 	eDebug("[eServiceMP3] stop %s", m_ref.path.c_str());
@@ -1051,8 +1051,12 @@ RESULT eServiceMP3::stop()
 
 	GstStateChangeReturn ret;
 	GstState state, pending;
-	/* make sure that last state change was successfull */
-	ret = gst_element_get_state(m_gst_playbin, &state, &pending, 5 * GST_SECOND);
+	/* Non-blocking state query: gst_element_set_state(NULL) aborts any
+	 * pending state change internally, so we do not need to wait here.
+	 * The previous 5 * GST_SECOND blocking wait caused the UI to freeze
+	 * (spinner with video still playing) on rapid channel zaps, especially
+	 * on H.265 channels where hardware decoders are slower to respond. */
+	ret = gst_element_get_state(m_gst_playbin, &state, &pending, 0);
 	eDebug("[eServiceMP3] stop state:%s pending:%s ret:%s",
 		gst_element_state_get_name(state),
 		gst_element_state_get_name(pending),
@@ -1468,16 +1472,22 @@ GstPadProbeReturn eServiceMP3::hdrProbeCallback(GstPad*, GstPadProbeInfo *info, 
 	GstBuffer *buf = GST_PAD_PROBE_INFO_BUFFER(info);
 	if (!buf) return GST_PAD_PROBE_OK;
 
+	/* Atomic pre-check before any buffer mapping or mutex: stopHDRProbe()
+	 * sets m_hdr_probe_active to 0 via g_atomic_int_set() WITHOUT acquiring
+	 * the mutex, so this check is always safe and avoids the cost of
+	 * gst_buffer_map + mutex acquisition when we are already stopping. */
+	if (!g_atomic_int_get(&self->m_hdr_probe_active))
+		return GST_PAD_PROBE_REMOVE;
+
 	GstMapInfo map;
 	if (!gst_buffer_map(buf, &map, GST_MAP_READ))
 		return GST_PAD_PROBE_OK;  /* DMA/opaque buffer — skip silently */
 
 	g_mutex_lock(&self->m_hdr_probe_mutex);
-	if (!self->m_hdr_probe_active)
+	if (!g_atomic_int_get(&self->m_hdr_probe_active))
 	{
-		/* stopHDRProbe() was called; self-remove so gst_pad_remove_probe()
-		 * (called immediately after releasing the mutex in stopHDRProbe) does
-		 * not have to wait for us, avoiding a potential main-thread stall. */
+		/* Double-check under mutex in case stopHDRProbe() ran between the
+		 * atomic pre-check above and acquiring the mutex. */
 		g_mutex_unlock(&self->m_hdr_probe_mutex);
 		gst_buffer_unmap(buf, &map);
 		return GST_PAD_PROBE_REMOVE;
@@ -1630,7 +1640,7 @@ void eServiceMP3::startHDRProbe()
 	}
 	m_hdr_probe_last_classify = 0;
 	m_hdr_probe_first_sps_at = 0;
-	m_hdr_probe_active = true;
+	g_atomic_int_set(&m_hdr_probe_active, 1);
 	g_mutex_unlock(&m_hdr_probe_mutex);
 
 	m_hdr_probe_id = gst_pad_add_probe(hevc_pad, GST_PAD_PROBE_TYPE_BUFFER,
@@ -1647,22 +1657,24 @@ void eServiceMP3::stopHDRProbe()
 {
 	if (m_hdr_probe_timer) { m_hdr_probe_timer->stop(); m_hdr_probe_timer = 0; }
 
-	/* Signal the probe callback to self-remove by returning GST_PAD_PROBE_REMOVE.
-	 * We do NOT call gst_pad_remove_probe() here:
-	 *  - Called from startHDRProbe()/checkHDRProbe() while the pipeline is PLAYING:
-	 *    gst_pad_remove_probe() acquires GST_OBJECT_LOCK(pad), which the streaming
-	 *    thread also holds briefly during probe-list iteration.  On hardware STBs
-	 *    where the streaming thread is stalled inside a hardware decoder, this can
-	 *    hang the main thread.
-	 *  - Called from stop() after gst_element_set_state(NULL) returns ASYNC:
-	 *    the streaming thread may still be running, same risk applies.
-	 * The probe callback returns GST_PAD_PROBE_REMOVE when m_hdr_probe_active==false,
-	 * causing GStreamer to remove it from the streaming thread automatically.
-	 * Any remaining probe is cleaned up when the pipeline is destroyed. */
-	g_mutex_lock(&m_hdr_probe_mutex);
-	m_hdr_probe_active = false;
-	std::vector<uint8_t>().swap(m_hdr_probe_es);
-	g_mutex_unlock(&m_hdr_probe_mutex);
+	/* Set the active flag atomically WITHOUT acquiring m_hdr_probe_mutex.
+	 * This is the key fix for the UI lockup on H.265 channel zapping:
+	 *  - gst_element_set_state(NULL) can return GST_STATE_CHANGE_ASYNC,
+	 *    meaning the streaming thread is still running hdrProbeCallback.
+	 *  - hdrProbeCallback holds m_hdr_probe_mutex while copying H.265 I-frame
+	 *    data (can be 500KB-2MB per frame), which could block the main thread
+	 *    for a significant time if we call g_mutex_lock() here.
+	 *  - By using g_atomic_int_set(), we set inactive instantly without
+	 *    contending the mutex.  The probe callback's atomic pre-check sees the
+	 *    flag and returns GST_PAD_PROBE_REMOVE without touching the mutex at all.
+	 * m_hdr_probe_es cleanup: try a non-blocking lock; if the probe is mid-copy
+	 * skip the clear — the data is harmless and freed with the object. */
+	g_atomic_int_set(&m_hdr_probe_active, 0);
+	if (g_mutex_trylock(&m_hdr_probe_mutex))
+	{
+		std::vector<uint8_t>().swap(m_hdr_probe_es);
+		g_mutex_unlock(&m_hdr_probe_mutex);
+	}
 	std::vector<uint8_t>().swap(m_hdr_probe_snap); /* main-thread only, no lock needed */
 
 	/* Release our pad ref; GStreamer holds its own ref until the probe is removed. */
@@ -2236,13 +2248,20 @@ void eServiceMP3::clearBuffers(bool force)
 {
 	if ((!m_initial_start || !m_clear_buffers) && !force) return;
 
+	/* Live streams cannot seek back; flushing would stall playback, so skip. */
+	if (m_is_live && !force)
+	{
+		eDebug ("[eServiceMP3] Clear Buffers skipped (live stream)");
+		return;
+	}
+
 	eDebug ("[eServiceMP3] Clear Buffers!");
 	bool validposition = false;
 	pts_t ppos = 0;
 	if (getPlayPosition(ppos) >= 0)
 	{
 		validposition = true;
-		ppos -= 90000;
+		ppos -= 9000; /* seek back ~100ms instead of 1s for faster audio switch */
 		if (ppos < 0)
 			ppos = 0;
 	}
@@ -2263,16 +2282,32 @@ void eServiceMP3::clearBuffers(bool force)
 
 int eServiceMP3::selectAudioStream(int i, bool skipAudioFix)
 {
+	/* Validate index against our own track list to avoid relying solely on
+	 * an immediate g_object_get readback which can return a stale value when
+	 * GStreamer is in a transitional state. */
+	if (i < 0 || i >= (int)m_audioStreams.size())
+	{
+		eDebug ("[eServiceMP3] selectAudioStream: index %d out of range (n=%d)", i, (int)m_audioStreams.size());
+		return -1;
+	}
 	int current_audio, current_audio_orig;
 	g_object_get (G_OBJECT (m_gst_playbin), "current-audio", &current_audio_orig, NULL);
 	g_object_set (G_OBJECT (m_gst_playbin), "current-audio", i, NULL);
 	g_object_get (G_OBJECT (m_gst_playbin), "current-audio", &current_audio, NULL);
+	if (current_audio != i)
+	{
+		/* GStreamer may be in a transitional state and hasn't applied the
+		 * property yet. Since we validated the index ourselves, trust the set. */
+		eDebug ("[eServiceMP3] selectAudioStream: readback returned %d (expected %d), trusting range-validated set", current_audio, i);
+		current_audio = i;
+	}
 	if ( current_audio == i )
 	{
 		if (!skipAudioFix)
 		{
 			eDebug ("[eServiceMP3] switched to audio stream %i", current_audio);
 			m_currentAudioStream = i;
+			m_event((iPlayableService*)this, evUpdatedInfo);
 #ifdef PASSTHROUGH_FIX
 			GstPad* pad = 0;
 			g_signal_emit_by_name (m_gst_playbin, "get-audio-pad", i, &pad);

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -411,7 +411,7 @@ private:
 	size_t          m_hdr_probe_first_sps_at;
 	gulong          m_hdr_probe_id;
 	GstPad         *m_hdr_probe_pad;
-	bool            m_hdr_probe_active;
+	gint            m_hdr_probe_active; /* atomic: 0=inactive, 1=active; use g_atomic_int_* */
 	ePtr<eTimer>    m_hdr_probe_timer;
 	void startHDRProbe();
 	void stopHDRProbe();


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes in the handling of service playback, event transitions, and audio stream management, with a particular focus on thread safety, UI responsiveness, and correctness during rapid channel changes or live streaming scenarios. The most significant changes are in the `eServiceMP3` class for atomic state handling and in the navigation logic for deferring stop/play operations to improve UI updates.

**Thread safety and atomicity improvements:**

* Replaced the `m_hdr_probe_active` boolean with an atomic integer (`gint`) in `eServiceMP3`, and updated all related logic to use atomic operations for thread-safe state changes during HDR probe start/stop. This avoids UI lockups and race conditions when stopping or starting HDR probes, especially during rapid channel zapping. [[1]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL565-R565) [[2]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fR1475-R1490) [[3]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL1633-R1643) [[4]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL1650-R1677) [[5]](diffhunk://#diff-dacebfa9a557e700e29cd10b58e83e033d50352340a620b61d1460165a1f5e74L414-R414)

**Playback and navigation improvements:**

* Deferred the actual stop and play operations in `Navigation.py` to the next event-loop iteration, allowing UI repaints (like InfoBar) to occur before firing synchronous service events. Also added logic to cancel any pending deferred plays when stopping the service, preventing unwanted restarts. [[1]](diffhunk://#diff-3a1494cbff8a8543e62f1b7271be5dd8907bd5325c20e29176afce06279cd3adL183-L193) [[2]](diffhunk://#diff-3a1494cbff8a8543e62f1b7271be5dd8907bd5325c20e29176afce06279cd3adR231-R275) [[3]](diffhunk://#diff-3a1494cbff8a8543e62f1b7271be5dd8907bd5325c20e29176afce06279cd3adR302) [[4]](diffhunk://#diff-3a1494cbff8a8543e62f1b7271be5dd8907bd5325c20e29176afce06279cd3adL270-L273) [[5]](diffhunk://#diff-3a1494cbff8a8543e62f1b7271be5dd8907bd5325c20e29176afce06279cd3adR356-R360)

**Service event handling and UI update consistency:**

* Updated service and event info sources to preserve pre-populated service information across synchronous evEnd/evStart transitions, ensuring converters and renderers can display the new service or cached EPG immediately during fast service changes. [[1]](diffhunk://#diff-29be8509fd0a7fe08b029f7ab6079924fd326516b66440a5b742955312c5f8d2R30-R35) [[2]](diffhunk://#diff-bd9efb0eb027ce743dead1ed36dd252ef4b832b4e5b8c9bbc7ed81cb93f9f9bdR163-R167)

**eServiceMP3 playback and buffer management:**

* Improved live stream handling by skipping buffer clearing for live streams (unless forced), and reduced the seek-back duration for faster audio switching.
* Added validation of audio stream indices before switching, and improved handling when GStreamer is in a transitional state, ensuring robust audio stream selection.

**Minor robustness and correctness fixes:**

* Added null checks for service references in various locations to prevent dereferencing null pointers, especially during concurrent or rapid operations. [[1]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL1022-R1022) [[2]](diffhunk://#diff-18a82f635a72430800527cf2622ff6c9ea947c0e9fed3e407846186476b1506fL1046-R1059) [[3]](diffhunk://#diff-76c193d949c9a9948af50f07df208d39baf284dfd95791c12ea835c35ed2c464R863-R884)

These changes collectively enhance the stability, responsiveness, and correctness of service playback and UI updates, particularly under rapid user actions or edge-case streaming scenarios.