### PR TITLE
Fix transparency and compositing order in immediate mode rendering

### DIFF
--- a/lib/gui/ewidgetdesktop.cpp
+++ b/lib/gui/ewidgetdesktop.cpp
@@ -10,15 +10,22 @@ void eWidgetDesktop::addRootWidget(eWidget *root)
 	ASSERT(!root->m_desktop);
 
 	int invert_sense = 0;
-		/* buffered mode paints back-to-front, while immediate mode is front-to-back. */
+		/* m_root is always kept sorted front-to-back in immediate mode (used for
+		   clip region calculation, front to back), and back-to-front in buffered
+		   mode (used for composition, back to front). immediate mode painting
+		   itself walks m_root in reverse (back-to-front) -- see paint(). */
 	if (m_comp_mode == cmBuffered)
 		invert_sense = 1;
 
 	ePtrList<eWidget>::iterator insert_position = m_root.begin();
 
+		/* <= rather than < : among widgets sharing the same (e.g. default,
+		   unset) zPosition, the one added last ends up on top, consistent
+		   with how child widgets are stacked (see eWidget::insertIntoParent)
+		   and with the painting order below. */
 	for (;;)
 	{
-		if ((insert_position == m_root.end()) || (invert_sense ^ (insert_position->m_z_position < root->m_z_position)))
+		if ((insert_position == m_root.end()) || (invert_sense ^ (insert_position->m_z_position <= root->m_z_position)))
 		{
 			m_root.insert(insert_position, root);
 			break;
@@ -59,7 +66,7 @@ int eWidgetDesktop::movedWidget(eWidget *root)
 	return 0; /* native move ok */
 }
 
-void eWidgetDesktop::calcWidgetClipRegion(eWidget *widget, gRegion &parent_visible, bool parent)
+void eWidgetDesktop::calcWidgetClipRegion(eWidget *widget, gRegion &parent_visible)
 {
 		/* start with our clip region, clipped with the parent's */
 	if (widget->m_vis & eWidget::wVisShow)
@@ -68,8 +75,13 @@ void eWidgetDesktop::calcWidgetClipRegion(eWidget *widget, gRegion &parent_visib
 		widget->m_visible_region.moveBy(widget->position());
 		widget->m_visible_region &= parent_visible; // in parent space!
 
-		if (!widget->isTransparent() && (!widget->m_gradient_alphablend || parent) && (widget->m_cornerRadius == 0 || parent) && (!widget->m_alphaBlend || parent))
-				/* remove everything this widget will contain from parent's visible list, unless widget is transparent. */
+		if (!widget->isTransparent() && !widget->m_gradient_alphablend && widget->m_cornerRadius == 0 && !widget->m_alphaBlend)
+				/* remove everything this widget will contain from parent's visible list, unless the
+				   widget is transparent, alphablended, gradient-alphablended or rounded -- in that
+				   case whatever is behind it (a parent widget, another root widget, or the desktop
+				   background) must stay available so it keeps being calculated/painted underneath.
+				   this applies the same way at root (screen) level as it does for nested widgets,
+				   so overlapping root windows respect zPosition and composite correctly. */
 			parent_visible -= widget->m_visible_region; // will remove child regions too!
 
 			/* now prepare for recursing to childs */
@@ -87,7 +99,7 @@ void eWidgetDesktop::calcWidgetClipRegion(eWidget *widget, gRegion &parent_visib
 		if (i != widget->m_childs.end())
 		{
 			if (i->m_vis & eWidget::wVisShow)
-				calcWidgetClipRegion(*i, widget->m_visible_region, false);
+				calcWidgetClipRegion(*i, widget->m_visible_region);
 			else
 				clearVisibility(*i);
 		}
@@ -275,20 +287,21 @@ void eWidgetDesktop::setPalette(gPixmap &pm)
 	}
 }
 
-void eWidgetDesktop::paintBackground(eWidgetDesktopCompBuffer *comp)
+void eWidgetDesktop::paintBackground(eWidgetDesktopCompBuffer *comp, bool clearDirty)
 {
 	if (!comp)
 		return;
 
-	comp->m_dirty_region &= comp->m_background_region;
+	gRegion background_dirty = comp->m_dirty_region & comp->m_background_region;
 
 	gPainter painter(comp->m_dc);
 
-	painter.resetClip(comp->m_dirty_region);
+	painter.resetClip(background_dirty);
 	painter.setBackgroundColor(comp->m_background_color);
 	painter.clear();
 
-	comp->m_dirty_region = gRegion();
+	if (clearDirty)
+		comp->m_dirty_region = gRegion();
 }
 
 
@@ -301,12 +314,13 @@ void eWidgetDesktop::paintLayer(eWidget *widget, int layer)
 		return;
 	gPainter painter(comp->m_dc);
 	painter.moveOffset(-comp->m_position);
-	if (widget->m_cornerRadius > 0 || widget->m_gradient_set || widget->m_alphaBlend)
-	{
-		painter.resetClip(comp->m_dirty_region);
-		painter.setBackgroundColor(gRGB(0, 0, 0, 0xFF));
-		painter.clear();
-	}
+		/* no pre-clear here: alphablended/gradient/rounded-corner drawing (see
+		   gPixmap::drawRectangle/drawRectangleNew) blends against whatever is
+		   already in the destination, and rounded corners outside the radius
+		   are deliberately left untouched. Both rely on the real content behind
+		   this widget -- the desktop background or another root widget -- having
+		   already been painted there (see paint()); clearing to a fixed color
+		   first would blend/leave that fixed color instead of what's behind. */
 	widget->doPaint(painter, comp->m_dirty_region, layer);
 	painter.resetOffset();
 }
@@ -315,25 +329,43 @@ void eWidgetDesktop::paint()
 {
 	m_require_redraw = 0;
 
-		/* walk all root windows. */
-	for (ePtrList<eWidget>::iterator i(m_root.begin()); i != m_root.end(); ++i)
+	if (m_comp_mode == cmImmediate)
 	{
+			/* paint the true (video) background first: widgets with a transparent,
+			   alphablended, gradient-alphablended or rounded-corner background rely
+			   on whatever is behind them -- the desktop background, or another root
+			   widget -- already being painted, so they can composite on top of it. */
+		paintBackground(&m_screen, false);
 
-		if (!(i->m_vis & eWidget::wVisShow))
-			continue;
+			/* m_root is sorted front-to-back (see addRootWidget). paint it back-to-
+			   front, so widgets further back are painted first and the ones in front
+			   of them (which may be transparent/blended) composite correctly on top,
+			   respecting zPosition. */
+		for (ePtrList<eWidget>::reverse_iterator i(m_root.rbegin()); i != m_root.rend(); ++i)
+		{
+			if (!(i->m_vis & eWidget::wVisShow))
+				continue;
 
-		if (m_comp_mode == cmImmediate)
 			paintLayer(i, 0);
-		else
+		}
+
+		m_screen.m_dirty_region = gRegion();
+	}
+	else
+	{
+			/* walk all root windows. */
+		for (ePtrList<eWidget>::iterator i(m_root.begin()); i != m_root.end(); ++i)
+		{
+			if (!(i->m_vis & eWidget::wVisShow))
+				continue;
+
 			for (int l = 0; l < MAX_LAYER; ++l)
 			{
 				paintLayer(i, l);
 				paintBackground(i->m_comp_buffer[l]);
 			}
+		}
 	}
-
-	if (m_comp_mode == cmImmediate)
-		paintBackground(&m_screen);
 
 	if (m_comp_mode == cmBuffered)
 	{

--- a/lib/gui/ewidgetdesktop.h
+++ b/lib/gui/ewidgetdesktop.h
@@ -80,8 +80,8 @@ public:
 	void setMargins(const eRect& value) { m_margins = value; }
 private:
 	ePtrList<eWidget> m_root;
-	void calcWidgetClipRegion(eWidget *widget, gRegion &parent_visible, bool parent = true);
-	void paintBackground(eWidgetDesktopCompBuffer *comp);
+	void calcWidgetClipRegion(eWidget *widget, gRegion &parent_visible);
+	void paintBackground(eWidgetDesktopCompBuffer *comp, bool clearDirty = true);
 
 	eMainloop *m_mainloop;
 	ePtr<eTimer> m_timer;

--- a/lib/gui/ewindow.cpp
+++ b/lib/gui/ewindow.cpp
@@ -170,3 +170,13 @@ void eWindow::setCornerRadius(int radius, uint8_t edges)
 	eWidget::setCornerRadius(radius, edges);
 	m_child->setCornerRadius(radius, edges);
 }
+
+void eWindow::setWidgetAlphaBlend(bool blend)
+{
+	/* set alphablend for child, too -- the window itself only ever paints its
+	   border/title decoration (see event(evtPaint)), the actual background is
+	   painted by m_child, so it needs to alphablend as well for a screen-level
+	   alphaBlend skin attribute to have any visible effect. */
+	eWidget::setWidgetAlphaBlend(blend);
+	m_child->setWidgetAlphaBlend(blend);
+}

--- a/lib/gui/ewindow.h
+++ b/lib/gui/ewindow.h
@@ -25,6 +25,7 @@ public:
 	void setBackgroundColor(const gRGB &col) override;
 	void setBackgroundGradient(const gRGB &startcolor, const gRGB &midcolor, const gRGB &endcolor, uint8_t direction, bool alphablend);
 	void setCornerRadius(int radius, uint8_t edges);
+	void setWidgetAlphaBlend(bool blend) override;
 
 	void setFlag(int flags);
 	void clearFlag(int flags);


### PR DESCRIPTION
This pull request refactors and improves the painting and compositing logic for root widgets and their children in the GUI system. The main focus is on ensuring correct compositing order, handling of transparency, alpha blending, gradients, and rounded corners, and improving clarity and maintainability. The changes also update method signatures and add documentation to clarify behavior.

**Painting and compositing improvements:**

* Changed the root widget list (`m_root`) to always be sorted front-to-back in immediate mode and back-to-front in buffered mode, ensuring correct z-ordering and compositing. The insertion logic now uses `<=` to make sure newly added widgets with the same z-position appear on top.
* Updated the painting routine in `eWidgetDesktop::paint()` to paint the background first and then root widgets back-to-front in immediate mode, ensuring that transparent, blended, or rounded widgets composite correctly on top of what is behind them.
* Removed unnecessary pre-clearing of the drawing area for widgets with alpha blending, gradients, or rounded corners, so they blend against the actual content behind them as intended.

**Clip region and visibility calculation:**

* Simplified `calcWidgetClipRegion` by removing the `parent` parameter and clarifying the logic for when a widget should subtract its region from the parent's visible region. Now, regions are only subtracted for fully opaque, non-gradient, non-alphablended, and non-rounded widgets. [[1]](diffhunk://#diff-5ff4382cbf88c1bf99834d6b08245cd92dd28f87104a85af8fc0e3d5b9513819L62-R69) [[2]](diffhunk://#diff-5ff4382cbf88c1bf99834d6b08245cd92dd28f87104a85af8fc0e3d5b9513819L71-R84) [[3]](diffhunk://#diff-5ff4382cbf88c1bf99834d6b08245cd92dd28f87104a85af8fc0e3d5b9513819L90-R102)

**API and maintainability improvements:**

* Updated method signatures in `eWidgetDesktop` and `eWindow` to reflect the new logic and added documentation for clarity. Added `setWidgetAlphaBlend` to `eWindow` to ensure both the window and its child use the correct alpha blending setting. [[1]](diffhunk://#diff-48fd35ad4bc600fabcad1123b8151d387dbd3a9edfbed29226b9f66b2b4ab15fL83-R84) [[2]](diffhunk://#diff-6b7e1207ac1044c132594149c55030a047f5e9f20b76e5116a6225640e436e6aR173-R182) [[3]](diffhunk://#diff-5f25a9f80fd0f0b1132786d7246f3d1a7f72af9320905c898f0009e31e2d1609R28)