### PR TITLE
Fix unreliable hardware alpha blending on forced acceleration targets

### DIFF
--- a/lib/gdi/gpixmap.cpp
+++ b/lib/gdi/gpixmap.cpp
@@ -2112,13 +2112,10 @@ void gPixmap::blit(const gPixmap& src, const eRect& _pos, const gRegion& clip, i
 				/* alpha blending is requested */
 				if (gAccel::getInstance()->hasAlphaBlendingSupport()) {
 #ifdef FORCE_ALPHABLENDING_ACCELERATION
-					/* Hardware alpha blending is broken on the few
-					 * boxes that support it, so only use it
-					 * when scaling */
-					if (flag & blitScale)
-						accel = true;
-					else
-						accel = false;
+					/* Hardware alpha blending is unreliable on these boxes
+					 * even when scaling is involved (e.g. picons silently
+					 * fail to render), so always fall back to software. */
+					accel = false;
 #else
 					if (flag & blitScale)
 						accel = true;


### PR DESCRIPTION
This pull request updates the alpha blending behavior in the `gPixmap::blit` method to always use software rendering, even when scaling is involved. This change addresses issues where hardware alpha blending is unreliable on certain devices, causing rendering failures.

Rendering reliability:

* Modified the alpha blending logic in `gPixmap::blit` (in `lib/gdi/gpixmap.cpp`) to always fall back to software rendering when `FORCE_ALPHABLENDING_ACCELERATION` is defined, due to hardware blending being unreliable even during scaling operations.