### PR TITLE
Enable hardware alpha blending with software fallback for Dreambox

### DIFF
--- a/lib/gdi/gpixmap.cpp
+++ b/lib/gdi/gpixmap.cpp
@@ -2112,10 +2112,11 @@ void gPixmap::blit(const gPixmap& src, const eRect& _pos, const gRegion& clip, i
 				/* alpha blending is requested */
 				if (gAccel::getInstance()->hasAlphaBlendingSupport()) {
 #ifdef FORCE_ALPHABLENDING_ACCELERATION
-					/* Hardware alpha blending is unreliable on these boxes
-					 * even when scaling is involved (e.g. picons silently
-					 * fail to render), so always fall back to software. */
+#ifdef DREAMBOX
 					accel = false;
+#else
+					accel = true;
+#endif
 #else
 					if (flag & blitScale)
 						accel = true;


### PR DESCRIPTION
This pull request updates the logic for enabling hardware alpha blending acceleration in the `gPixmap::blit` method. The main change is to conditionally enable or disable hardware acceleration based on the target platform, improving rendering reliability on certain devices.

Platform-specific hardware acceleration logic:

* In the `gPixmap::blit` method in `lib/gdi/gpixmap.cpp`, hardware alpha blending acceleration is now enabled by default, except on Dreambox devices (`DREAMBOX`), where it remains disabled due to reliability issues.