### PR TITLE
[elistbox] fix wrap-around logic for selection movement at boundaries

### DIFF
--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -481,9 +481,9 @@ void eListbox::moveSelection(long dir)
 			break;
 		case pageUp:
 		case prevPage: {
-			if (m_enabled_wrap_around && oldsel < m_items_per_page)
+			if (m_enabled_wrap_around && oldsel == 0)
 			{
-				// already on the first page, wrap around to the last selectable entry
+				// already at the first entry, wrap around to the last selectable entry
 				m_content->cursorEnd();
 				m_content->cursorMove(-1);
 				newsel = m_content->cursorGet();
@@ -534,9 +534,9 @@ void eListbox::moveSelection(long dir)
 		}
 		case pageDown:
 		case nextPage: {
-			if (m_enabled_wrap_around && oldsel >= ((m_content->size() - 1) / m_items_per_page) * m_items_per_page)
+			if (m_enabled_wrap_around && oldsel == m_content->size() - 1)
 			{
-				// already on the last page, wrap around to the first selectable entry
+				// already at the last entry, wrap around to the first selectable entry
 				m_content->cursorHome();
 				newsel = m_content->cursorGet();
 				while (newsel != oldsel && !m_content->currentCursorSelectable())

--- a/lib/gui/elistbox.cpp
+++ b/lib/gui/elistbox.cpp
@@ -481,7 +481,7 @@ void eListbox::moveSelection(long dir)
 			break;
 		case pageUp:
 		case prevPage: {
-			if (m_enabled_wrap_around && oldsel == 0)
+			if (m_orientation == orHorizontal && m_enabled_wrap_around && oldsel == 0)
 			{
 				// already at the first entry, wrap around to the last selectable entry
 				m_content->cursorEnd();
@@ -534,7 +534,7 @@ void eListbox::moveSelection(long dir)
 		}
 		case pageDown:
 		case nextPage: {
-			if (m_enabled_wrap_around && oldsel == m_content->size() - 1)
+			if (m_orientation == orHorizontal && m_enabled_wrap_around && oldsel == m_content->size() - 1)
 			{
 				// already at the last entry, wrap around to the first selectable entry
 				m_content->cursorHome();


### PR DESCRIPTION
This pull request updates the selection wrap-around logic in the `eListbox` component to improve accuracy and user experience when navigating between pages. The conditions for wrapping around at the beginning and end of the list have been refined to trigger only when the selection is at the very first or last entry, rather than at the start or end of a page.

**Selection wrap-around logic improvements:**

* In `eListbox::moveSelection`, the wrap-around when moving up (`pageUp`/`prevPage`) now only occurs if the selection is at the very first entry, instead of anywhere on the first page.
* Similarly, the wrap-around when moving down (`pageDown`/`nextPage`) now only occurs if the selection is at the very last entry, instead of anywhere on the last page.