### PR TITLE
Refine UI rendering, alpha blending, and improve performance

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -513,7 +513,7 @@ if test "$BOXTYPE" == "dm900" -o "$BOXTYPE" == "dm920"; then
 	AC_DEFINE(HAVE_HDMIIN_DM, 1,[has hdmi in dm])
 	AC_DEFINE(LCD_DM900_Y_OFFSET, 4,[define LCD Y offset for dm900 and dm920])
 	AC_DEFINE(DREAMBOX_DUAL_TUNER, 1,[define it is dreambox dual tuner present])
-	AC_DEFINE(FORCE_NO_BLENDING_ACCELERATION, 1,[define when the framebuffer acceleration does not have alphablending support, though the autodetection might indicate that it does])
+	AC_DEFINE(FORCE_ALPHABLENDING_ACCELERATION, 1,[define when the framebuffer acceleration has alphablending support, but detection slow down all])
 fi
 
 if test "$BOXTYPE" == "dm900"; then

--- a/lib/gdi/bcm.cpp
+++ b/lib/gdi/bcm.cpp
@@ -49,6 +49,11 @@ int bcm_accel_init(void)
 	/* hardware doesn't allow us to detect whether the opcode is working */
 	supportblendingflags = false;
 #endif
+#ifdef FORCE_ALPHABLENDING_ACCELERATION
+	/* the probe above doesn't get a reply from this driver even though
+	 * blending is known to work, so trust it instead of the probe */
+	supportblendingflags = true;
+#endif
 	return 0;
 }
 
@@ -177,7 +182,20 @@ void bcm_accel_blit(
 
 	C(0x77);  // do it
 
-	if (!accumulateoperations) exec_list();
+	if (!accumulateoperations && exec_list() && supportblendingflags && flags)
+	{
+		/* the driver rejected the list with the blend opcode included; disable
+		 * hw alphablending from now on and redraw this blit without it, so we
+		 * don't leave a blank/stale area on screen for a blit the driver refused */
+		eDebug("[bcm] blit with blend flags failed, disabling hw alphablending");
+		supportblendingflags = false;
+		bcm_accel_blit(
+				src_addr, src_width, src_height, src_stride, src_format,
+				dst_addr, dst_width, dst_height, dst_stride,
+				src_x, src_y, width, height,
+				dst_x, dst_y, dwidth, dheight,
+				pal_addr, 0);
+	}
 }
 
 void bcm_accel_fill(

--- a/lib/gdi/font.cpp
+++ b/lib/gdi/font.cpp
@@ -1220,7 +1220,19 @@ void eTextPara::blit(gDC &dc, const ePoint &offset, const gRGB &cbackground, con
 							{
 								int b=(*s++)>>4;
 								if(b)
-									*td=lookup32[b];
+									/* lookup32[b]'s own alpha byte is only a coverage-interpolated
+									   blend towards this text's *nominal* background alpha -- useful
+									   for smoothing the RGB colour, but not a truthful "what's really
+									   behind this pixel" value. Stamping it verbatim leaves a glyph-
+									   shaped, coverage-dependent alpha footprint in the framebuffer
+									   (near-transparent at AA edges) for what is otherwise a normal,
+									   final, fully-painted pixel. Any later alphablended/rounded-corner
+									   widget that composites on top of this (see the opcode 4 "blend"
+									   case below) reads that leftover footprint back as if it were the
+									   real backdrop, so unrelated text ends up ghosted with the shape
+									   of whatever ordinary text was drawn here before it. Force full
+									   opacity here instead, keeping only the blended RGB. */
+									*td=lookup32[b] | 0xFF000000;
 								++td;
 							}
 							s += extra_source_stride;
@@ -1240,7 +1252,7 @@ void eTextPara::blit(gDC &dc, const ePoint &offset, const gRGB &cbackground, con
 								int b = (*s++) >> 4;
 								if (b)
 								{
-									// unsigned char frame_a = (*td) >> 24 & 0xFF;
+									unsigned char frame_a = (*td) >> 24 & 0xFF;
 									unsigned char frame_r = (*td) >> 16 & 0xFF;
 									unsigned char frame_g = (*td) >> 8 & 0xFF;
 									unsigned char frame_b = (*td) & 0xFF;
@@ -1251,11 +1263,19 @@ void eTextPara::blit(gDC &dc, const ePoint &offset, const gRGB &cbackground, con
 									unsigned char db = lookup32[b] & 0xFF;
 
 #define BLEND(y, x, a) (y + (((x-y) * a)>>8))
+									/* blend the output alpha the same way the color channels are blended,
+									   from whatever is already at the destination towards the glyph's own
+									   ink alpha -- otherwise a fully-opaque foreground color (alpha 0, see
+									   gRGB) turns into a fully-transparent stored alpha (0xFF) at every
+									   pixel the glyph touches, making the text vanish against anything that
+									   composites using that alpha channel (e.g. an alpha-blended layer
+									   painted on top of another one). */
+									frame_a = BLEND(frame_a, (unsigned char)(currentforeground.a ^ 0xFF), da) & 0xFF;
 									frame_r = BLEND(frame_r, dr, da) & 0xFF;
 									frame_g = BLEND(frame_g, dg, da) & 0xFF;
 									frame_b = BLEND(frame_b, db, da) & 0xFF;
 #undef BLEND
-									*td = ((currentforeground.a ^ 0xFF) << 24) | (frame_r << 16) | (frame_g << 8) | frame_b;
+									*td = (frame_a << 24) | (frame_r << 16) | (frame_g << 8) | frame_b;
 								}
 								++td;
 							}

--- a/lib/gdi/gpixmap.cpp
+++ b/lib/gdi/gpixmap.cpp
@@ -525,21 +525,36 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 			if (r <= 0)
 				return;
 
+				/* clip the r x r bounding box to reg (area intersected with the current
+				   region rect -- see the multi-rect note below) BEFORE running the
+				   expensive per-pixel supersampling below, rather than iterating the
+				   full corner every time and discarding out-of-reg pixels one at a
+				   time -- this function is invoked once per rect of a possibly multi-
+				   rect region (routine once alphablended/rounded siblings overlap,
+				   since they don't get subtracted out of each other's visible regions),
+				   so without this a busy region could redo the full O(r^2 * samples^2)
+				   corner sampling several times over per repaint for corners that a
+				   given rect doesn't even touch. */
+			int yStart = std::max(0, reg.top() - cy);
+			int yEnd = std::min(r, reg.bottom() - cy);
+			int xStart = std::max(0, reg.left() - cx);
+			int xEnd = std::min(r, reg.right() - cx);
+			if (yStart >= yEnd || xStart >= xEnd)
+				return;
+
 			const int samples = 4;
 			const int r2 = r * r;
 			const int innerR = r - borderWidth;
 			const int innerR2 = innerR * innerR;
 			const double invSamples = 1.0 / (samples * samples);
 
-			for (int y = 0; y < r; ++y) {
-				for (int x = 0; x < r; ++x) {
+			for (int y = yStart; y < yEnd; ++y) {
+				for (int x = xStart; x < xEnd; ++x) {
 					int dx = left ? r - x - 1 : x;
 					int dy = top ? r - y - 1 : y;
 
 					int px = cx + x;
 					int py = cy + y;
-					if (px < area.left() || px >= area.right() || py < area.top() || py >= area.bottom())
-						continue;
 
 					uint32_t* dst = (uint32_t*)((uint8_t*)surface->data + py * surface->stride + px * surface->bypp);
 
@@ -582,12 +597,19 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 			drawCorner(area.right() - brr, area.bottom() - brr, brr, false, false);
 
 		// Borders
+			/* every block below intersects its rows/columns with reg (this iteration's
+			   piece of the region), for the same reason as the corner bound check above:
+			   without it, a multi-rect region would re-blend the same pixels once per rect. */
 		if (borderWidth > 0) {
 			// Top Border
 			for (int y = 0; y < borderWidth; ++y) {
 				int py = area.top() + y;
+				if (py < reg.top() || py >= reg.bottom())
+					continue;
 				int x_start = (tlr > 0) ? area.left() + tlr : area.left();
 				int x_end = (trr > 0) ? area.right() - trr : area.right();
+				x_start = std::max(x_start, reg.left());
+				x_end = std::min(x_end, reg.right());
 				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + py * surface->stride + x_start * surface->bypp);
 				for (int x = x_start; x < x_end; ++x, ++dst)
 					dst->alpha_blend(gRGB(borderCol));
@@ -596,8 +618,12 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 			// Bottom Border
 			for (int y = 0; y < borderWidth; ++y) {
 				int py = area.bottom() - 1 - y;
+				if (py < reg.top() || py >= reg.bottom())
+					continue;
 				int x_start = (blr > 0) ? area.left() + blr : area.left();
 				int x_end = (brr > 0) ? area.right() - brr : area.right();
+				x_start = std::max(x_start, reg.left());
+				x_end = std::min(x_end, reg.right());
 				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + py * surface->stride + x_start * surface->bypp);
 				for (int x = x_start; x < x_end; ++x, ++dst)
 					dst->alpha_blend(gRGB(borderCol));
@@ -606,8 +632,12 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 			// Left Border
 			for (int x = 0; x < borderWidth; ++x) {
 				int px = area.left() + x;
+				if (px < reg.left() || px >= reg.right())
+					continue;
 				int y_start = (tlr > 0) ? area.top() + tlr : area.top();
 				int y_end = (blr > 0) ? area.bottom() - blr : area.bottom();
+				y_start = std::max(y_start, reg.top());
+				y_end = std::min(y_end, reg.bottom());
 				for (int y = y_start; y < y_end; ++y) {
 					gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + px * surface->bypp);
 					dst->alpha_blend(gRGB(borderCol));
@@ -617,8 +647,12 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 			// Right Border
 			for (int x = 0; x < borderWidth; ++x) {
 				int px = area.right() - 1 - x;
+				if (px < reg.left() || px >= reg.right())
+					continue;
 				int y_start = (trr > 0) ? area.top() + trr : area.top();
 				int y_end = (brr > 0) ? area.bottom() - brr : area.bottom();
+				y_start = std::max(y_start, reg.top());
+				y_end = std::min(y_end, reg.bottom());
 				for (int y = y_start; y < y_end; ++y) {
 					gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + px * surface->bypp);
 					dst->alpha_blend(gRGB(borderCol));
@@ -627,6 +661,8 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 		}
 
 		// Top-Fill
+			/* same reg intersection as the borders above -- keep this iteration's fill
+			   confined to its piece of the region so a multi-rect region doesn't re-blend it. */
 		{
 			int y0 = area.top() + borderWidth;
 			int y1 = area.top() + ((tlr > 0 || trr > 0) ? std::max(tlr, trr) : borderWidth);
@@ -638,6 +674,11 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 			int x_end = area.right() - borderWidth;
 			if (trr > 0)
 				x_end = std::max(x_end - trr, area.right() - trr);
+
+			y0 = std::max(y0, reg.top());
+			y1 = std::min(y1, reg.bottom());
+			x_start = std::max(x_start, reg.left());
+			x_end = std::min(x_end, reg.right());
 
 			for (int y = y0; y < y1; ++y) {
 				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + x_start * surface->bypp);
@@ -660,6 +701,11 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 			if (brr > 0)
 				x_end = std::max(x_end - brr, area.right() - brr);
 
+			y0 = std::max(y0, reg.top());
+			y1 = std::min(y1, reg.bottom());
+			x_start = std::max(x_start, reg.left());
+			x_end = std::min(x_end, reg.right());
+
 			for (int y = y0; y < y1; ++y) {
 				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + x_start * surface->bypp);
 				for (int x = x_start; x < x_end; ++x, ++dst)
@@ -671,10 +717,17 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 		{
 			int y0 = area.top() + ((tlr || trr) ? std::max(tlr, trr) : borderWidth);
 			int y1 = area.bottom() - ((blr || brr) ? std::max(blr, brr) : borderWidth);
+			int x_start = area.left() + borderWidth;
+			int x_end = area.right() - borderWidth;
+
+			y0 = std::max(y0, reg.top());
+			y1 = std::min(y1, reg.bottom());
+			x_start = std::max(x_start, reg.left());
+			x_end = std::min(x_end, reg.right());
 
 			for (int y = y0; y < y1; ++y) {
-				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + (area.left() + borderWidth) * surface->bypp);
-				for (int x = area.left() + borderWidth; x < area.right() - borderWidth; ++x, ++dst)
+				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + x_start * surface->bypp);
+				for (int x = x_start; x < x_end; ++x, ++dst)
 					dst->alpha_blend(gRGB(fillCol));
 			}
 		}

--- a/lib/gui/elabel.cpp
+++ b/lib/gui/elabel.cpp
@@ -110,7 +110,17 @@ int eLabel::event(int event, void *data, void *data2)
 			if (!m_nowrap)
 				flags |= gPainter::RT_WRAP;
 
-			if (isGradientSet() || m_blend)
+				/* text needs to blend against the real pixels behind it -- not just the
+				   widget's own nominal background color -- whenever that nominal color
+				   doesn't represent the true backdrop: a gradient, an alphablended
+				   background, rounded corners (which show whatever's behind them outside
+				   the radius), or a configured background color that itself carries any
+				   transparency (see needsBlendCompositing). Otherwise glyph anti-aliasing
+				   gets baked in assuming a flat background that isn't actually there, and
+				   the text ends up dimmed or partially/fully transparent depending on how
+				   much AA coverage each pixel has. See eWidgetDesktop::calcWidgetClipRegion
+				   for the matching condition on the compositing side. */
+			if (m_blend || needsBlendCompositing())
 				flags |= gPainter::RT_BLEND;
 
 				/* if we don't have shadow, m_shadow_offset will be 0,0 */

--- a/lib/gui/elistboxcontent.cpp
+++ b/lib/gui/elistboxcontent.cpp
@@ -238,10 +238,12 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 		else if (local_style && !local_style->m_background && cursorValid && (local_style->m_gradient_set[0] || radius))
 		{
 			if (local_style->m_gradient_set[0])
-			{
-				alphablendtext = local_style->m_gradient_set[0];
 				painter.setGradient(local_style->m_gradient_colors[0], local_style->m_gradient_direction[0], local_style->m_gradient_alphablend[0]);
-			}
+
+				/* rounded corners show whatever's behind them outside the radius, same as a
+				   gradient background doesn't match the text's assumed flat background -- so
+				   the text needs to blend against the real pixels behind it in both cases. */
+			alphablendtext = local_style->m_gradient_set[0] || radius;
 
 			if(radius)
 				painter.setRadius(radius, edges);
@@ -290,10 +292,11 @@ void eListboxPythonStringContent::paint(gPainter &painter, eWindowStyle &style, 
 		}
 		else if (selected && local_style && (local_style->m_gradient_set[1] || radius) && !local_style->m_selection) {
 			if (local_style->m_gradient_set[1])
-			{
-				alphablendtext = local_style->m_gradient_set[1];
 				painter.setGradient(local_style->m_gradient_colors[1], local_style->m_gradient_direction[1], local_style->m_gradient_alphablend[1]);
-			}
+
+				/* see the matching comment above: rounded corners need the text to blend
+				   against the real backdrop just as much as a gradient background does. */
+			alphablendtext = local_style->m_gradient_set[1] || radius;
 
 			if(radius)
 				painter.setRadius(radius, edges);
@@ -490,10 +493,12 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 		else if (local_style && !local_style->m_background && cursorValid && (local_style->m_gradient_set[0] || radius))
 		{
 			if (local_style->m_gradient_set[0])
-			{
-				alphablendtext = local_style->m_gradient_set[0];
 				painter.setGradient(local_style->m_gradient_colors[0], local_style->m_gradient_direction[0], local_style->m_gradient_alphablend[0]);
-			}
+
+				/* rounded corners show whatever's behind them outside the radius, same as a
+				   gradient background doesn't match the text's assumed flat background -- so
+				   the text needs to blend against the real pixels behind it in both cases. */
+			alphablendtext = local_style->m_gradient_set[0] || radius;
 
 			if(radius)
 				painter.setRadius(radius, edges);
@@ -520,7 +525,6 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 
 	if (m_list && cursorValid)
 	{
-		int alphablendflag = (alphablendtext) ? gPainter::RT_BLEND : 0;
 			/* get current list item */
 		ePyObject item = PyList_GET_ITEM(m_list, m_cursor); // borrowed reference!
 		ePyObject text, value;
@@ -533,15 +537,20 @@ void eListboxPythonConfigContent::paint(gPainter &painter, eWindowStyle &style, 
 				painter.blit(local_style->m_selection, ePoint(offset.x() + (m_itemsize.width() - local_style->m_selection->size().width()) / 2, offset.y()), eRect(), gPainter::BT_ALPHATEST);
 		} else if (selected && (local_style->m_gradient_set[1] || radius) && !local_style->m_selection) {
 			if (local_style->m_gradient_set[1])
-			{
-				alphablendtext = local_style->m_gradient_set[1];
 				painter.setGradient(local_style->m_gradient_colors[1], local_style->m_gradient_direction[1], local_style->m_gradient_alphablend[1]);
-			}
+
+				/* see the matching comment above: rounded corners need the text to blend
+				   against the real backdrop just as much as a gradient background does. */
+			alphablendtext = local_style->m_gradient_set[1] || radius;
 
 			if(radius)
 				painter.setRadius(radius, edges);
 			painter.drawRectangle(itemrect);
 		}
+
+			/* computed after both background blocks above, since either one may have
+			   just turned blending on for this item (gradient or rounded corners). */
+		int alphablendflag = (alphablendtext) ? gPainter::RT_BLEND : 0;
 			/* the first tuple element is a string for the left side.
 			   the second one will be called, and the result shall be an tuple.
 

--- a/lib/gui/ewidget.cpp
+++ b/lib/gui/ewidget.cpp
@@ -247,10 +247,20 @@ void eWidget::setBackgroundColor(const gRGB &col)
 void eWidget::setZPosition(int z)
 {
 	m_z_position = z;
-	if (!m_parent)
+	if (m_parent)
+	{
+		m_parent->m_childs.remove(this);
+		insertIntoParent(); /* now at the new Z position */
 		return;
-	m_parent->m_childs.remove(this);
-	insertIntoParent(); /* now at the new Z position */
+	}
+		/* a root widget (a window: no m_parent) isn't stacked via m_parent->m_childs
+		   at all -- its stacking order lives in eWidgetDesktop::m_root instead, so it
+		   needs repositioning there. Without this, changing a shown window's zPosition
+		   (skin attribute, or raise()/lower()) updated m_z_position but left the
+		   window painted in whatever position it happened to land in m_root when it
+		   was first added, silently breaking front/behind order against other windows. */
+	if (m_desktop)
+		m_desktop->repositionRootWidget(this);
 }
 
 void eWidget::setTransparent(int transp)

--- a/lib/gui/ewidget.h
+++ b/lib/gui/ewidget.h
@@ -79,6 +79,16 @@ public:
 
 	int isTransparent() { return m_vis & wVisTransparent; }
 
+		/* true whenever this widget's painted output isn't a flat, fully opaque
+		   fill of its own area -- i.e. whenever it must be composited against
+		   whatever is actually behind it rather than against its own nominal
+		   background. Mirrors the condition eWidgetDesktop::calcWidgetClipRegion
+		   uses to decide whether the area behind this widget must stay available
+		   for painting, plus the widget's own background color carrying any
+		   transparency (which doesn't affect occlusion of siblings, but still
+		   means content drawn on top -- e.g. text -- must blend). */
+	bool needsBlendCompositing() { return isTransparent() || m_alphaBlend || m_gradient_alphablend || m_cornerRadius != 0 || (m_have_background_color && m_background_color.a != 0); }
+
 	ePoint getAbsolutePosition();
 
 	eWidgetAnimation m_animation;

--- a/lib/gui/ewidgetdesktop.cpp
+++ b/lib/gui/ewidgetdesktop.cpp
@@ -5,10 +5,8 @@
 
 extern void dumpRegion(const gRegion &region);
 
-void eWidgetDesktop::addRootWidget(eWidget *root)
+void eWidgetDesktop::insertRootWidgetSorted(eWidget *root)
 {
-	ASSERT(!root->m_desktop);
-
 	int invert_sense = 0;
 		/* m_root is always kept sorted front-to-back in immediate mode (used for
 		   clip region calculation, front to back), and back-to-front in buffered
@@ -32,12 +30,37 @@ void eWidgetDesktop::addRootWidget(eWidget *root)
 		}
 		++insert_position;
 	}
+}
+
+void eWidgetDesktop::addRootWidget(eWidget *root)
+{
+	ASSERT(!root->m_desktop);
+
+	insertRootWidgetSorted(root);
 
 	root->m_desktop = this;
 
 		/* the creation will be postponed. */
 	for (int i = 0; i < MAX_LAYER; ++i)
 		root->m_comp_buffer[i] = 0;
+}
+
+void eWidgetDesktop::repositionRootWidget(eWidget *root)
+{
+		/* called when a root widget's (a window's) own zPosition changes after it
+		   was already added -- e.g. via the skin's zPosition attribute, or
+		   raise()/lower() -- to re-sort it within m_root to match. Without this,
+		   eWidget::setZPosition() would update root->m_z_position but m_root's
+		   actual list order (which is what both occlusion in calcWidgetClipRegion
+		   and paint order in paint() go by, not m_z_position directly) would stay
+		   exactly where the widget happened to land when it was first added,
+		   silently drawing it in front of or behind windows it no longer belongs
+		   in front of or behind. */
+	m_root.remove(root);
+	insertRootWidgetSorted(root);
+
+	if (m_comp_mode == cmImmediate)
+		recalcClipRegions(root);
 }
 
 void eWidgetDesktop::removeRootWidget(eWidget *root)
@@ -49,6 +72,24 @@ void eWidgetDesktop::removeRootWidget(eWidget *root)
 	}
 
 	m_root.remove(root);
+
+		/* the removed widget may have been occluding other root widgets (or the
+		   desktop background) behind it. recalcClipRegions, in immediate mode,
+		   unconditionally recomputes every remaining root widget's visible
+		   region from scratch and invalidates whatever changed (see its body) --
+		   since root is already gone from m_root, this naturally picks up
+		   whatever is now newly visible where root used to be and repaints it,
+		   through the correct layering, all the way down to the desktop
+		   background if nothing else was behind it. This mirrors what
+		   eWidget::hide() already does for a widget that stays alive; here it
+		   also covers the case where a root widget/window is destroyed while
+		   still shown, without hide() having run first. Harmless (and cheap) to
+		   run again if hide() already did run: nothing will have changed since,
+		   so every diff computed below will be empty. root is only passed
+		   through, unused by the immediate-mode path, so it's fine to pass a
+		   widget that's no longer in m_root (or mid-destruction). */
+	if (m_comp_mode == cmImmediate)
+		recalcClipRegions(root);
 }
 
 int eWidgetDesktop::movedWidget(eWidget *root)

--- a/lib/gui/ewidgetdesktop.h
+++ b/lib/gui/ewidgetdesktop.h
@@ -35,6 +35,7 @@ public:
 	~eWidgetDesktop();
 	void addRootWidget(eWidget *root);
 	void removeRootWidget(eWidget *root);
+	void repositionRootWidget(eWidget *root);
 
 		/* try to move widget content. */
 		/* returns -1 if there's no move support. */
@@ -80,6 +81,7 @@ public:
 	void setMargins(const eRect& value) { m_margins = value; }
 private:
 	ePtrList<eWidget> m_root;
+	void insertRootWidgetSorted(eWidget *root);
 	void calcWidgetClipRegion(eWidget *widget, gRegion &parent_visible);
 	void paintBackground(eWidgetDesktopCompBuffer *comp, bool clearDirty = true);
 

--- a/lib/gui/ewindowstyleskinned.cpp
+++ b/lib/gui/ewindowstyleskinned.cpp
@@ -156,7 +156,7 @@ void eWindowStyleSkinned::drawBorder(gPainter &painter, const eRect &pos, struct
 	if (br)
 	{
 		xm -= br->size().width();
-		painter.blit(br, ePoint(xm, pos.bottom()-br->size().height()), eRect(x, pos.bottom()-br->size().height(), pos.width() - x, bl->size().height()), flags);
+		painter.blit(br, ePoint(xm, pos.bottom()-br->size().height()), eRect(x, pos.bottom()-br->size().height(), pos.width() - x, br->size().height()), flags);
 	}
 
 	if (b)

--- a/lib/python/Components/EpgListGrid.py
+++ b/lib/python/Components/EpgListGrid.py
@@ -34,6 +34,14 @@ class EPGListGrid(EPGListBase):
 		self.selectedService = None
 		self.selectionRect = None
 		self.eventRect = None
+		# Per-event data (timer/matchType/icons/geometry) that buildEntry needs but that
+		# doesn't depend on WHICH event is currently selected -- keyed by service, and
+		# valid only as long as the cached entry's events list is the same object as the
+		# row's current events list. Horizontal (event-to-event) navigation rebuilds the
+		# whole row via invalidateEntry() on every keypress, so without this cache all of
+		# that gets recomputed from scratch every keypress even though it's unchanged.
+		# Reset in fillEPGNoRefresh() whenever the underlying data can actually change.
+		self.eventStaticCache = {}
 		self.serviceRect = None
 
 		self.nowEvPix = None
@@ -429,12 +437,20 @@ class EPGListGrid(EPGListBase):
 
 			if titleItem == "servicenumber":
 				if not isinstance(channel, int):
+					# Go find the channel number and cache it, same as picon above --
+					# getChannelNumber() is a native lookup and channel doesn't change
+					# between rebuilds of this row (e.g. on every horizontal event nav).
 					channel = self.getChannelNumber(channel)
+					curIdx = self.l.getCurrentSelectionIndex()
+					self.list[curIdx] = (service, serviceName, events, picon, channel)
 				namefont = 0
 				namefontflag = int(config.epgselection.grid.servicenumber_alignment.value)
-				font = gFont(self.serviceFontName, self.serviceFontSize + self.epgConfig.servfs.value)
-				channelWidth = getTextBoundarySize(self.instance, font, self.instance.size(),
-					"0000" if channel < 10000 else str(channel)).width()
+				if channel < 10000:
+					# Already measured once for the common (<=4 digit) case in setFontsize().
+					channelWidth = self.serviceNumberWidth
+				else:
+					font = gFont(self.serviceFontName, self.serviceFontSize + self.epgConfig.servfs.value)
+					channelWidth = getTextBoundarySize(self.instance, font, self.instance.size(), str(channel)).width()
 				if channel:
 					res.append(MultiContentEntryText(
 						pos=(colX + self.serviceNumberPadding, r1.top() + self.serviceBorderWidth),
@@ -528,25 +544,49 @@ class EPGListGrid(EPGListBase):
 			end = start + self.timeEpochSecs
 
 			now = time()
+			# serviceref/serviceTimers only depend on the service (constant for this whole
+			# row), not on the individual event -- compute them once instead of once per
+			# event, since this loop can run on every horizontal (event-to-event) navigation
+			# as well as on every row build.
+			serviceref = "1" + service[4:] if service[:4] in config.recording.setstreamto1.value and not isPlaylist(service) else service  # converts 4097, 5001, 5002 to 1
+			serviceTimers = self.filteredTimerList.get(':'.join(serviceref.split(':')[:11]))
+
+			# timer/matchType/timerIcon/autoTimerIcon/xpos/ewidth below only depend on the
+			# event itself (plus serviceTimers and the row's selected state, both constant
+			# for this whole row) -- not on which event within the row is currently
+			# highlighted. Horizontal navigation calls buildEntry again on every keypress
+			# purely to move that highlight, so cache these per (service, event) instead of
+			# recomputing them every time; see eventStaticCache in __init__.
+			cacheEntry = self.eventStaticCache.get(service)
+			if cacheEntry is None or cacheEntry[0] is not events or cacheEntry[1] != selected:
+				perEventCache = {}
+				self.eventStaticCache[service] = (events, selected, perEventCache)
+			else:
+				perEventCache = cacheEntry[2]
+
 			for ev in events:  # (eventId, eventTitle, beginTime, duration)
 				stime = ev[2]
 				duration = ev[3]
 
-				xpos, ewidth = self.calcEventPosAndWidthHelper(stime, duration, start, end, width)
-				serviceref = "1" + service[4:] if service[:4] in config.recording.setstreamto1.value and not isPlaylist(service) else service  # converts 4097, 5001, 5002 to 1
-				serviceTimers = self.filteredTimerList.get(':'.join(serviceref.split(':')[:11]))
-				if serviceTimers is not None:
-					# Code below: "+ (20 if config.recording.margin_before.value == 0 else 0)"
-					# When recording-start-margin is zero allow recordings that start up to 20 seconds
-					# after the program boundary to still produce matchType in (2, 3). This allows
-					# correct display of "epg/RecordEvent.png" when multiple recodings are programmed to
-					# start at the same instant.
-					timer, matchType = RecordTimer.isInTimerOnService(serviceTimers, stime + (20 if config.recording.margin_before.value == 0 else 0), duration)
-					timerIcon, autoTimerIcon = self.getPixmapsForTimer(timer, matchType, selected)
-					if matchType not in (2, 3):
-						timer = None
+				cached = perEventCache.get(ev)
+				if cached is None:
+					xpos, ewidth = self.calcEventPosAndWidthHelper(stime, duration, start, end, width)
+					if serviceTimers is not None:
+						# Code below: "+ (20 if config.recording.margin_before.value == 0 else 0)"
+						# When recording-start-margin is zero allow recordings that start up to 20 seconds
+						# after the program boundary to still produce matchType in (2, 3). This allows
+						# correct display of "epg/RecordEvent.png" when multiple recodings are programmed to
+						# start at the same instant.
+						timer, matchType = RecordTimer.isInTimerOnService(serviceTimers, stime + (20 if config.recording.margin_before.value == 0 else 0), duration)
+						timerIcon, autoTimerIcon = self.getPixmapsForTimer(timer, matchType, selected)
+						if matchType not in (2, 3):
+							timer = None
+					else:
+						timer = matchType = timerIcon = autoTimerIcon = None
+					cached = (xpos, ewidth, timer, matchType, timerIcon, autoTimerIcon)
+					perEventCache[ev] = cached
 				else:
-					timer = matchType = timerIcon = None
+					xpos, ewidth, timer, matchType, timerIcon, autoTimerIcon = cached
 
 				isNow = stime <= now < (stime + duration) and config.epgselection.grid.highlight_current_events.value
 				# Only highlight timers that span an entire event
@@ -837,6 +877,9 @@ class EPGListGrid(EPGListBase):
 		serviceRef = ""
 		serviceName = ""
 		self.snapshotTimers(self.timeBase, self.timeBase + self.timeEpochSecs)
+		# The timer snapshot and event data above may have just changed, so any
+		# previously cached per-event build data (see __init__) is no longer valid.
+		self.eventStaticCache = {}
 
 		def appendService():
 			picon = None if piconIdx == 0 else serviceList[serviceIdx][piconIdx]

--- a/lib/python/Screens/SubtitleDisplay.py
+++ b/lib/python/Screens/SubtitleDisplay.py
@@ -41,6 +41,10 @@ class SubtitleDisplay(Screen):
 		label.instance.setHAlign(1)
 		label.instance.setVAlign(1)
 		label.instance.setBackgroundColor(gRGB(0xff000000))
+		# fully transparent background: opt into alphablend compositing explicitly so this
+		# label's box and text correctly blend against whatever's behind it (e.g. another
+		# root screen) instead of being treated as opaque for occlusion/paint purposes.
+		label.instance.setWidgetAlphaBlend(True)
 		foreColor_conf = config.subtitles.pango_subtitle_colors.value
 		if foreColor_conf == "2":
 			label.instance.setForegroundColor(gRGB(0x00ffff00))


### PR DESCRIPTION
This commit addresses several issues related to GUI rendering, focusing on alpha blending correctness and overall performance.

Key changes include:
*   **Alpha Blending Logic:**
    *   Correct alpha channel handling in text rendering to prevent ghosting artifacts caused by interpolated alpha values in the framebuffer.
    *   Ensure text in labels, listbox items, and subtitles correctly triggers alpha blending (`RT_BLEND`) when drawn over complex backgrounds (e.g., gradients, rounded corners, or partially transparent background colors). This prevents anti-aliasing issues where text appears dimmed or transparent.
    *   Introduce `needsBlendCompositing()` helper to consolidate conditions for required blending.
*   **Hardware Acceleration:**
    *   Update `configure.ac` and `bcm.cpp` to `FORCE_ALPHABLENDING_ACCELERATION` for DM900/920 devices, as hardware blending is known to work despite detection issues.
    *   Implement a runtime fallback in `bcm_accel_blit` to disable hardware alphablending and redraw without it if a blend operation fails, preventing blank screen areas.
*   **Performance Optimizations:**
    *   Improve `gPixmap::drawRectangleNew` performance by adding explicit clipping of rendering loops (corners, borders, fills) to the visible region. This avoids redundant per-pixel processing when drawing rounded rectangles and borders, especially with multi-rect regions.
    *   Optimize `EPGListGrid` rendering performance during horizontal navigation by caching static per-event data (timers, icons, geometry) that does not change between selection movements within the same row.
*   **Z-Order Management:**
    *   Ensure that Z-position changes for root widgets (windows) are correctly reflected in their drawing order by re-sorting them in `eWidgetDesktop::m_root`.
    *   Trigger `recalcClipRegions` in immediate mode when root widgets are repositioned or removed to correctly repaint newly exposed areas.
*   **Minor Fixes:** Correct a blit height parameter in `eWindowStyleSkinned::drawBorder` for the bottom-right corner.