### PR TITLE
[elistbox] ensure content is always painted to clear stale pixels

### DIFF
--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -948,10 +948,9 @@ int eListbox::event(int event, void *data, void *data2)
 					gRegion entry_clip_rect = paint_region & entryrect;
 					if (!entry_clip_rect.empty())
 					{
-						if (m_content->cursorValid())
-						{
-							m_content->paint(painter, *style, ePoint(posx, posy), m_selected == m_content->cursorGet() && m_content->size() && m_selection_enabled);
-						}
+						// always paint, even for out-of-range cursors (e.g. a ragged last row),
+						// so the content clears stale/selected pixels left over from a previous entry
+						m_content->paint(painter, *style, ePoint(posx, posy), m_selected == m_content->cursorGet() && m_content->size() && m_selection_enabled);
 					}
 					m_content->cursorMove(+1);
 				}


### PR DESCRIPTION
This pull request makes a small but important change to the `eListbox` painting logic in `elistbox.cpp`. The update ensures that the listbox always paints entries, even if the cursor is out of range, which helps prevent stale or selected pixels from being left over when the content changes.

- **Painting logic improvement:**
  * The conditional check for a valid cursor was removed, so `m_content->paint()` is now always called for visible entries, ensuring that stale or selected pixels are cleared properly.