### PR TITLE
[elistbox] enhance selection movement with wrap-around functionality

### DIFF
--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -297,30 +297,31 @@ void eListbox::moveSelection(long dir)
 				}
 				else
 				{
+					// Move left within the current row, wrapping to the row's last column if enabled
+					int rowStart = oldsel - oldColumn;
+					int rowEnd = rowStart + m_max_columns - 1;
+					if (rowEnd > m_content->size() - 1)
+						rowEnd = m_content->size() - 1;
 					int current = oldsel;
-					bool isFirstInRow = current % m_max_columns == 0;
-					
+
 					do
 					{
-						if (isFirstInRow) break;
-						m_content->cursorMove(-1);
-						newsel = m_content->cursorGet();
-						if (newsel == prevsel) {  // cursorMove reached top and left cursor position the same. Must wrap around ?
-							if (m_enabled_wrap_around)
+						--current;
+						if (current < rowStart)
+						{
+							if (!m_enabled_wrap_around)
 							{
-								m_content->cursorEnd();
-								m_content->cursorMove(-1);
-								newsel = m_content->cursorGet();
-							}
-							else
-							{
-								m_content->cursorSet(oldsel);
+								current = oldsel;
+								m_content->cursorSet(current);
 								break;
 							}
+							current = rowEnd;
 						}
-						prevsel = newsel;
+						m_content->cursorSet(current);
 					}
-					while (newsel != oldsel && !m_content->currentCursorSelectable());
+					while (current != oldsel && !m_content->currentCursorSelectable());
+
+					newsel = m_content->cursorGet();
 				}
 			}
 			else
@@ -434,23 +435,31 @@ void eListbox::moveSelection(long dir)
 				}
 				else
 				{
+					// Move right within the current row, wrapping to the row's first column if enabled
+					int rowStart = oldsel - oldColumn;
+					int rowEnd = rowStart + m_max_columns - 1;
+					if (rowEnd > m_content->size() - 1)
+						rowEnd = m_content->size() - 1;
 					int current = oldsel;
+
 					do
 					{
-						current += 1;
-						bool isLastColumn = (current % m_max_columns) == 0;
-						if (isLastColumn)
-							break;
-						m_content->cursorMove(1);
-						if (!m_content->cursorValid()) { //cursorMove reached end and left cursor position past the list. Must wrap around ?
-							if (m_enabled_wrap_around)
-								m_content->cursorHome();
-							else
-								m_content->cursorSet(oldsel);
+						++current;
+						if (current > rowEnd)
+						{
+							if (!m_enabled_wrap_around)
+							{
+								current = oldsel;
+								m_content->cursorSet(current);
+								break;
+							}
+							current = rowStart;
 						}
-						newsel = m_content->cursorGet();
+						m_content->cursorSet(current);
 					}
-					while (newsel != oldsel && !m_content->currentCursorSelectable());
+					while (current != oldsel && !m_content->currentCursorSelectable());
+
+					newsel = m_content->cursorGet();
 				}
 
 			}
@@ -472,6 +481,19 @@ void eListbox::moveSelection(long dir)
 			break;
 		case pageUp:
 		case prevPage: {
+			if (m_enabled_wrap_around && oldsel < m_items_per_page)
+			{
+				// already on the first page, wrap around to the last selectable entry
+				m_content->cursorEnd();
+				m_content->cursorMove(-1);
+				newsel = m_content->cursorGet();
+				while (newsel != oldsel && !m_content->currentCursorSelectable())
+				{
+					m_content->cursorMove(-1);
+					newsel = m_content->cursorGet();
+				}
+				break;
+			}
 			int pageind;
 			do
 			{
@@ -512,6 +534,18 @@ void eListbox::moveSelection(long dir)
 		}
 		case pageDown:
 		case nextPage: {
+			if (m_enabled_wrap_around && oldsel >= ((m_content->size() - 1) / m_items_per_page) * m_items_per_page)
+			{
+				// already on the last page, wrap around to the first selectable entry
+				m_content->cursorHome();
+				newsel = m_content->cursorGet();
+				while (newsel != oldsel && !m_content->currentCursorSelectable())
+				{
+					m_content->cursorMove(1);
+					newsel = m_content->cursorGet();
+				}
+				break;
+			}
 			int pageind;
 			do
 			{


### PR DESCRIPTION
This pull request refactors and improves the navigation logic in the `eListbox::moveSelection` method, especially for multi-column listboxes. The main changes enhance the behavior of left/right movement within rows and add wrap-around support for page up/down navigation, ensuring a more intuitive and robust user experience.

Navigation improvements within rows:
* Improved left movement logic to properly wrap to the last column of the current row when wrap-around is enabled, and to handle non-selectable items more reliably (`lib/gui/elistbox.cpp`).
* Improved right movement logic to wrap to the first column of the current row when wrap-around is enabled, with consistent handling of non-selectable items (`lib/gui/elistbox.cpp`).

Wrap-around support for page navigation:
* Added support for wrapping from the first page to the last page when pressing Page Up or Prev Page, moving to the last selectable entry if wrap-around is enabled (`lib/gui/elistbox.cpp`).
* Added support for wrapping from the last page to the first page when pressing Page Down or Next Page, moving to the first selectable entry if wrap-around is enabled (`lib/gui/elistbox.cpp`).