### PR TITLE
Refine blitting robustness: clamp rounded corner blits and enforce Dreambox software fallback

### DIFF
--- a/lib/gdi/gpixmap.cpp
+++ b/lib/gdi/gpixmap.cpp
@@ -2083,16 +2083,22 @@ void gPixmap::blit(const gPixmap& src, const eRect& _pos, const gRegion& clip, i
 		//			srcarea.x(), srcarea.y(), srcarea.width(), srcarea.height());
 
 		if (cornerRadius && surface->bpp == 32) {
+			/* use 'area', not the raw clip.rects[i]: area is already clamped to
+			 * both pos and this pixmap's own surface bounds. clip.rects[i] alone
+			 * isn't guaranteed to be, and the rounded-corner blitters below trust
+			 * their clip rect completely (no further bounds check), so passing
+			 * the raw clip could make them write past the right/bottom edge of
+			 * the destination surface into the next scanline. */
 			if (src.surface->bpp == 32) {
 				if (flag & blitScale)
-					blitRounded32BitScaled(src, pos, clip.rects[i], cornerRadius, edges, flag);
+					blitRounded32BitScaled(src, pos, area, cornerRadius, edges, flag);
 				else
-					blitRounded32Bit(src, pos, clip.rects[i], cornerRadius, edges, flag);
+					blitRounded32Bit(src, pos, area, cornerRadius, edges, flag);
 			} else {
 				if (flag & blitScale)
-					blitRounded8BitScaled(src, pos, clip.rects[i], cornerRadius, edges, flag);
+					blitRounded8BitScaled(src, pos, area, cornerRadius, edges, flag);
 				else
-					blitRounded8Bit(src, pos, clip.rects[i], cornerRadius, edges, flag);
+					blitRounded8Bit(src, pos, area, cornerRadius, edges, flag);
 			}
 
 			continue;
@@ -2108,15 +2114,22 @@ void gPixmap::blit(const gPixmap& src, const eRect& _pos, const gRegion& clip, i
 		}
 		if (accel) {
 			/* we have hardware acceleration for this blit operation */
+#if defined(FORCE_ALPHABLENDING_ACCELERATION) && defined(DREAMBOX)
+			/* Hardware blitting is unreliable on these boxes even for
+			 * plain (non-alpha) blits -- not just alpha blending -- so
+			 * always fall back to software regardless of the requested
+			 * flags. Restricting this to alpha-flagged blits only (as
+			 * done below for other targets) still left opaque blits
+			 * (e.g. alphatest="off" pixmaps, JPEG covers, opaque 8-bit
+			 * indexed PNGs) on the flaky hardware path, where they could
+			 * silently fail to render. */
+			accel = false;
+#else
 			if (flag & (blitAlphaTest | blitAlphaBlend)) {
 				/* alpha blending is requested */
 				if (gAccel::getInstance()->hasAlphaBlendingSupport()) {
 #ifdef FORCE_ALPHABLENDING_ACCELERATION
-#ifdef DREAMBOX
-					accel = false;
-#else
 					accel = true;
-#endif
 #else
 					if (flag & blitScale)
 						accel = true;
@@ -2130,6 +2143,7 @@ void gPixmap::blit(const gPixmap& src, const eRect& _pos, const gRegion& clip, i
 					accel = false;
 				}
 			}
+#endif
 		}
 
 #ifdef GPIXMAP_CHECK_THRESHOLD


### PR DESCRIPTION
This commit addresses two areas for improved blitting reliability:

*   **Rounded Corner Blits:** Correctly clamp the blit area passed to rounded-corner blitters. Previously, passing the raw clip rectangle could lead to out-of-bounds writes if it extended beyond the destination surface's bounds, as these blitters trust the provided rect completely.
*   **Dreambox Hardware Acceleration:** Broadens the software fallback for hardware blitting on Dreambox devices. While previous fixes targeted unreliable alpha blending, it was found that *all* hardware blitting on these platforms, even for opaque content, could be unreliable and lead to silently failed renders. This change ensures a complete software fallback for all blits on Dreambox when `FORCE_ALPHABLENDING_ACCELERATION` is defined, guaranteeing visual correctness.