### PR TITLE
Refine video plane clearing and hardware blitting fallback

### DIFF
--- a/lib/dvb/decoder.cpp
+++ b/lib/dvb/decoder.cpp
@@ -1031,7 +1031,7 @@ RESULT eTSMPEGDecoder::setAC3Delay(int delay)
 }
 
 eTSMPEGDecoder::eTSMPEGDecoder(eDVBDemux *demux, int decoder)
-	: m_demux(demux),
+	: m_radio_pic_shown(false), m_demux(demux),
 		m_vpid(-1), m_vtype(-1), m_apid(-1), m_atype(-1), m_pcrpid(-1), m_textpid(-1),
 		m_changed(0), m_decoder(decoder), m_video_clip_fd(-1), m_showSinglePicTimer(eTimer::create(eApp)),
 		m_fcc_fd(-1), m_fcc_enable(false), m_fcc_state(fcc_state_stop), m_fcc_feid(-1), m_fcc_vpid(-1), m_fcc_vtype(-1), m_fcc_pcrpid(-1)
@@ -1072,6 +1072,7 @@ void eTSMPEGDecoder::freeDecoder()
 eTSMPEGDecoder::~eTSMPEGDecoder()
 {
 	finishShowSinglePic();
+	clearRadioBackground();
 	m_vpid = m_apid = m_pcrpid = m_textpid = pidNone;
 	m_changed = -1;
 	setState();
@@ -1305,6 +1306,7 @@ RESULT eTSMPEGDecoder::showSinglePic(const char *filename)
 				m_video_clip_fd = open("/dev/dvb/adapter0/video0", O_WRONLY);
 			if (m_video_clip_fd >= 0)
 			{
+				m_radio_pic_shown = true;
 				bool seq_end_avail = false;
 				size_t pos=0;
 				unsigned char pes_header[] = { 0x00, 0x00, 0x01, 0xE0, 0x00, 0x00, 0x80, 0x80, 0x05, 0x21, 0x00, 0x01, 0x00, 0x01 };
@@ -1380,6 +1382,46 @@ void eTSMPEGDecoder::finishShowSinglePic()
 		close(m_video_clip_fd);
 		m_video_clip_fd = -1;
 	}
+}
+
+RESULT eTSMPEGDecoder::blankPrimaryVideoDecoder()
+{
+	int fd = open("/dev/dvb/adapter0/video0", O_WRONLY);
+	if (fd < 0)
+	{
+		eDebug("[eTSMPEGDecoder] blankPrimaryVideoDecoder: couldn't open video device: %m");
+		return -1;
+	}
+	if (ioctl(fd, VIDEO_STOP, 1) < 0)
+		eDebug("[eTSMPEGDecoder] VIDEO_STOP failed: %m");
+	if (ioctl(fd, VIDEO_SELECT_SOURCE, VIDEO_SOURCE_DEMUX) < 0)
+		eDebug("[eTSMPEGDecoder] VIDEO_SELECT_SOURCE DEMUX failed: %m");
+	close(fd);
+	return 0;
+}
+
+void eTSMPEGDecoder::clearRadioBackground()
+{
+	/* if we ever displayed a radio background still picture and no real video pid took
+	   over since, the last decoded frame stays latched on the video plane forever
+	   (finishShowSinglePic() deliberately keeps it visible). Make sure it actually
+	   goes away once this decoder is torn down. Note: servicemp3 uses a dedicated
+	   eTSMPEGDecoder(NULL, 0) purely to inject the still picture and never calls
+	   setRadioPic(), so this must not depend on m_radio_pic being set. */
+	if (m_decoder != 0 || m_video || !m_radio_pic_shown)
+		return;
+
+	if (m_video_clip_fd >= 0)
+	{
+		if (ioctl(m_video_clip_fd, VIDEO_STOP, 1) < 0)
+			eDebug("[eTSMPEGDecoder] VIDEO_STOP failed: %m");
+		if (ioctl(m_video_clip_fd, VIDEO_SELECT_SOURCE, VIDEO_SOURCE_DEMUX) < 0)
+			eDebug("[eTSMPEGDecoder] VIDEO_SELECT_SOURCE DEMUX failed: %m");
+		close(m_video_clip_fd);
+		m_video_clip_fd = -1;
+	}
+	else
+		blankPrimaryVideoDecoder();
 }
 
 RESULT eTSMPEGDecoder::connectVideoEvent(const sigc::slot<void(struct videoEvent)> &event, ePtr<eConnection> &conn)

--- a/lib/dvb/decoder.h
+++ b/lib/dvb/decoder.h
@@ -95,6 +95,7 @@ private:
 	static int m_ac3_delay;
 	static int m_audio_channel;
 	std::string m_radio_pic;
+	bool m_radio_pic_shown;
 	ePtr<eDVBDemux> m_demux;
 	ePtr<eDVBAudio> m_audio;
 	ePtr<eDVBVideo> m_video;
@@ -130,6 +131,7 @@ private:
 	int m_fcc_vtype;
 	int m_fcc_pcrpid;
 	void finishShowSinglePic(); // called by timer
+	void clearRadioBackground(); // blanks the video plane if a radio background picture is still displayed
 public:
 	enum { pidNone = -1 };
 	eTSMPEGDecoder(eDVBDemux *demux, int decoder);
@@ -184,6 +186,11 @@ public:
 	int getVideoGamma();
 	static RESULT setHwPCMDelay(int delay);
 	static RESULT setHwAC3Delay(int delay);
+		/* blanks the primary decoder's video plane directly. Used by consumers
+		   (e.g. servicemp3's GstDVBVideoSink playback) that write frames to the
+		   decoder without going through an eDVBVideo instance, so there is
+		   nobody else to issue the blanking VIDEO_STOP on their behalf. */
+	static RESULT blankPrimaryVideoDecoder();
 
 	enum
 	{

--- a/lib/gdi/accel.cpp
+++ b/lib/gdi/accel.cpp
@@ -57,7 +57,7 @@ extern void stmfb_accel_fill(
 #ifdef BCM_ACCEL
 extern int bcm_accel_init(void);
 extern void bcm_accel_close(void);
-extern void bcm_accel_blit(
+extern bool bcm_accel_blit(
 		int src_addr, int src_width, int src_height, int src_stride, int src_format,
 		int dst_addr, int dst_width, int dst_height, int dst_stride,
 		int src_x, int src_y, int width, int height,
@@ -272,12 +272,13 @@ int gAccel::blit(gUnmanagedSurface *dst, gUnmanagedSurface *src, const eRect &p,
 		} else
 			return -1; /* unsupported source format */
 
-		bcm_accel_blit(
+		if (!bcm_accel_blit(
 			src->data_phys, src->x, src->y, src->stride, src_format,
 			dst->data_phys, dst->x, dst->y, dst->stride,
 			area.left(), area.top(), area.width(), area.height(),
 			p.x(), p.y(), p.width(), p.height(),
-			pal_addr, flags);
+			pal_addr, flags))
+			return -1; /* hw blit failed, let the caller redraw in software */
 		return 0;
 	}
 #endif

--- a/lib/gdi/bcm.cpp
+++ b/lib/gdi/bcm.cpp
@@ -114,7 +114,7 @@ int bcm_accel_sync()
 	return retval;
 }
 
-void bcm_accel_blit(
+bool bcm_accel_blit(
 		int src_addr, int src_width, int src_height, int src_stride, int src_format,
 		int dst_addr, int dst_width, int dst_height, int dst_stride,
 		int src_x, int src_y, int width, int height,
@@ -182,20 +182,22 @@ void bcm_accel_blit(
 
 	C(0x77);  // do it
 
-	if (!accumulateoperations && exec_list() && supportblendingflags && flags)
+	if (accumulateoperations)
+		return true; /* deferred until bcm_accel_sync(), result not known yet */
+
+	if (!exec_list())
+		return true;
+
+	if (supportblendingflags && flags)
 	{
-		/* the driver rejected the list with the blend opcode included; disable
-		 * hw alphablending from now on and redraw this blit without it, so we
-		 * don't leave a blank/stale area on screen for a blit the driver refused */
+		/* the driver rejected (or the hardware failed) the blit with the
+		 * blend opcode included; disable hw alphablending from now on and
+		 * report failure so the caller redraws this blit in software
+		 * instead, rather than leaving a blank/stale area on screen */
 		eDebug("[bcm] blit with blend flags failed, disabling hw alphablending");
 		supportblendingflags = false;
-		bcm_accel_blit(
-				src_addr, src_width, src_height, src_stride, src_format,
-				dst_addr, dst_width, dst_height, dst_stride,
-				src_x, src_y, width, height,
-				dst_x, dst_y, dwidth, dheight,
-				pal_addr, 0);
 	}
+	return false;
 }
 
 void bcm_accel_fill(

--- a/lib/gdi/gfbdc.cpp
+++ b/lib/gdi/gfbdc.cpp
@@ -22,7 +22,7 @@
 #if defined(CONFIG_ION) || defined(CONFIG_HISILICON_FB)
 #include <lib/gdi/grc.h>
 
-extern void bcm_accel_blit(
+extern bool bcm_accel_blit(
 		int src_addr, int src_width, int src_height, int src_stride, int src_format,
 		int dst_addr, int dst_width, int dst_height, int dst_stride,
 		int src_x, int src_y, int width, int height,

--- a/lib/gdi/gpixmap.cpp
+++ b/lib/gdi/gpixmap.cpp
@@ -612,7 +612,7 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 				x_end = std::min(x_end, reg.right());
 				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + py * surface->stride + x_start * surface->bypp);
 				for (int x = x_start; x < x_end; ++x, ++dst)
-					dst->alpha_blend(gRGB(borderCol));
+					if (borderA == 255) *dst = borderCol; else dst->alpha_blend(gRGB(borderCol));
 			}
 
 			// Bottom Border
@@ -626,7 +626,7 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 				x_end = std::min(x_end, reg.right());
 				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + py * surface->stride + x_start * surface->bypp);
 				for (int x = x_start; x < x_end; ++x, ++dst)
-					dst->alpha_blend(gRGB(borderCol));
+					if (borderA == 255) *dst = borderCol; else dst->alpha_blend(gRGB(borderCol));
 			}
 
 			// Left Border
@@ -640,7 +640,7 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 				y_end = std::min(y_end, reg.bottom());
 				for (int y = y_start; y < y_end; ++y) {
 					gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + px * surface->bypp);
-					dst->alpha_blend(gRGB(borderCol));
+					if (borderA == 255) *dst = borderCol; else dst->alpha_blend(gRGB(borderCol));
 				}
 			}
 
@@ -655,7 +655,7 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 				y_end = std::min(y_end, reg.bottom());
 				for (int y = y_start; y < y_end; ++y) {
 					gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + px * surface->bypp);
-					dst->alpha_blend(gRGB(borderCol));
+					if (borderA == 255) *dst = borderCol; else dst->alpha_blend(gRGB(borderCol));
 				}
 			}
 		}
@@ -683,7 +683,7 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 			for (int y = y0; y < y1; ++y) {
 				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + x_start * surface->bypp);
 				for (int x = x_start; x < x_end; ++x, ++dst)
-					dst->alpha_blend(gRGB(fillCol));
+					if (fillA == 255) *dst = fillCol; else dst->alpha_blend(gRGB(fillCol));
 			}
 		}
 
@@ -709,7 +709,7 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 			for (int y = y0; y < y1; ++y) {
 				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + x_start * surface->bypp);
 				for (int x = x_start; x < x_end; ++x, ++dst)
-					dst->alpha_blend(gRGB(fillCol));
+					if (fillA == 255) *dst = fillCol; else dst->alpha_blend(gRGB(fillCol));
 			}
 		}
 
@@ -728,7 +728,7 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 			for (int y = y0; y < y1; ++y) {
 				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + x_start * surface->bypp);
 				for (int x = x_start; x < x_end; ++x, ++dst)
-					dst->alpha_blend(gRGB(fillCol));
+					if (fillA == 255) *dst = fillCol; else dst->alpha_blend(gRGB(fillCol));
 			}
 		}
 	}
@@ -2115,8 +2115,10 @@ void gPixmap::blit(const gPixmap& src, const eRect& _pos, const gRegion& clip, i
 					/* Hardware alpha blending is broken on the few
 					 * boxes that support it, so only use it
 					 * when scaling */
-
-					accel = true;
+					if (flag & blitScale)
+						accel = true;
+					else
+						accel = false;
 #else
 					if (flag & blitScale)
 						accel = true;

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -1067,6 +1067,7 @@ struct StopWorkerArgs
 {
 	GstElement *playbin;
 	StopWatchdog *watchdog;
+	bool hadVideo;
 };
 
 /* gst_element_set_state(..., GST_STATE_NULL) is the call that can still block
@@ -1084,12 +1085,22 @@ gpointer stopWorker(gpointer data)
 	StopWorkerArgs *args = static_cast<StopWorkerArgs*>(data);
 	GstElement *playbin = args->playbin;
 	StopWatchdog *watchdog = args->watchdog;
+	bool hadVideo = args->hadVideo;
 	delete args;
 
 	GstStateChangeReturn ret = gst_element_set_state(playbin, GST_STATE_NULL);
 	if (ret != GST_STATE_CHANGE_SUCCESS)
 		eDebug("[eServiceMP3] stop GST_STATE_NULL failure");
 	gst_object_unref(playbin);
+
+	/* GstDVBVideoSink's own device fd is gone once GST_STATE_NULL has actually
+	 * returned (guaranteed synchronous per the comment above), but whether it
+	 * blanks the video plane on the way down is up to that (out-of-tree) sink.
+	 * Force it here too so the last decoded frame doesn't stay frozen on
+	 * screen after playback has genuinely stopped - this opens its own fd, so
+	 * it doesn't race the sink's teardown. */
+	if (hadVideo)
+		eTSMPEGDecoder::blankPrimaryVideoDecoder();
 
 	g_atomic_int_set(&watchdog->done, 1);
 	stopWatchdogRelease(watchdog);
@@ -1206,7 +1217,7 @@ RESULT eServiceMP3::stop()
 	 * see stopWatchdog()'s comment for why that's a thread and not a timer. */
 	gst_object_ref(m_gst_playbin);
 	StopWatchdog *watchdog = new StopWatchdog{0, 2};
-	GThread *worker = g_thread_new("mp3stop", stopWorker, new StopWorkerArgs{m_gst_playbin, watchdog});
+	GThread *worker = g_thread_new("mp3stop", stopWorker, new StopWorkerArgs{m_gst_playbin, watchdog, videoSink != NULL});
 	g_thread_unref(worker);
 	GThread *watchdogThread = g_thread_new("mp3stopwd", stopWatchdog, watchdog);
 	g_thread_unref(watchdogThread);


### PR DESCRIPTION
This commit introduces further refinements to visual output management and hardware acceleration robustness.

Key changes include:
*   **Video Plane Management:**
    *   Ensure radio background still pictures are properly cleared upon decoder teardown, preventing the last frame from remaining frozen on screen.
    *   Add a static helper to explicitly blank the primary video decoder, used by external video sinks (e.g., GStreamer) to guarantee a blank screen after playback stops.
*   **Hardware Blitting Refinements:**
    *   Modify `bcm_accel_blit` to return `false` upon hardware blit failure (especially with blend flags), allowing `gAccel::blit` to fall back to software rendering instead of attempting a partial hardware retry.
    *   Optimize `drawRectangleNew` to avoid unnecessary alpha blending for fully opaque colors.
    *   Adjust hardware acceleration conditions for blits on BCM, focusing acceleration primarily on scaling operations due to potential stability issues with non-scaling alpha blends.