### PR TITLE
[gpixmap] fixed full transparent fill

### DIFF
--- a/lib/gdi/gpixmap.cpp
+++ b/lib/gdi/gpixmap.cpp
@@ -482,10 +482,12 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 
 		uint32_t fillCol = fillColor.argb() ^ 0xFF000000;
 		uint32_t borderCol = borderColor.argb() ^ 0xFF000000;
+		// fillA/borderA of 0 means "fully transparent" (see the ^0xFF above) - draw
+		// nothing rather than forcing a minimum alpha, which used to make every fully
+		// transparent fill/border pay for a full per-pixel alpha_blend() pass for a
+		// visually imperceptible 1/255 blend (measured ~2.2s for a 1920x750 fill).
 		uint8_t fillA = fillColor.a ^ 0xFF;
 		uint8_t borderA = borderColor.a ^ 0xFF;
-		if (fillA == 0)
-			fillA = 1;
 
 		int tlr = (edges & RADIUS_TOP_LEFT) ? radius : 0;
 		int trr = (edges & RADIUS_TOP_RIGHT) ? radius : 0;
@@ -680,10 +682,12 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 			x_start = std::max(x_start, reg.left());
 			x_end = std::min(x_end, reg.right());
 
-			for (int y = y0; y < y1; ++y) {
-				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + x_start * surface->bypp);
-				for (int x = x_start; x < x_end; ++x, ++dst)
-					if (fillA == 255) *dst = fillCol; else dst->alpha_blend(gRGB(fillCol));
+			if (fillA) {
+				for (int y = y0; y < y1; ++y) {
+					gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + x_start * surface->bypp);
+					for (int x = x_start; x < x_end; ++x, ++dst)
+						if (fillA == 255) *dst = fillCol; else dst->alpha_blend(gRGB(fillCol));
+				}
 			}
 		}
 
@@ -706,10 +710,12 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 			x_start = std::max(x_start, reg.left());
 			x_end = std::min(x_end, reg.right());
 
-			for (int y = y0; y < y1; ++y) {
-				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + x_start * surface->bypp);
-				for (int x = x_start; x < x_end; ++x, ++dst)
-					if (fillA == 255) *dst = fillCol; else dst->alpha_blend(gRGB(fillCol));
+			if (fillA) {
+				for (int y = y0; y < y1; ++y) {
+					gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + x_start * surface->bypp);
+					for (int x = x_start; x < x_end; ++x, ++dst)
+						if (fillA == 255) *dst = fillCol; else dst->alpha_blend(gRGB(fillCol));
+				}
 			}
 		}
 
@@ -725,10 +731,12 @@ void gPixmap::drawRectangleNew(const gRegion& region, const eRect& area, const g
 			x_start = std::max(x_start, reg.left());
 			x_end = std::min(x_end, reg.right());
 
-			for (int y = y0; y < y1; ++y) {
-				gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + x_start * surface->bypp);
-				for (int x = x_start; x < x_end; ++x, ++dst)
-					if (fillA == 255) *dst = fillCol; else dst->alpha_blend(gRGB(fillCol));
+			if (fillA) {
+				for (int y = y0; y < y1; ++y) {
+					gRGB* dst = (gRGB*)(uint32_t*)((uint8_t*)surface->data + y * surface->stride + x_start * surface->bypp);
+					for (int x = x_start; x < x_end; ++x, ++dst)
+						if (fillA == 255) *dst = fillCol; else dst->alpha_blend(gRGB(fillCol));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
removed the clamp, and wrapped the Top-Fill/Bottom-Fill/Middle-Fill loops in if (fillA) { ... } so a fully-transparent fill is skipped outright, matching how the corner-blend code already handles alpha=0.
the problem was seen on dm900. without the fix the rendering took 2s.